### PR TITLE
fix(container-menu): equip mode shift stuck

### DIFF
--- a/source/actionscript/ItemMenus/ContainerMenu.as
+++ b/source/actionscript/ItemMenus/ContainerMenu.as
@@ -66,11 +66,13 @@ class ContainerMenu extends ItemMenu
    function handleInput(details, pathToFocus)
    {
       super.handleInput(details,pathToFocus);
-      if(this.shouldProcessItemsListInput(false))
+      
+      if(this._platform == 0 && details.skseKeycode == this._equipModeKey)
       {
-         if(this._platform == 0 && details.skseKeycode == this._equipModeKey && this.inventoryLists.itemList.selectedIndex != -1)
+         this._bEquipMode = details.value != "keyUp";
+         
+         if(this.shouldProcessItemsListInput(false))
          {
-            this._bEquipMode = details.value != "keyUp";
             this.updateBottomBar(true);
          }
       }


### PR DESCRIPTION
Fixes #159.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved equip-mode input handling to ensure the bottom bar updates correctly during key events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->