### PR TITLE
fix(quest-journal): jumping hover when focusing late after selecting a category

### DIFF
--- a/source/actionscript/PauseMenu/SystemPage.as
+++ b/source/actionscript/PauseMenu/SystemPage.as
@@ -562,19 +562,24 @@ class SystemPage extends MovieClip
    }
    function onCategoryButtonPress(event)
    {
-      this.CategoryList.setInteractive(false);
       if(event.entry.disabled)
       {
          gfx.io.GameDelegate.call("PlaySound",["UIMenuCancel"]);
+         return;
       }
-      else if(this.iCurrentState == SystemPage.MAIN_STATE)
+      if(this.iCurrentState == SystemPage.MAIN_STATE)
       {
+         this.CategoryList.setInteractive(false);
+      }
+      
          switch(event.index)
          {
             case this.IDX_QUICKSAVE:
                gfx.io.GameDelegate.call("PlaySound",["UIMenuOK"]);
                gfx.io.GameDelegate.call("QuickSave",[]);
+               this.CategoryList.setInteractive(true);
                return;
+               
             case this.IDX_SAVE:
                gfx.io.GameDelegate.call("UseCurrentCharacterFilter",[]);
                this.SaveLoadListHolder.isSaving = true;
@@ -585,11 +590,12 @@ class SystemPage extends MovieClip
                }
                gfx.io.GameDelegate.call("SAVE",[this.SaveLoadListHolder.List_mc.entryList,this.SaveLoadListHolder.batchSize]);
                return;
-               break;
+               
             case this.IDX_LOAD:
                this.SaveLoadListHolder.isSaving = false;
                gfx.io.GameDelegate.call("LOAD",[this.SaveLoadListHolder.List_mc.entryList,this.SaveLoadListHolder.batchSize]);
                return;
+               
             case this.IDX_INSTALLED_CONTENT:
                if(this.CreationsList.entryList.length == 0)
                {
@@ -604,18 +610,24 @@ class SystemPage extends MovieClip
                   return;
                }
                gfx.io.GameDelegate.call("PlaySound",["UIMenuCancel"]);
+               this.CategoryList.setInteractive(true);
                return;
-               break;
+               
             case this.IDX_CREATIONS:
                gfx.io.GameDelegate.call("ModManager",[]);
+               this.CategoryList.setInteractive(true);
                return;
+               
             case this.IDX_SETTINGS:
                this.StartState(SystemPage.SETTINGS_CATEGORY_STATE);
                gfx.io.GameDelegate.call("PlaySound",["UIMenuOK"]);
                return;
+               
             case this.IDX_MOD_CONFIG:
                _root.QuestJournalFader.Menu_mc.ConfigPanelOpen();
+               this.CategoryList.setInteractive(true);
                return;
+               
             case this.IDX_CONTROLS:
                if(this.MappingList.entryList.length == 0)
                {
@@ -626,6 +638,7 @@ class SystemPage extends MovieClip
                this.StartState(SystemPage.INPUT_MAPPING_STATE);
                gfx.io.GameDelegate.call("PlaySound",["UIMenuOK"]);
                return;
+               
             case this.IDX_HELP:
                if(this.HelpList.entryList.length == 0)
                {
@@ -641,16 +654,19 @@ class SystemPage extends MovieClip
                else
                {
                   gfx.io.GameDelegate.call("PlaySound",["UIMenuCancel"]);
+                  this.CategoryList.setInteractive(true);
                }
                return;
+               
             case this.IDX_QUIT:
                gfx.io.GameDelegate.call("PlaySound",["UIMenuOK"]);
                gfx.io.GameDelegate.call("RequestIsOnPC",[],this,"populateQuitList");
                return;
+               
             default:
                gfx.io.GameDelegate.call("PlaySound",["UIMenuCancel"]);
+               this.CategoryList.setInteractive(true);
                return;
-         }
       }
    }
    function onCategoryListPress(event)

--- a/source/actionscript/PauseMenu/SystemPage.as
+++ b/source/actionscript/PauseMenu/SystemPage.as
@@ -562,6 +562,7 @@ class SystemPage extends MovieClip
    }
    function onCategoryButtonPress(event)
    {
+      this.CategoryList.setInteractive(false);
       if(event.entry.disabled)
       {
          gfx.io.GameDelegate.call("PlaySound",["UIMenuCancel"]);
@@ -1314,6 +1315,7 @@ class SystemPage extends MovieClip
       switch(aiNewState)
       {
          case SystemPage.MAIN_STATE:
+            this.CategoryList.setInteractive(true);
             gfx.managers.FocusHandler.instance.setFocus(this.CategoryList,0);
             break;
          case SystemPage.SETTINGS_CATEGORY_STATE:

--- a/source/actionscript/Vanilla/Shared/CenteredScrollingList.as
+++ b/source/actionscript/Vanilla/Shared/CenteredScrollingList.as
@@ -309,4 +309,10 @@ class Shared.CenteredScrollingList extends Shared.BSScrollingList
          super.onItemPress(aiKeyboardOrMouse);
       }
    }
+
+   /* @extension */
+   function setInteractive(abInteractive:Boolean) {
+      this.bDisableInput = !abInteractive;
+      this.disableSelection = !abInteractive;
+   }
 }


### PR DESCRIPTION
You may have observed this in PauseMenu: when you selected a category and accidentally hovered over the category list, the hover would remain on any last hovered item for literally a second. This is because focus hasn't yet moved to the right content pane. This PR fixes the issue by blocking focus on `CategoryList` in `SystemPage` immediately after selecting a category.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved menu category navigation to explicitly manage list interactivity during transitions for smoother behavior.
  * Ensures category list becomes interactive again when returning to the main menu.

* **Bug Fixes**
  * Disabled category entries no longer respond when pressed, and cancel feedback is played.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->