### PR TITLE
feat(inventory-list): add quick navigation for active/equipped items

### DIFF
--- a/source/actionscript/CraftingMenu/CraftingLists.as
+++ b/source/actionscript/CraftingMenu/CraftingLists.as
@@ -192,6 +192,17 @@ class CraftingLists extends MovieClip
             return true;
          }
       }
+      var kc = details.code;
+      var isCtrl = details.ctrlKey || Key.isDown(Key.CONTROL);
+
+      if (isCtrl && (kc == 87 || kc == 38 || kc == 83 || kc == 40)) {
+         if (details.value == "keyDown" || details.value == "keyHold") {
+            var dir = (kc == 83 || kc == 40) ? 1 : -1;
+            this.selectEquippedItem(dir);
+            return true;
+         }
+         if (details.value == "keyUp") return true;
+      }
       if(Shared.GlobalFunc.IsKeyPressed(details))
       {
          if(details.skseKeycode == this._searchKey)
@@ -489,6 +500,31 @@ class CraftingLists extends MovieClip
       this.CategoriesList.disableSelection = this.CategoriesList.disableInput = false;
       this.itemList.disableSelection = this.itemList.disableInput = false;
       this._nameFilter.filterText = event.data;
+   }
+
+   function selectEquippedItem(a_direction: Number)
+   {
+      var list = this.itemList;
+      var enumSize = list.getListEnumSize();
+      if (enumSize <= 0) return;
+
+      var currentEnumIdx = list.getSelectedListEnumIndex();
+      if (currentEnumIdx == undefined || currentEnumIdx == -1) {
+         currentEnumIdx = (a_direction > 0) ? -1 : 0;
+      }
+
+      for (var i = 1; i <= enumSize; i++) {
+         var nextEnumIdx = (currentEnumIdx + (i * a_direction)) % enumSize;
+         if (nextEnumIdx < 0) nextEnumIdx += enumSize;
+         
+         var entry = list.getListEnumEntry(nextEnumIdx);
+
+         if (entry != undefined && entry.equipState != undefined && entry.equipState > 0) {
+            list.doSetSelectedIndex(entry.itemIndex, 1); 
+            gfx.io.GameDelegate.call("PlaySound", ["UIMenuFocus"]);
+            return;
+         }
+      }
    }
 
    function applyDynamicWidth(a_newWidth: Number)

--- a/source/actionscript/ItemMenus/InventoryLists.as
+++ b/source/actionscript/ItemMenus/InventoryLists.as
@@ -178,6 +178,19 @@ class InventoryLists extends MovieClip
             return true;
          }
       }
+      
+      var kc = details.code;
+      var isCtrl = details.ctrlKey || Key.isDown(Key.CONTROL);
+
+      if (isCtrl && (kc == 87 || kc == 38 || kc == 83 || kc == 40)) {
+         if (details.value == "keyDown" || details.value == "keyHold") {
+            var dir = (kc == 83 || kc == 40) ? 1 : -1;
+            this.selectEquippedItem(dir);
+            return true;
+         }
+         if (details.value == "keyUp") return true;
+      }
+
       if(Shared.GlobalFunc.IsKeyPressed(details))
       {
          if(details.skseKeycode == this._searchKey)
@@ -412,6 +425,30 @@ class InventoryLists extends MovieClip
       this._nameFilter.filterText = event.data;
    }
 
+   function selectEquippedItem(a_direction: Number)
+   {
+      var list = this.itemList;
+      var enumSize = list.getListEnumSize();
+      if (enumSize <= 0) return;
+
+      var currentEnumIdx = list.getSelectedListEnumIndex();
+      if (currentEnumIdx == undefined || currentEnumIdx == -1) {
+         currentEnumIdx = (a_direction > 0) ? -1 : 0;
+      }
+
+      for (var i = 1; i <= enumSize; i++) {
+         var nextEnumIdx = (currentEnumIdx + (i * a_direction)) % enumSize;
+         if (nextEnumIdx < 0) nextEnumIdx += enumSize;
+         
+         var entry = list.getListEnumEntry(nextEnumIdx);
+
+         if (entry != undefined && entry.equipState != undefined && entry.equipState > 0) {
+            list.doSetSelectedIndex(entry.itemIndex, 1); 
+            gfx.io.GameDelegate.call("PlaySound", ["UIMenuFocus"]);
+            return;
+         }
+      }
+   }
 
    function applyDynamicWidth(a_newWidth: Number)
    {


### PR DESCRIPTION
This PR introduces a quality-of-life improvement for inventory management, allowing players to quickly locate and cycle through their active gear without manual scrolling.

**Key Changes:**
* **New Navigation Logic:** Implemented `selectEquippedItem` in `InventoryLists.as` which scans the list for items with an active `equipState`.
* **Bidirectional Support:** 
    * `Ctrl + S` or `Ctrl + Down`: Cycle forward.
    * `Ctrl + W` or `Ctrl + Up`: Cycle backward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts (Ctrl+arrow keys) to navigate between equipped items in inventory and crafting menus. Selection cycles through equipped items and wraps around the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->