### PR TITLE
fix(mcm): allow message dialogs to open regardless of menu state

### DIFF
--- a/source/actionscript/ModConfigPanel/ConfigPanel.as
+++ b/source/actionscript/ModConfigPanel/ConfigPanel.as
@@ -312,7 +312,7 @@ class ConfigPanel extends MovieClip
    }
    function showMessageDialog(a_text, a_acceptLabel, a_cancelLabel)
    {
-      if(this._state == ConfigPanel.READY)
+      if(this._state != ConfigPanel.READY)
       {
          skse.SendModEvent("SKICP_messageDialogClosed",null,0);
          return undefined;


### PR DESCRIPTION
Fixes #121 
Fixes #157 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where message dialogs were not displaying in certain panel states, preventing users from seeing important confirmations and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->