### PR TITLE
fix: trim textField1 before SetText in InventoryListEntry

### DIFF
--- a/source/actionscript/ItemMenus/InventoryListEntry.as
+++ b/source/actionscript/ItemMenus/InventoryListEntry.as
@@ -19,18 +19,20 @@ class InventoryListEntry extends skyui.components.list.TabularListEntry
    function initialize(a_index, a_state)
    {
       super.initialize();
-      var _loc5_ = new MovieClipLoader();
-      _loc5_.addListener(this);
-      _loc5_.loadClip(a_state.iconSource,this.itemIcon);
+      var _loc4_ = new MovieClipLoader();
+      _loc4_.addListener(this);
+      _loc4_.loadClip(a_state.iconSource,this.itemIcon);
       this.itemIcon._visible = false;
       this.equipIcon._visible = false;
-      var _loc6_ = 0;
-      while(this["textField" + _loc6_] != undefined)
+      var _loc3_ = 0;
+      while(this["textField" + _loc3_] != undefined)
       {
-         this["textField" + _loc6_]._visible = false;
-         _loc6_ += 1;
+         this["textField" + _loc3_]._visible = false;
+         _loc3_ = _loc3_ + 1;
       }
    }
+   // HACK: specific workaround for tab-delimited translation text (e.g. BOOBIES Potions).
+   // TODO: replace with a cleaner generic solution if SkyUI handles this case centrally later.
    function __rf_cleanDisplayText(a_text)
    {
       var _loc2_;
@@ -124,20 +126,20 @@ class InventoryListEntry extends skyui.components.list.TabularListEntry
    }
    function setSpecificEntryLayout(a_entryObject, a_state)
    {
-      var _loc4_ = skyui.components.list.TabularList(a_state.list).layout.entryHeight * 0.25;
-      var _loc5_ = skyui.components.list.TabularList(a_state.list).layout.entryHeight * 0.5;
-      this.bestIcon._height = this.bestIcon._width = _loc5_;
-      this.favoriteIcon._height = this.favoriteIcon._width = _loc5_;
-      this.poisonIcon._height = this.poisonIcon._width = _loc5_;
-      this.stolenIcon._height = this.stolenIcon._width = _loc5_;
-      this.enchIcon._height = this.enchIcon._width = _loc5_;
-      this.readIcon._height = this.readIcon._width = _loc5_;
-      this.bestIcon._y = _loc4_;
-      this.favoriteIcon._y = _loc4_;
-      this.poisonIcon._y = _loc4_;
-      this.stolenIcon._y = _loc4_;
-      this.enchIcon._y = _loc4_;
-      this.readIcon._y = _loc4_;
+      var _loc2_ = skyui.components.list.TabularList(a_state.list).layout.entryHeight * 0.25;
+      var _loc3_ = skyui.components.list.TabularList(a_state.list).layout.entryHeight * 0.5;
+      this.bestIcon._height = this.bestIcon._width = _loc3_;
+      this.favoriteIcon._height = this.favoriteIcon._width = _loc3_;
+      this.poisonIcon._height = this.poisonIcon._width = _loc3_;
+      this.stolenIcon._height = this.stolenIcon._width = _loc3_;
+      this.enchIcon._height = this.enchIcon._width = _loc3_;
+      this.readIcon._height = this.readIcon._width = _loc3_;
+      this.bestIcon._y = _loc2_;
+      this.favoriteIcon._y = _loc2_;
+      this.poisonIcon._y = _loc2_;
+      this.stolenIcon._y = _loc2_;
+      this.enchIcon._y = _loc2_;
+      this.readIcon._y = _loc2_;
    }
    function formatEquipIcon(a_entryField, a_entryObject, a_state)
    {
@@ -164,28 +166,28 @@ class InventoryListEntry extends skyui.components.list.TabularListEntry
          a_entryField.SetText(" ");
          return undefined;
       }
-      var _loc5_ = a_entryObject.text;
+      var _loc4_ = a_entryObject.text;
       if(a_entryObject.soulLVL != undefined)
       {
-         _loc5_ = _loc5_ + " (" + a_entryObject.soulLVL + ")";
+         _loc4_ = _loc4_ + " (" + a_entryObject.soulLVL + ")";
       }
       if(a_entryObject.count > 1)
       {
-         _loc5_ = _loc5_ + " (" + a_entryObject.count.toString() + ")";
+         _loc4_ = _loc4_ + " (" + a_entryObject.count.toString() + ")";
       }
-      if(_loc5_.length > a_state.maxTextLength)
+      if(_loc4_.length > a_state.maxTextLength)
       {
-         _loc5_ = _loc5_.substr(0,a_state.maxTextLength - 3) + "...";
+         _loc4_ = _loc4_.substr(0,a_state.maxTextLength - 3) + "...";
       }
       a_entryField.autoSize = "left";
