### PR TITLE
fix(mcm): incorrect check for closing a dialog box

### DIFF
--- a/source/actionscript/Common/skyui/components/dialog/BasicDialog.as
+++ b/source/actionscript/Common/skyui/components/dialog/BasicDialog.as
@@ -1,0 +1,95 @@
+class skyui.components.dialog.BasicDialog extends MovieClip
+{
+    var _fadeTween;
+    var dispatchEvent;
+    var onDialogClosed;
+    var onDialogClosing;
+    var onDialogOpen;
+    var onDialogOpening;
+    var removeAllEventListeners;
+    static var OPEN = 0;
+    static var CLOSED = 1;
+    static var OPENING = 2;
+    static var CLOSING = 3;
+    var _dialogState = -1;
+    function BasicDialog()
+    {
+        super();
+        gfx.events.EventDispatcher.initialize(this);
+        Mouse.addListener(this);
+    }
+    function openDialog()
+    {
+        this.setDialogState(skyui.components.dialog.BasicDialog.OPENING);
+        if(this._fadeTween)
+        {
+            this._fadeTween.stop();
+            delete this._fadeTween;
+        }
+        this._fadeTween = new mx.transitions.Tween(this,"_alpha",mx.transitions.easing.None.easeNone,0,100,0.4,true);
+        this._fadeTween.FPS = 40;
+        this._fadeTween.onMotionFinished = mx.utils.Delegate.create(this,this.fadedInFunc);
+    }
+    function closeDialog()
+    {
+        this.setDialogState(skyui.components.dialog.BasicDialog.CLOSING);
+        if(this._fadeTween)
+        {
+            this._fadeTween.stop();
+            delete this._fadeTween;
+        }
+        this._fadeTween = new mx.transitions.Tween(this,"_alpha",mx.transitions.easing.None.easeNone,100,0,0.4,true);
+        this._fadeTween.FPS = 40;
+        this._fadeTween.onMotionFinished = mx.utils.Delegate.create(this,this.fadedOutFunc);
+    }
+    function setDialogState(a_newState)
+    {
+        if(this._dialogState == a_newState)
+        {
+            return undefined;
+        }
+        this._dialogState = a_newState;
+        if(a_newState == skyui.components.dialog.BasicDialog.OPENING)
+        {
+            if(this.onDialogOpening)
+            {
+                this.onDialogOpening();
+            }
+            this.dispatchEvent({type:"dialogOpening"});
+        }
+        else if(a_newState == skyui.components.dialog.BasicDialog.OPEN)
+        {
+            if(this.onDialogOpen)
+            {
+                this.onDialogOpen();
+            }
+            this.dispatchEvent({type:"dialogOpen"});
+        }
+        else if(a_newState == skyui.components.dialog.BasicDialog.CLOSING)
+        {
+            if(this.onDialogClosing)
+            {
+                this.onDialogClosing();
+            }
+            this.dispatchEvent({type:"dialogClosing"});
+        }
+        else if(a_newState == skyui.components.dialog.BasicDialog.CLOSED)
+        {
+            if(this.onDialogClosed)
+            {
+                this.onDialogClosed();
+            }
+            this.dispatchEvent({type:"dialogClosed"});
+            this.removeAllEventListeners();
+            this.removeMovieClip();
+        }
+    }
+    function fadedInFunc()
+    {
+        this.setDialogState(skyui.components.dialog.BasicDialog.OPEN);
+    }
+    function fadedOutFunc()
+    {
+        this.setDialogState(skyui.components.dialog.BasicDialog.CLOSED);
+    }
+}

--- a/source/actionscript/Common/skyui/util/DialogManager.as
+++ b/source/actionscript/Common/skyui/util/DialogManager.as
@@ -1,0 +1,26 @@
+class skyui.util.DialogManager
+{
+    static var _activeDialog;
+    static var _previousFocus;
+    function DialogManager()
+    {
+    }
+    static function open(a_target, a_linkageID, a_init)
+    {
+        if(skyui.util.DialogManager._activeDialog)
+        {
+            skyui.util.DialogManager.close();
+        }
+        skyui.util.DialogManager._previousFocus = gfx.managers.FocusHandler.instance.getFocus(0);
+        skyui.util.DialogManager._activeDialog = skyui.components.dialog.BasicDialog(a_target.attachMovie(a_linkageID,"dialog",a_target.getNextHighestDepth(),a_init));
+        gfx.managers.FocusHandler.instance.setFocus(skyui.util.DialogManager._activeDialog,0);
+        skyui.util.DialogManager._activeDialog.openDialog();
+        return skyui.util.DialogManager._activeDialog;
+    }
+    static function close()
+    {
+        gfx.managers.FocusHandler.instance.setFocus(skyui.util.DialogManager._previousFocus,0);
+        skyui.util.DialogManager._activeDialog.closeDialog();
+        skyui.util.DialogManager._activeDialog = null;
+    }
+}

