### PR TITLE
fix(crafting-menu): decentered MenuDescriptionHolder position

### DIFF
--- a/source/actionscript/CraftingMenu/CraftingMenu.as
+++ b/source/actionscript/CraftingMenu/CraftingMenu.as
@@ -304,12 +304,9 @@ class CraftingMenu extends MovieClip
       this.CategoryList._y -= Stage.safeRect.y;
       this.MenuNameHolder.Lock("L");
       this.MenuNameHolder._x -= CraftingMenu.LIST_OFFSET;
-      this.MenuDescriptionHolder.Lock("TR");
+
       var leftOffset = Stage.visibleRect.x + Stage.safeRect.x;
       var rightOffset = Stage.visibleRect.x + Stage.visibleRect.width - Stage.safeRect.x;
-      var listBounds = this.CategoryList.getContentBounds();
-      var listRightEdge = this.CategoryList._x + listBounds[0] + listBounds[2] + 25;
-      this.MenuDescriptionHolder._x = 7 + listRightEdge + (rightOffset - listRightEdge) / 2 + this.MenuDescriptionHolder._width / 2;
 
       var marginBottomBarInfo = 17;
       
@@ -360,6 +357,10 @@ class CraftingMenu extends MovieClip
          _loc2_._x = _loc6_ + _loc3_.xOffset + (Stage.visibleRect.x + Stage.visibleRect.width - _loc6_ - _loc5_) / 2;
       }
       _loc2_._y += _loc3_.yOffset;
+      
+      this.MenuDescriptionHolder.Lock("TR");
+      this.MenuDescriptionHolder._x = _loc2_._x + _loc2_._width - 17;
+
       MovieClip(this.MouseRotationRect).Lock("T");
       this.MouseRotationRect._x = this.ItemInfo._parent._x;
       this.MouseRotationRect._width = this.ItemInfo._parent._width;

--- a/source/actionscript/CraftingMenu/CraftingMenu.as
+++ b/source/actionscript/CraftingMenu/CraftingMenu.as
@@ -307,9 +307,9 @@ class CraftingMenu extends MovieClip
       this.MenuDescriptionHolder.Lock("TR");
       var leftOffset = Stage.visibleRect.x + Stage.safeRect.x;
       var rightOffset = Stage.visibleRect.x + Stage.visibleRect.width - Stage.safeRect.x;
-      var _loc3_ = this.CategoryList.getContentBounds();
-      var _loc4_ = this.CategoryList._x + _loc3_[0] + _loc3_[2] + 25;
-      this.MenuDescriptionHolder._x = 10 + _loc4_ + (_loc2_ - _loc4_) / 2 + this.MenuDescriptionHolder._width / 2;
+      var listBounds = this.CategoryList.getContentBounds();
+      var listRightEdge = this.CategoryList._x + listBounds[0] + listBounds[2] + 25;
+      this.MenuDescriptionHolder._x = listRightEdge + (rightOffset - listRightEdge) / 2 + this.MenuDescriptionHolder._width / 2;
 
       var marginBottomBarInfo = 17;
       

--- a/source/actionscript/CraftingMenu/CraftingMenu.as
+++ b/source/actionscript/CraftingMenu/CraftingMenu.as
@@ -309,7 +309,7 @@ class CraftingMenu extends MovieClip
       var rightOffset = Stage.visibleRect.x + Stage.visibleRect.width - Stage.safeRect.x;
       var listBounds = this.CategoryList.getContentBounds();
       var listRightEdge = this.CategoryList._x + listBounds[0] + listBounds[2] + 25;
-      this.MenuDescriptionHolder._x = listRightEdge + (rightOffset - listRightEdge) / 2 + this.MenuDescriptionHolder._width / 2;
+      this.MenuDescriptionHolder._x = 7 + listRightEdge + (rightOffset - listRightEdge) / 2 + this.MenuDescriptionHolder._width / 2;
 
       var marginBottomBarInfo = 17;
       


### PR DESCRIPTION
Fixes regression #52, now the MenuDescriptionHolder (description at the top screen of the ItemCard: Blacksmith Forge...) center is aligned with the ItemCard center.
<img width="2560" height="1080" alt="Снимок экрана 2026-04-22 142446" src="https://github.com/user-attachments/assets/8f9f0c71-cd83-45ac-8eef-dc8a3a8d5c75" />
<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/d9aab3f4-2116-4e57-b544-19da694f8b0a" />
