### PR TITLE
build: there is no deleted file in output when rebuilding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,6 @@ add_custom_target("ActionScript" DEPENDS ${AS_TARGETS})
 if(IS_DEBUG_BUILD)
 
     set(_DEPLOY_SCRIPT    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Deploy.cmake")
-    set(_DEPLOY_STAMP     "${CMAKE_BINARY_DIR}/_deploy.stamp")
     set(_DEPLOY_LISTS_DIR "${CMAKE_BINARY_DIR}/_deploy_lists")
 
     file(MAKE_DIRECTORY "${_DEPLOY_LISTS_DIR}")
@@ -153,25 +152,19 @@ if(IS_DEBUG_BUILD)
     file(WRITE "${_DEPLOY_LISTS_DIR}/swf_passthrough.txt" "") # Obsolete
     file(WRITE "${_DEPLOY_LISTS_DIR}/esp_file.txt"        "${_ESP_FILE}")
 
-    add_custom_command(
-        OUTPUT "${_DEPLOY_STAMP}"
+    add_custom_target("deploy_debug" ALL
         COMMAND "${CMAKE_COMMAND}"
             "-DOUTPUT_DIR=${MOD_DEBUG_PATH}"
             "-DDEPLOY_LISTS_DIR=${_DEPLOY_LISTS_DIR}"
             "-DSWF_COMPILED_BASE=${CMAKE_BINARY_DIR}/interface"
             "-DSWF_PASSTHROUGH_BASE=${CMAKE_CURRENT_SOURCE_DIR}/data/interface"
             -P "${_DEPLOY_SCRIPT}"
-        COMMAND "${CMAKE_COMMAND}" -E touch "${_DEPLOY_STAMP}"
         DEPENDS
             ${Papyrus_OUTPUT}
             ${SWF_COMPILED_OUTPUTS}
             "${_ESP_FILE}"
         COMMENT "Deploying to ${MOD_DEBUG_PATH}"
         VERBATIM
-    )
-
-    add_custom_target("deploy_debug" ALL
-        DEPENDS "${_DEPLOY_STAMP}"
     )
     add_dependencies("deploy_debug" "Papyrus" "ActionScript")
 


### PR DESCRIPTION
It can be useful to delete a contaminated .swf file after making changes to the output folder. Now, if the file is missing from the output folder, rebuilding will place the built file back in the output folder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the debug deployment build process by removing redundant file-stamp mechanism and consolidating into a single build target while maintaining all dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->