### PR TITLE
fix(list-entry): add `flash.geom` prefix

### DIFF
--- a/source/actionscript/CraftingMenu/CraftingListEntry.as
+++ b/source/actionscript/CraftingMenu/CraftingListEntry.as
@@ -159,8 +159,8 @@ class CraftingListEntry extends skyui.components.list.TabularListEntry
          element = a_icon[e];
          if (element instanceof MovieClip) {
             //Note: Could check if all values of RGBA mult and .rgb are all the same then skip
-            var ct: ColorTransform = new ColorTransform();
-            var tf: Transform = new Transform(MovieClip(element));
+            var ct: ColorTransform = new flash.geom.ColorTransform();
+            var tf: Transform = new flash.geom.Transform(MovieClip(element));
             // Could return here if (a_rgb == tf.colorTransform.rgb && a_rgb != undefined)
             ct.rgb = (a_rgb == undefined)? 0xFFFFFF: a_rgb;
             tf.colorTransform = ct;

--- a/source/actionscript/CraftingMenu/CraftingListEntry.as
+++ b/source/actionscript/CraftingMenu/CraftingListEntry.as
@@ -162,7 +162,7 @@ class CraftingListEntry extends skyui.components.list.TabularListEntry
             var ct: ColorTransform = new flash.geom.ColorTransform();
             var tf: Transform = new flash.geom.Transform(MovieClip(element));
             // Could return here if (a_rgb == tf.colorTransform.rgb && a_rgb != undefined)
-            ct.rgb = (a_rgb == undefined)? 0xFFFFFF: a_rgb;
+            ct.rgb = (a_rgb == undefined) ? 0xFFFFFF : a_rgb;
             tf.colorTransform = ct;
             // Shouldn't be necessary to recurse since we don't expect multiple clip depths for an icon
             //this.changeIconColor(element, a_rgb);

--- a/source/actionscript/ItemMenus/InventoryListEntry.as
+++ b/source/actionscript/ItemMenus/InventoryListEntry.as
@@ -216,7 +216,7 @@ class InventoryListEntry extends skyui.components.list.TabularListEntry
             var ct: ColorTransform = new flash.geom.ColorTransform();
             var tf: Transform = new flash.geom.Transform(MovieClip(element));
             // Could return here if (a_rgb == tf.colorTransform.rgb && a_rgb != undefined)
-            ct.rgb = (a_rgb == undefined)? 0xFFFFFF: a_rgb;
+            ct.rgb = (a_rgb == undefined) ? 0xFFFFFF : a_rgb;
             tf.colorTransform = ct;
             // Shouldn't be necessary to recurse since we don't expect multiple clip depths for an icon
             //this.changeIconColor(element, a_rgb);

--- a/source/actionscript/ItemMenus/InventoryListEntry.as
+++ b/source/actionscript/ItemMenus/InventoryListEntry.as
@@ -213,8 +213,8 @@ class InventoryListEntry extends skyui.components.list.TabularListEntry
          element = a_icon[e];
          if (element instanceof MovieClip) {
             //Note: Could check if all values of RGBA mult and .rgb are all the same then skip
-            var ct: ColorTransform = new ColorTransform();
-            var tf: Transform = new Transform(MovieClip(element));
+            var ct: ColorTransform = new flash.geom.ColorTransform();
+            var tf: Transform = new flash.geom.Transform(MovieClip(element));
             // Could return here if (a_rgb == tf.colorTransform.rgb && a_rgb != undefined)
             ct.rgb = (a_rgb == undefined)? 0xFFFFFF: a_rgb;
             tf.colorTransform = ct;


### PR DESCRIPTION
A minor regression in #176 caused inventory icons to become discolored. JPEXS requires a scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code clarity and dependency management in internal color-handling components for crafting and inventory menus by making package references more explicit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->