### PR TITLE
fix(quest-journal): MouseWheel did not update the selection in the list

### DIFF
--- a/source/actionscript/Vanilla/Shared/CenteredScrollingList.as
+++ b/source/actionscript/Vanilla/Shared/CenteredScrollingList.as
@@ -220,12 +220,20 @@ class Shared.CenteredScrollingList extends Shared.BSScrollingList
       this.bMouseDrivenNav = true;
       
       var oldScroll = this.iScrollPosition;
+      var oldSelectedIndex = this.iSelectedIndex;
       var direction = (delta > 0) ? -1 : 1;
       
       this.iScrollPosition = Math.max(0, Math.min(this.iMaxScrollPosition, this.iScrollPosition + direction));
       
       if (oldScroll != this.iScrollPosition) {
          this.UpdateList();
+         if (this.iSelectedIndex != oldSelectedIndex && this.iSelectedIndex != -1) {
+            this.dispatchEvent({
+               type: "selectionChange",
+               index: this.iSelectedIndex,
+               keyboardOrMouse: 0
+            });
+         }
       }
    }
    function GetItemUnderMouse()


### PR DESCRIPTION
Fixes #140.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed selection change notifications in scrolling lists when using mouse wheel input, ensuring proper event propagation and consistent UI state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->