### PR TITLE
fix(quest-journal): reset text color before applying disabled state

### DIFF
--- a/source/actionscript/Vanilla/Shared/CenteredScrollingList.as
+++ b/source/actionscript/Vanilla/Shared/CenteredScrollingList.as
@@ -144,6 +144,10 @@ class Shared.CenteredScrollingList extends Shared.BSScrollingList
    {
       if (!aEntryClip) return;
       
+      if (aEntryClip.textField != undefined) {
+         aEntryClip.textField.textColor = 0xFFFFFF;
+      }
+      
       var isDivider = this.IsDivider(aEntryObject);
       aEntryClip.gotoAndStop(isDivider ? "Divider" : "Normal");
       


### PR DESCRIPTION
Fixes #143.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed text color consistency in list entries to ensure text displays with proper visibility regardless of visual state.
  * Streamlined rendering logic to apply visual settings consistently at entry initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->