-      a_entryField.SetText(_loc5_);
+      a_entryField.SetText(_loc4_);
       this.formatColor(a_entryField,a_entryObject,a_state);
-      var _loc6_ = a_entryField._x + a_entryField._width + 5;
-      var _loc7_ = this.bestIcon._width * 1.25;
+      var _loc2_ = a_entryField._x + a_entryField._width + 5;
+      var _loc5_ = this.bestIcon._width * 1.25;
       if(a_entryObject.bestInClass == true)
       {
-         this.bestIcon._x = _loc6_;
-         _loc6_ += _loc7_;
+         this.bestIcon._x = _loc2_;
+         _loc2_ += _loc5_;
          this.bestIcon.gotoAndStop("show");
       }
       else
@@ -194,8 +196,8 @@ class InventoryListEntry extends skyui.components.list.TabularListEntry
       }
       if(a_entryObject.favorite == true)
       {
-         this.favoriteIcon._x = _loc6_;
-         _loc6_ += _loc7_;
+         this.favoriteIcon._x = _loc2_;
+         _loc2_ += _loc5_;
          this.favoriteIcon.gotoAndStop("show");
       }
       else
@@ -204,8 +206,8 @@ class InventoryListEntry extends skyui.components.list.TabularListEntry
       }
       if(a_entryObject.isPoisoned == true)
       {
-         this.poisonIcon._x = _loc6_;
-         _loc6_ += _loc7_;
+         this.poisonIcon._x = _loc2_;
+         _loc2_ += _loc5_;
          this.poisonIcon.gotoAndStop("show");
       }
       else
@@ -214,8 +216,8 @@ class InventoryListEntry extends skyui.components.list.TabularListEntry
       }
       if((a_entryObject.isStolen == true || a_entryObject.isStealing == true) && a_state.showStolenIcon == true)
       {
-         this.stolenIcon._x = _loc6_;
-         _loc6_ += _loc7_;
+         this.stolenIcon._x = _loc2_;
+         _loc2_ += _loc5_;
          this.stolenIcon.gotoAndStop("show");
       }
       else
@@ -224,8 +226,8 @@ class InventoryListEntry extends skyui.components.list.TabularListEntry
       }
       if(a_entryObject.isEnchanted == true)
       {
-         this.enchIcon._x = _loc6_;
-         _loc6_ += _loc7_;
+         this.enchIcon._x = _loc2_;
+         _loc2_ += _loc5_;
          this.enchIcon.gotoAndStop("show");
       }
       else
@@ -234,8 +236,8 @@ class InventoryListEntry extends skyui.components.list.TabularListEntry
       }
       if(a_entryObject.isRead == true)
       {
-         this.readIcon._x = _loc6_;
-         _loc6_ += _loc7_;
+         this.readIcon._x = _loc2_;
+         _loc2_ += _loc5_;
          this.readIcon.gotoAndStop("show");
       }
       else
@@ -270,18 +272,18 @@ class InventoryListEntry extends skyui.components.list.TabularListEntry
    }
    function changeIconColor(a_icon, a_rgb)
    {
+      var _loc2_;
+      var _loc1_;
       var _loc3_;
-      var _loc4_;
-      var _loc5_;
       for(var _loc6_ in a_icon)
       {
-         _loc3_ = a_icon[_loc6_];
-         if(_loc3_ instanceof MovieClip)
+         _loc2_ = a_icon[_loc6_];
+         if(_loc2_ instanceof MovieClip)
          {
-            _loc4_ = new flash.geom.ColorTransform();
-            _loc5_ = new flash.geom.Transform(MovieClip(_loc3_));
-            _loc4_.rgb = a_rgb != undefined ? a_rgb : 16777215;
-            _loc5_.colorTransform = _loc4_;
+            _loc1_ = new flash.geom.ColorTransform();
+            _loc3_ = new flash.geom.Transform(MovieClip(_loc2_));
+            _loc1_.rgb = a_rgb != undefined ? a_rgb : 16777215;
+            _loc3_.colorTransform = _loc1_;
          }
       }
    }


### PR DESCRIPTION
Trim tab-delimited injected text before assignment.

- Applies only to textField1
- Preserves drop shadows
- Avoids empty column regression
- Maintains correct sorting and display behavior

Addresses UI issues caused by translation-based text injection (e.g., B.O.O.B.I.E.S – Potions), where tab-delimited values can affect alignment in the Type (textField1) column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual selection indicator for inventory items

* **Bug Fixes**
  * Improved text formatting and cleaning in inventory lists
  * Enhanced handling of missing values in item entries (displays as "-")
  * Fixed text display for items with special formatting
  * Added text color support for inventory items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->