### PR TITLE
fix: revert "fix(mcm): allow message dialogs to open regardless of menu state"

### DIFF
--- a/source/actionscript/ModConfigPanel/ConfigPanel.as
+++ b/source/actionscript/ModConfigPanel/ConfigPanel.as
@@ -312,7 +312,7 @@ class ConfigPanel extends MovieClip
    }
    function showMessageDialog(a_text, a_acceptLabel, a_cancelLabel)
    {
-      if(this._state != ConfigPanel.READY)
+      if(this._state == ConfigPanel.READY)
       {
          skse.SendModEvent("SKICP_messageDialogClosed",null,0);
          return undefined;


### PR DESCRIPTION
Reverts doodlum/SkyUI-Community#161. Most MCM mods are already built on this architecture, so it is dangerous to change anything in ConfigPanel.as

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed message dialog behavior in the configuration panel to properly manage when dialogs are displayed based on the system state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->