### PR TITLE
feat(inventory-list): add a setting for the spacing between columns

### DIFF
--- a/data/interface/skyui/config.txt
+++ b/data/interface/skyui/config.txt
@@ -56,7 +56,7 @@ vars.a_textBorder.value = <0, 0, 1.1, 0> ; left right top bottom
 vars.n_iconSize.value = 18
 
 defaults.entryWidth = 530
-defaults.columnMargin = 0 ; Global indentation between columns in the inventory list
+defaults.columnMargin = 0 ; global spacing between columns of the right block
 
 ; Default text format defaults -------------------------------------------------------
 defaults.entry.textFormat.font = '$EverywhereMediumFont'

--- a/data/interface/skyui/config.txt
+++ b/data/interface/skyui/config.txt
@@ -56,6 +56,7 @@ vars.a_textBorder.value = <0, 0, 1.1, 0> ; left right top bottom
 vars.n_iconSize.value = 18
 
 defaults.entryWidth = 530
+defaults.columnMargin = 0 ; Global indentation between columns in the inventory list
 
 ; Default text format defaults -------------------------------------------------------
 defaults.entry.textFormat.font = '$EverywhereMediumFont'

--- a/source/actionscript/Common/skyui/components/list/ListLayout.as
+++ b/source/actionscript/Common/skyui/components/list/ListLayout.as
@@ -464,7 +464,7 @@ class skyui.components.list.ListLayout
         var xPos = 0;
         c = 0;
         for (var i = 0; i < this._columnList.length; i++) {
-            var col = _columnList[i];
+            var col = this._columnList[i];
             // Skip
             if (col.hidden == true)
                 continue;

--- a/source/actionscript/Common/skyui/components/list/ListLayout.as
+++ b/source/actionscript/Common/skyui/components/list/ListLayout.as
@@ -133,6 +133,18 @@ class skyui.components.list.ListLayout
         return this._sortAttributes;
     }
 
+    private var _columnMargin: Number;
+
+    public function get columnMargin()
+    {
+        return this._columnMargin;
+    }
+
+    public function set columnMargin(a_margin: Number)
+    {
+        this._columnMargin = a_margin;
+    }
+
 
 
   /* INITIALIZATION */
@@ -157,6 +169,9 @@ class skyui.components.list.ListLayout
 
         if (this._entryWidth == undefined)
             this._entryWidth = this._defaultsData.entryWidth;
+
+        if (this._columnMargin == undefined)
+            this._columnMargin = this._defaultsData.columnMargin;
         
         this.updateViewList();
         this.updateColumnList();
@@ -460,6 +475,8 @@ class skyui.components.list.ListLayout
             }
         }
         
+        var visibleColumnCount = this._columnLayoutData.length;
+
         // Set x positions based on calculated widths, and set label data
         var xPos = 0;
         c = 0;
@@ -469,22 +486,29 @@ class skyui.components.list.ListLayout
             if (col.hidden == true)
                 continue;
                 
+            var currentVisibleIdx = c;
             var columnLayoutData = this._columnLayoutData[c++];
             
             if (col.indent != undefined)
                 xPos += col.indent;
 
-            columnLayoutData.labelX = xPos;
+            var offset = 0;
+            if (columnLayoutData.type == skyui.components.list.ListLayout.COL_TYPE_TEXT) {
+                var multiplier = (visibleColumnCount - 1) - currentVisibleIdx;
+                offset = this.columnMargin * multiplier;
+            }
+
+            columnLayoutData.labelX = xPos - offset;
 
             if (col.border != undefined) {
                 columnLayoutData.labelWidth = columnLayoutData.width + col.border[skyui.components.list.ListLayout.LEFT] + col.border[skyui.components.list.ListLayout.RIGHT];
-                columnLayoutData.x = xPos;
+                columnLayoutData.x = xPos - offset;
                 xPos += col.border[skyui.components.list.ListLayout.LEFT];
-                columnLayoutData.x = xPos;
+                columnLayoutData.x = xPos - offset;
                 xPos += col.border[skyui.components.list.ListLayout.RIGHT] + columnLayoutData.width;
             } else {
                 columnLayoutData.labelWidth = columnLayoutData.width;
-                columnLayoutData.x = xPos;
+                columnLayoutData.x = xPos - offset;
                 xPos += columnLayoutData.width;
             }
         }

--- a/source/swfsources.cmake
+++ b/source/swfsources.cmake
@@ -122,6 +122,7 @@ Add_SWF(craftingmenu
     Common/skyui/filter/NameFilter.as
     Common/skyui/filter/SortFilter.as
     Common/skyui/components/list/BasicListEntry.as
+    Common/skyui/components/list/ListLayout.as
     Common/skyui/components/list/TabularListEntry.as
     CraftingMenu/CraftingDataSetter.as
     CraftingMenu/CraftingIconSetter.as
@@ -481,6 +482,7 @@ Add_SWF(skyui_inventorylists
     Common/skyui/filter/NameFilter.as
     Common/skyui/filter/SortFilter.as
     Common/skyui/components/list/BasicListEntry.as
+    Common/skyui/components/list/ListLayout.as
     Common/skyui/components/list/TabularListEntry.as
     Common/skyui/components/list/ScrollingList.as
     ItemMenus/CategoryList.as


### PR DESCRIPTION
Resolve #153.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Column spacing in list layouts is now configurable, letting you adjust horizontal margins between columns for finer layout control. The setting has a default value of zero so existing layouts remain unchanged unless customized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->