### PR TITLE
fix(scripts): block Favorites Menu hotkeys in Crafting Menu and input elements

### DIFF
--- a/source/scripts/SKI_FavoritesManager.psc
+++ b/source/scripts/SKI_FavoritesManager.psc
@@ -15,6 +15,8 @@ import Math
 ; 4:    - EDC - Added repeat find to InvalidateItem()
 ;
 ; 5:	- UnequipHand function will also unequip shields
+;
+; 6:	- Fix to prevent hotkeys from triggering in non-pausing menus and text input fields (e.g. the search box in the crafting menu)
 
 int function GetVersion()
 	return 4
@@ -334,7 +336,9 @@ event OnKeyDown(int a_keyCode)
 	gotoState("PROCESSING")
 
 	int groupIndex = _groupHotkeys.Find(a_keyCode)
-	if (groupIndex != -1 && !Utility.IsInMenuMode())
+	
+	; Fix #6
+	if (groupIndex != -1 && !Utility.IsInMenuMode() && !UI.IsTextInputEnabled() && !UI.IsMenuOpen("Crafting Menu"))
 		GroupUse(groupIndex)
 	endIf
 


### PR DESCRIPTION
Fixes #136.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hotkey activation logic to prevent unintended triggering when text input fields are active or the Crafting Menu is open. Hotkeys now more reliably respect active UI contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->