--- a/source/actionscript/ModConfigPanel/ConfigPanel.as
+++ b/source/actionscript/ModConfigPanel/ConfigPanel.as
@@ -312,11 +312,6 @@ class ConfigPanel extends MovieClip
    }
    function showMessageDialog(a_text, a_acceptLabel, a_cancelLabel)
    {
-      // if(this._state == ConfigPanel.READY)
-      // {
-      //    skse.SendModEvent("SKICP_messageDialogClosed",null,0);
-      //    return undefined;
-      // }
       var _loc2_ = {_x:719,_y:265,platform:this._platform,messageText:a_text,acceptLabel:a_acceptLabel,cancelLabel:a_cancelLabel};
       var _loc3_ = skyui.util.DialogManager.open(this,"MessageDialog",_loc2_);
       _loc3_.addEventListener("dialogClosing",this,"onMessageDialogClosing");

--- a/source/actionscript/ModConfigPanel/ConfigPanel.as
+++ b/source/actionscript/ModConfigPanel/ConfigPanel.as
@@ -312,6 +312,11 @@ class ConfigPanel extends MovieClip
    }
    function showMessageDialog(a_text, a_acceptLabel, a_cancelLabel)
    {
+      if (skyui.util.DialogManager._activeDialog)
+      {
+         skse.SendModEvent("SKICP_messageDialogClosed", null, 0);
+         return undefined;
+      }
       var _loc2_ = {_x:719,_y:265,platform:this._platform,messageText:a_text,acceptLabel:a_acceptLabel,cancelLabel:a_cancelLabel};
       var _loc3_ = skyui.util.DialogManager.open(this,"MessageDialog",_loc2_);
       _loc3_.addEventListener("dialogClosing",this,"onMessageDialogClosing");

--- a/source/actionscript/ModConfigPanel/ConfigPanel.as
+++ b/source/actionscript/ModConfigPanel/ConfigPanel.as
@@ -312,11 +312,11 @@ class ConfigPanel extends MovieClip
    }
    function showMessageDialog(a_text, a_acceptLabel, a_cancelLabel)
    {
-      if(this._state != ConfigPanel.READY)
-      {
-         skse.SendModEvent("SKICP_messageDialogClosed",null,0);
-         return undefined;
-      }
+      // if(this._state == ConfigPanel.READY)
+      // {
+      //    skse.SendModEvent("SKICP_messageDialogClosed",null,0);
+      //    return undefined;
+      // }
       var _loc2_ = {_x:719,_y:265,platform:this._platform,messageText:a_text,acceptLabel:a_acceptLabel,cancelLabel:a_cancelLabel};
       var _loc3_ = skyui.util.DialogManager.open(this,"MessageDialog",_loc2_);
       _loc3_.addEventListener("dialogClosing",this,"onMessageDialogClosing");

--- a/source/swfsources.cmake
+++ b/source/swfsources.cmake
@@ -429,6 +429,8 @@ Add_SWF(skyui_configpanel
     skyui/configpanel.swf
     skyui/configpanel.xml
     Common/skyui/defines/Input.as
+    Common/skyui/components/dialog/BasicDialog.as
+    Common/skyui/util/DialogManager.as
     ModConfigPanel/ColorDialog.as
     ModConfigPanel/ConfigPanel.as
     ModConfigPanel/MenuDialog.as


### PR DESCRIPTION
Fixes regression #161. 

If `showMessageDialog` is called by the Papyrus script itself, then the protection is meaningless. The `if(this._state != ConfigPanel.READY)` protection is needed when the user controls the input. They click on the option and launch the action. To avoid multiple calls to the option, some functions have the `if(this._state != ConfigPanel.READY)` protection (do nothing until we are ready). But the call to showMessageDialog seems to be performed by Papyrus, and it decides whether showMessageDialog can be launched. That is, the user clicks on the option, and selectOption is launched, which already has the `if(this._state != ConfigPanel.READY)` protection. If the option is responsible for launching the dialog box, then Papyrus itself calls `UI.Invoke("showMessageDialog")`

The options responsible for launching the dialog box are currently broken. Issues due to the != check are found in:
- Frostfall
- Campfire
- Last Seed
- SmoothCam

No issues found in:
- Forgotten Magic Redon SE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable dialog component with open/close lifecycle, events and fade animations.
  * Added a dialog manager to enforce single active dialog and restore focus when dialogs close.

* **Bug Fixes**
  * Message dialog now opens reliably even when other internal state checks would previously block it.

* **Chores**
  * Common dialog sources integrated into the build so dialogs are available project-wide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->