### PR TITLE
chore: add source `skyui/components/list` scripts for editing/import

### DIFF
--- a/source/actionscript/Common/skyui/components/list/BSList.as
+++ b/source/actionscript/Common/skyui/components/list/BSList.as
@@ -1,0 +1,58 @@
+/*
+ *  Basic list API expected by the game.
+ */
+
+// @abstract
+class skyui.components.list.BSList extends MovieClip
+{
+  /* PROPERTIES */
+  
+  	// Entries of the list, represented by dynamic objects.
+	// When the internal representation of the entry list, changes are pushed directly into entryList.
+	// As such, the order of this array should not be modified for certain lists.
+	private var _entryList: Array;
+	
+	public function get entryList()
+	{
+		return this._entryList;
+	}
+
+	// Indicates the selected index and is read by the game directly.
+	private var _selectedIndex: Number;
+	
+	public function get selectedIndex()
+	{
+		return this._selectedIndex;
+	}
+
+	function set selectedIndex(a_newIndex: Number)
+	{
+		this._selectedIndex = a_newIndex;
+	}
+	
+	// The selected entry.
+	public function get selectedEntry()
+	{
+		return this._entryList[this._selectedIndex];
+	}
+	
+	
+  /* CONSTRUCTORS */
+  
+	public function BSList()
+	{
+		this._entryList = new Array();
+		this._selectedIndex = -1;
+	}
+	
+	
+  /* PUBLIC FUNCTIONS */
+	
+	// Indicates that entryList has been updated.
+	// @abstract
+	public function InvalidateData() { }
+	
+	// Redraws the list.
+	// @abstract
+	public function UpdateList() { }
+}

--- a/source/actionscript/Common/skyui/components/list/BasicEnumeration.as
+++ b/source/actionscript/Common/skyui/components/list/BasicEnumeration.as
@@ -1,0 +1,47 @@
+class skyui.components.list.BasicEnumeration implements skyui.components.list.BasicEnumeration.IEntryEnumeration
+{
+  /* PROPERTIES */
+
+    private var _entryData: Array;
+
+
+  /* INITIALIZATION */
+
+    public function BasicEnumeration(a_data: Array)
+    {
+        this._entryData = a_data;
+    }
+
+
+  /* PUBLIC FUNCTIONS */
+
+    // @override skyui.IEntryEnumeration
+    public function size()
+    {
+        return this._entryData.length;
+    }
+
+    // @override skyui.IEntryEnumeration
+    public function at(a_index: Number)
+    {
+        return this._entryData[a_index];
+    }
+
+    // @override skyui.IEntryEnumeration
+    public function lookupEntryIndex(a_enumIndex: Number)
+    {
+        return a_enumIndex;
+    }
+
+    // @override skyui.IEntryEnumeration
+    public function lookupEnumIndex(a_entryIndex: Number)
+    {
+        return a_entryIndex;
+    }
+
+    // @override skyui.IEntryEnumeration
+    public function invalidate()
+    {
+        // Do nothing.
+    }
+}

--- a/source/actionscript/Common/skyui/components/list/BasicList.as
+++ b/source/actionscript/Common/skyui/components/list/BasicList.as
@@ -1,0 +1,398 @@
+// @abstract
+class skyui.components.list.BasicList extends skyui.components.list.BSList
+{
+  /* CONSTANTS */
+  
+	public static var PLATFORM_PC = 0;
+
+	public static var SELECT_MOUSE = 0;
+	public static var SELECT_KEYBOARD = 1;
+
+	
+  /* STAGE ELEMENTS */
+
+	public var background: MovieClip;
+	
+	
+  /* PRIVATE VARIABLES */
+
+  	private var _bRequestInvalidate: Boolean = false;
+  	private var _bRequestUpdate: Boolean = false;
+	private var _invalidateRequestID: Number;
+	private var _updateRequestID: Number;
+	
+	private var _entryClipManager: EntryClipManager;
+	
+	private var _dataProcessors: Array;
+	
+
+  /* PROPERTIES */
+  
+  	public var topBorder: Number = 0;
+	public var bottomBorder: Number = 0;
+	public var leftBorder: Number = 0;
+	public var rightBorder: Number = 0;
+	
+	public function get width()
+	{
+		return this.background._width;
+	}
+	
+	public function set width(a_val: Number)
+	{
+		this.background._width = a_val;
+	}
+	
+	public function get height()
+	{
+		return this.background._height;
+	}
+	
+	public function set height(a_val: Number)
+	{
+		this.background._height = a_val;
+	}
+  
+	private var _platform: Number = skyui.components.list.BasicList.PLATFORM_PC;
+	
+	public function get platform()
+	{
+		return this._platform;
+	}
+	
+	/*
+	// Removed 2012/12/18, use setPlatform()
+	public function set platform(a_platform: Number)
+	{
+		this._platform = a_platform;
+		this.isMouseDrivenNav = this._platform == skyui.components.list.BasicList.PLATFORM_PC;
+	}
+	*/
+	
+	public var isMouseDrivenNav: Boolean = false;
+	
+	public var isListAnimating: Boolean = false;
+	
+	public var disableInput: Boolean = false;
+	
+	public var disableSelection: Boolean = false;
+	
+	public var isAutoUnselect: Boolean = false;
+	
+	public var canSelectDisabled: Boolean = false;
+
+	// @override BSList
+	public function get selectedIndex()
+	{
+		return this._selectedIndex;
+	}
+	
+	// @override BSList
+	public function set selectedIndex(a_newIndex: Number)
+	{
+		this.doSetSelectedIndex(a_newIndex, skyui.components.list.BasicList.SELECT_MOUSE);
+	}
+	
+	public var entryRenderer: String;
+	
+	public var listEnumeration: IEntryEnumeration;
+	
+	public var listState: ListState;
+	
+	public function get itemCount()
+	{
+		return this.getListEnumSize();
+	}
+	
+	// The selected entry.
+	public function get selectedClip()
+	{
+		return this._entryClipManager.getClip(this.selectedEntry.clipIndex);
+	}
+	
+	
+	private var _bSuspended: Boolean = false;
+	
+	public function get suspended()
+	{
+		return this._bSuspended;
+	}
+	
+	public function set suspended(a_flag: Boolean)
+	{
+		if (this._bSuspended == a_flag)
+			return;
+		
+		// Lock
+		if (a_flag) {
+			this._bSuspended = true;
+		} else {
+			this._bSuspended = false;
+			
+			if (this._bRequestInvalidate)
+				this.InvalidateData();
+			else if(this._bRequestUpdate)
+				this.UpdateList();
+
+			this._bRequestInvalidate = false;
+			this._bRequestUpdate = false;
+			
+			// Allow custom handlers
+			if (this.onUnsuspend != undefined)
+				this.onUnsuspend();
+		}
+	}
+	
+	
+  /* INITIALIZATION */
+  
+	public function BasicList()
+	{
+		super();
+		
+		this._entryClipManager = new skyui.components.list.EntryClipManager(this);
+		this._dataProcessors = [];
+		this.listState = new skyui.components.list.ListState(this);
+
+		gfx.events.EventDispatcher.initialize(this);
+		Mouse.addListener(this);
+	}
+
+	
+  /* PUBLIC FUNCTIONS */
+  
+	// @mixin by gfx.events.EventDispatcher
+	public var dispatchEvent: Function;
+	public var dispatchQueue: Function;
+	public var hasEventListener: Function;
+	public var addEventListener: Function;
+	public var removeEventListener: Function;
+	public var removeAllEventListeners: Function;
+	public var cleanUpEvents: Function;
+
+	public function setPlatform(a_platform: Number, a_bPS3Switch: Boolean)
+	{
+		this._platform = a_platform;
+		this.isMouseDrivenNav = this._platform == skyui.components.list.BasicList.PLATFORM_PC;
+	}
+	
+	// Custom handlers
+	public var onUnsuspend: Function;
+	public var onInvalidate: Function;
+	
+	public function addDataProcessor(a_dataProcessor: IListProcessor)
+	{
+		this._dataProcessors.push(a_dataProcessor);
+	}
+	
+	public function clearList()
+	{
+		this._entryList.splice(0);
+	}
+	
+	public function requestInvalidate()
+	{
+		this._bRequestInvalidate = true;
+		
+		// Invalidate request replaces update request
+		if (this._updateRequestID) {
+			this._bRequestUpdate = false;
+			clearInterval(this._updateRequestID);
+			delete this._updateRequestID;
+		}
+		
+		// If suspsend, the unsuspend will trigger the requested invaliate.
+		if (!this._bSuspended && !this._invalidateRequestID)
+			this._invalidateRequestID = setInterval(this, "commitInvalidate", 1);
+	}
+	
+	public function requestUpdate()
+	{
+		this._bRequestUpdate = true;
+		
+		// Invalidate already requested? Includes update
+		if (this._invalidateRequestID)
+			return;
+			
+		// If suspsend, the unsuspend will trigger the requested invaliate.
+		if (!this._bSuspended && !this._invalidateRequestID)
+			this._updateRequestID = setInterval(this, "commitUpdate", 1);
+	}
+	
+	public function commitInvalidate()
+	{
+		clearInterval(this._invalidateRequestID);
+		delete this._invalidateRequestID;
+		
+		// Invalidate request replaces update request
+		if (this._updateRequestID) {
+			this._bRequestUpdate = false;
+			clearInterval(this._updateRequestID);
+			delete this._updateRequestID;
+		}
+		
+		this._bRequestInvalidate = false;
+		this.InvalidateData();
+	}
+	
+	public function commitUpdate()
+	{
+		clearInterval(this._updateRequestID);
+		delete this._updateRequestID;
+		
+		this._bRequestUpdate = false;
+		this.UpdateList();
+	}
+	
+	// @override BSList
+	public function InvalidateData()
+	{
+		if (this._bSuspended) {
+			this._bRequestInvalidate = true;
+			return;
+		}
+		
+		for (var i = 0; i < this._entryList.length; i++) {
+			this._entryList[i].itemIndex = i;
+			this._entryList[i].clipIndex = undefined;
+		}
+		
+		for (var i = 0; i < this._dataProcessors.length; i++)
+			this._dataProcessors[i].processList(this);
+		
+		this.listEnumeration.invalidate();
+		
+		if (this._selectedIndex >= this.listEnumeration.size())
+			this._selectedIndex = this.listEnumeration.size() - 1;
+
+		this.UpdateList();
+		
+		if (this.onInvalidate)
+			this.onInvalidate();
+	}
+
+	// @override BSList
+	// @abstract
+	public function UpdateList() { }
+	
+	
+  /* PRIVATE FUNCTIONS */
+  
+	private function onItemPress(a_index: Number, a_keyboardOrMouse: Number)
+	{
+		if (this.disableInput || this.disableSelection || this._selectedIndex == -1)
+			return;
+			
+		if (a_keyboardOrMouse == undefined)
+			a_keyboardOrMouse = skyui.components.list.BasicList.SELECT_KEYBOARD;
+			
+		this.dispatchEvent({type: "itemPress", index: this._selectedIndex, entry: this.selectedEntry, clip: this.selectedClip, keyboardOrMouse: a_keyboardOrMouse});
+	}
+	
+	private function onItemPressAux(a_index: Number, a_keyboardOrMouse: Number, a_buttonIndex: Number)
+	{
+		if (this.disableInput || this.disableSelection || this._selectedIndex == -1 || a_buttonIndex != 1)
+			return;
+			
+		if (a_keyboardOrMouse == undefined)
+			a_keyboardOrMouse = skyui.components.list.BasicList.SELECT_KEYBOARD;
+		
+		this.dispatchEvent({type: "itemPressAux", index: this._selectedIndex, entry: this.selectedEntry, clip: this.selectedClip, keyboardOrMouse: a_keyboardOrMouse});
+	}
+	
+	private function onItemRollOver(a_index: Number)
+	{
+		if (this.isListAnimating || this.disableSelection || this.disableInput)
+			return;
+			
+		this.doSetSelectedIndex(a_index, skyui.components.list.BasicList.SELECT_MOUSE);
+		this.isMouseDrivenNav = true;
+	}
+
+	private function onItemRollOut(a_index: Number)
+	{
+		if (!this.isAutoUnselect)
+			return;
+		
+		if (this.isListAnimating || this.disableSelection || this.disableInput)
+			return;
+			
+		this.doSetSelectedIndex(-1, skyui.components.list.BasicList.SELECT_MOUSE);
+		this.isMouseDrivenNav = true;
+	}
+
+	private function doSetSelectedIndex(a_newIndex: Number, a_keyboardOrMouse: Number)
+	{
+		if (this.disableSelection || a_newIndex == this._selectedIndex)
+			return;
+			
+		// Selection is not contained in current entry enumeration, ignore
+		if (a_newIndex != -1 && this.getListEnumIndex(a_newIndex) == undefined)
+			return;
+			
+		var oldIndex = this._selectedIndex;
+		this._selectedIndex = a_newIndex;
+
+		if (oldIndex != -1) {
+			var clip = this._entryClipManager.getClip(this._entryList[oldIndex].clipIndex);
+			clip.setEntry(this._entryList[oldIndex], this.listState);
+		}
+
+		if (this._selectedIndex != -1) {
+			var clip = this._entryClipManager.getClip(this._entryList[this._selectedIndex].clipIndex);
+			clip.setEntry(this._entryList[this._selectedIndex], this.listState);
+		}
+
+		this.dispatchEvent({type: "selectionChange", index: this._selectedIndex, keyboardOrMouse: a_keyboardOrMouse});
+	}
+	
+	private function getClipByIndex(a_index: Number)
+	{
+		return this._entryClipManager.getClip(a_index);
+	}
+	
+	private function setClipCount(a_count: Number)
+	{
+		this._entryClipManager.clipCount = a_count;
+	}
+	
+	private function getSelectedListEnumIndex()
+	{
+		return this.listEnumeration.lookupEnumIndex(this._selectedIndex);
+	}
+	
+	private function getListEnumIndex(a_index: Number)
+	{
+		return this.listEnumeration.lookupEnumIndex(a_index);
+	}
+	
+	private function getListEntryIndex(a_index: Number)
+	{
+		return this.listEnumeration.lookupEntryIndex(a_index);
+	}
+	
+	private function getListEnumSize()
+	{
+		return this.listEnumeration.size();
+	}
+	
+	private function getListEnumEntry(a_index: Number)
+	{
+		return this.listEnumeration.at(a_index);
+	}
+	
+	private function getListEnumFirstIndex()
+	{
+		return this.listEnumeration.lookupEntryIndex(0);
+	}
+	
+	private function getListEnumLastIndex()
+	{
+		return this.listEnumeration.lookupEntryIndex(this.getListEnumSize() - 1);
+	}
+	
+	private function getListEnumRelativeIndex(a_offset: Number)
+	{
+		return this.listEnumeration.lookupEntryIndex(this.getSelectedListEnumIndex() + a_offset);
+	}
+}

--- a/source/actionscript/Common/skyui/components/list/ButtonList.as
+++ b/source/actionscript/Common/skyui/components/list/ButtonList.as
@@ -13,7 +13,7 @@ class skyui.components.list.ButtonList extends skyui.components.list.BasicList
 	
 	private var _bAutoScale: Boolean = true;
 	
-	public function get autoScale(): Boolean
+	public function get autoScale()
 	{
 		return this._bAutoScale;
 	}
@@ -25,7 +25,7 @@ class skyui.components.list.ButtonList extends skyui.components.list.BasicList
 	
 	private var _minButtonWidth: Number = 10;
 	
-	public function get minButtonWidth(): Number
+	public function get minButtonWidth()
 	{
 		return this._minButtonWidth;
 	}
@@ -37,19 +37,19 @@ class skyui.components.list.ButtonList extends skyui.components.list.BasicList
 	
 	private var _buttonWidth: Number = 0;
 	
-	public function get buttonWidth(): Number
+	public function get buttonWidth()
 	{
 		return this._buttonWidth;
 	}
 
-	private var _align: Number = ALIGN_RIGHT;
+	private var _align: Number = skyui.components.list.ButtonList.prototype.ALIGN_RIGHT;
 	
 	public function set align(a_align: String)
 	{
-		if (align == "LEFT")
-			this._align = ALIGN_LEFT;
-		else if (align == "RIGHT")
-			this._align = ALIGN_RIGHT;
+		if (a_align == "LEFT")
+			this._align = this.ALIGN_LEFT;
+		else if (a_align == "RIGHT")
+			this._align = this.ALIGN_RIGHT;
 	}
 	
 	
@@ -64,7 +64,7 @@ class skyui.components.list.ButtonList extends skyui.components.list.BasicList
   /* PUBLIC FUNCTIONS */
 	
 	// @override BasicList
-	public function UpdateList(): Void
+	public function UpdateList()
 	{
 		if (this._bSuspended) {
 			this._bRequestUpdate = true;
@@ -85,9 +85,9 @@ class skyui.components.list.ButtonList extends skyui.components.list.BasicList
 			entryClip.itemIndex = i;
 			entryItem.clipIndex = i;
 			
-			entryClip.setEntry(entryItem, listState);
+			entryClip.setEntry(entryItem, this.listState);
 
-			entryClip._y = topBorder + h;
+			entryClip._y = this.topBorder + h;
 			entryClip._visible = true;
 			
 			entryClip.selectIndicator._width = 4;
@@ -99,73 +99,73 @@ class skyui.components.list.ButtonList extends skyui.components.list.BasicList
 			h = h + entryClip._height;
 		}
 		
-		for (var i = 0; i < getListEnumSize(); i++) {
-			entryClip._x = (_align == ALIGN_LEFT) ? leftBorder : -(buttonWidth + rightBorder);
+		for (var i = 0; i < this.getListEnumSize(); i++) {
+			entryClip._x = (this._align == this.ALIGN_LEFT) ? this.leftBorder : -(this.buttonWidth + this.rightBorder);
 			
-			var entryClip = getClipByIndex(i);
-			entryClip.selectIndicator._width = _buttonWidth;
-			entryClip.background._width = _buttonWidth;
+			var entryClip = this.getClipByIndex(i);
+			entryClip.selectIndicator._width = this._buttonWidth;
+			entryClip.background._width = this._buttonWidth;
 		}
 		
-		background._width = leftBorder + _buttonWidth + rightBorder;
-		background._height = topBorder + h + bottomBorder;
+		this.background._width = this.leftBorder + this._buttonWidth + this.rightBorder;
+		this.background._height = this.topBorder + h + this.bottomBorder;
 
-		background._x = (_align == ALIGN_LEFT) ? 0 : -background._width;
+		this.background._x = (this._align == this.ALIGN_LEFT) ? 0 : -this.background._width;
 	}
 	
 	// @GFx
-	public function handleInput(details, pathToFocus): Boolean
+	public function handleInput(details, pathToFocus)
 	{
 		var processed = false;
 
-		if (disableInput)
+		if (this.disableInput)
 			return false;
 
-		var entry = getClipByIndex(_selectedIndex);
+		var entry = this.getClipByIndex(this._selectedIndex);
 		var processed = entry != undefined && entry.handleInput != undefined && entry.handleInput(details, pathToFocus.slice(1));
 
-		if (!processed && GlobalFunc.IsKeyPressed(details)) {
-			if (details.navEquivalent == NavigationCode.UP || details.navEquivalent == NavigationCode.PAGE_UP) {
-				moveSelectionUp();
+		if (!processed && Shared.GlobalFunc.IsKeyPressed(details)) {
+			if (details.navEquivalent == gfx.ui.NavigationCode.UP || details.navEquivalent == gfx.ui.NavigationCode.PAGE_UP) {
+				this.moveSelectionUp();
 				processed = true;
-			} else if (details.navEquivalent == NavigationCode.DOWN || details.navEquivalent == NavigationCode.PAGE_DOWN) {
-				moveSelectionDown();
+			} else if (details.navEquivalent == gfx.ui.NavigationCode.DOWN || details.navEquivalent == gfx.ui.NavigationCode.PAGE_DOWN) {
+				this.moveSelectionDown();
 				processed = true;
-			} else if (!disableSelection && details.navEquivalent == NavigationCode.ENTER) {
-				onItemPress();
+			} else if (!this.disableSelection && details.navEquivalent == gfx.ui.NavigationCode.ENTER) {
+				this.onItemPress();
 				processed = true;
 			}
 		}
 		return processed;
 	}
 	
-	public function moveSelectionUp(): Void
+	public function moveSelectionUp()
 	{
-		if (disableSelection)
+		if (this.disableSelection)
 			return;
 			
-		if (_selectedIndex == -1) {
-			doSetSelectedIndex(getListEnumLastIndex(), SELECT_KEYBOARD);
-			isMouseDrivenNav = false;
-		} else if (getSelectedListEnumIndex() > 0) {
-			doSetSelectedIndex(getListEnumRelativeIndex(-1), SELECT_KEYBOARD);
-			isMouseDrivenNav = false;
-			dispatchEvent({type: "listMovedUp", index: _selectedIndex, scrollChanged: true});
+		if (this._selectedIndex == -1) {
+			this.doSetSelectedIndex(this.getListEnumLastIndex(), skyui.components.list.BasicList.SELECT_KEYBOARD);
+			this.isMouseDrivenNav = false;
+		} else if (this.getSelectedListEnumIndex() > 0) {
+			this.doSetSelectedIndex(this.getListEnumRelativeIndex(-1), skyui.components.list.BasicList.SELECT_KEYBOARD);
+			this.isMouseDrivenNav = false;
+			this.dispatchEvent({type: "listMovedUp", index: this._selectedIndex, scrollChanged: true});
 		}
 	}
 
-	public function moveSelectionDown(): Void
+	public function moveSelectionDown()
 	{
-		if (disableSelection)
+		if (this.disableSelection)
 			return;
 			
-		if (_selectedIndex == -1) {
-			doSetSelectedIndex(getListEnumFirstIndex(), SELECT_KEYBOARD);
-			isMouseDrivenNav = false;
-		} else if (getSelectedListEnumIndex() < getListEnumSize() - 1) {
-			doSetSelectedIndex(getListEnumRelativeIndex(+1), SELECT_KEYBOARD);
-			isMouseDrivenNav = false;
-			dispatchEvent({type: "listMovedDown", index: _selectedIndex, scrollChanged: true});
+		if (this._selectedIndex == -1) {
+			this.doSetSelectedIndex(this.getListEnumFirstIndex(), skyui.components.list.BasicList.SELECT_KEYBOARD);
+			this.isMouseDrivenNav = false;
+		} else if (this.getSelectedListEnumIndex() < this.getListEnumSize() - 1) {
+			this.doSetSelectedIndex(this.getListEnumRelativeIndex(1), skyui.components.list.BasicList.SELECT_KEYBOARD);
+			this.isMouseDrivenNav = false;
+			this.dispatchEvent({type: "listMovedDown", index: this._selectedIndex, scrollChanged: true});
 		}
 	}
 
@@ -175,18 +175,18 @@ class skyui.components.list.ButtonList extends skyui.components.list.BasicList
 	// @GFx
 	private function onMouseWheel(delta)
 	{
-		if (disableInput)
+		if (this.disableInput)
 			return;
 			
 		for (var target = Mouse.getTopMostEntity(); target && target != undefined; target = target._parent) {
 			if (target == this) {
 				if (delta < 0)
-					moveSelectionDown();
+					this.moveSelectionDown();
 				else if (delta > 0)
-					moveSelectionUp();
+					this.moveSelectionUp();
 			}
 		}
 		
-		isMouseDrivenNav = true;
+		this.isMouseDrivenNav = true;
 	}
 }

--- a/source/actionscript/Common/skyui/components/list/ButtonList.as
+++ b/source/actionscript/Common/skyui/components/list/ButtonList.as
@@ -1,0 +1,192 @@
+/*
+ *  A simple, general-purpose button list.
+ */
+class skyui.components.list.ButtonList extends skyui.components.list.BasicList
+{
+  /* CONSTANTS */
+  
+	public var ALIGN_LEFT = 0;
+	public var ALIGN_RIGHT = 1;
+	
+	
+  /* PROPERTIES */
+	
+	private var _bAutoScale: Boolean = true;
+	
+	public function get autoScale(): Boolean
+	{
+		return this._bAutoScale;
+	}
+	
+	public function set autoScale(a_bAutoScale: Boolean)
+	{
+		this._bAutoScale = a_bAutoScale;
+	}
+	
+	private var _minButtonWidth: Number = 10;
+	
+	public function get minButtonWidth(): Number
+	{
+		return this._minButtonWidth;
+	}
+	
+	public function set minButtonWidth(a_minButtonWidth: Number)
+	{
+		this._minButtonWidth = a_minButtonWidth;
+	}
+	
+	private var _buttonWidth: Number = 0;
+	
+	public function get buttonWidth(): Number
+	{
+		return this._buttonWidth;
+	}
+
+	private var _align: Number = ALIGN_RIGHT;
+	
+	public function set align(a_align: String)
+	{
+		if (align == "LEFT")
+			this._align = ALIGN_LEFT;
+		else if (align == "RIGHT")
+			this._align = ALIGN_RIGHT;
+	}
+	
+	
+  /* INITIALIZATION */
+	
+	public function ButtonList()
+	{
+		super();
+	}
+	
+	
+  /* PUBLIC FUNCTIONS */
+	
+	// @override BasicList
+	public function UpdateList(): Void
+	{
+		if (this._bSuspended) {
+			this._bRequestUpdate = true;
+			return;
+		}
+		
+		this.setClipCount(this.getListEnumSize());
+		
+		var h = 0;
+
+		this._buttonWidth = 4;
+
+		// Set entries
+		for (var i = 0; i < this.getListEnumSize(); i++) {
+			var entryClip = this.getClipByIndex(i);
+			var entryItem = this.getListEnumEntry(i);
+
+			entryClip.itemIndex = i;
+			entryItem.clipIndex = i;
+			
+			entryClip.setEntry(entryItem, listState);
+
+			entryClip._y = topBorder + h;
+			entryClip._visible = true;
+			
+			entryClip.selectIndicator._width = 4;
+			entryClip.background._width = 4;
+			
+			if (this._buttonWidth < entryClip._width)
+				this._buttonWidth = entryClip._width + 4;
+
+			h = h + entryClip._height;
+		}
+		
+		for (var i = 0; i < getListEnumSize(); i++) {
+			entryClip._x = (_align == ALIGN_LEFT) ? leftBorder : -(buttonWidth + rightBorder);
+			
+			var entryClip = getClipByIndex(i);
+			entryClip.selectIndicator._width = _buttonWidth;
+			entryClip.background._width = _buttonWidth;
+		}
+		
+		background._width = leftBorder + _buttonWidth + rightBorder;
+		background._height = topBorder + h + bottomBorder;
+
+		background._x = (_align == ALIGN_LEFT) ? 0 : -background._width;
+	}
+	
+	// @GFx
+	public function handleInput(details, pathToFocus): Boolean
+	{
+		var processed = false;
+
+		if (disableInput)
+			return false;
+
+		var entry = getClipByIndex(_selectedIndex);
+		var processed = entry != undefined && entry.handleInput != undefined && entry.handleInput(details, pathToFocus.slice(1));
+
+		if (!processed && GlobalFunc.IsKeyPressed(details)) {
+			if (details.navEquivalent == NavigationCode.UP || details.navEquivalent == NavigationCode.PAGE_UP) {
+				moveSelectionUp();
+				processed = true;
+			} else if (details.navEquivalent == NavigationCode.DOWN || details.navEquivalent == NavigationCode.PAGE_DOWN) {
+				moveSelectionDown();
+				processed = true;
+			} else if (!disableSelection && details.navEquivalent == NavigationCode.ENTER) {
+				onItemPress();
+				processed = true;
+			}
+		}
+		return processed;
+	}
+	
+	public function moveSelectionUp(): Void
+	{
+		if (disableSelection)
+			return;
+			
+		if (_selectedIndex == -1) {
+			doSetSelectedIndex(getListEnumLastIndex(), SELECT_KEYBOARD);
+			isMouseDrivenNav = false;
+		} else if (getSelectedListEnumIndex() > 0) {
+			doSetSelectedIndex(getListEnumRelativeIndex(-1), SELECT_KEYBOARD);
+			isMouseDrivenNav = false;
+			dispatchEvent({type: "listMovedUp", index: _selectedIndex, scrollChanged: true});
+		}
+	}
+
+	public function moveSelectionDown(): Void
+	{
+		if (disableSelection)
+			return;
+			
+		if (_selectedIndex == -1) {
+			doSetSelectedIndex(getListEnumFirstIndex(), SELECT_KEYBOARD);
+			isMouseDrivenNav = false;
+		} else if (getSelectedListEnumIndex() < getListEnumSize() - 1) {
+			doSetSelectedIndex(getListEnumRelativeIndex(+1), SELECT_KEYBOARD);
+			isMouseDrivenNav = false;
+			dispatchEvent({type: "listMovedDown", index: _selectedIndex, scrollChanged: true});
+		}
+	}
+
+
+  /* PRIVATE FUNCTIONS */
+
+	// @GFx
+	private function onMouseWheel(delta)
+	{
+		if (disableInput)
+			return;
+			
+		for (var target = Mouse.getTopMostEntity(); target && target != undefined; target = target._parent) {
+			if (target == this) {
+				if (delta < 0)
+					moveSelectionDown();
+				else if (delta > 0)
+					moveSelectionUp();
+			}
+		}
+		
+		isMouseDrivenNav = true;
+	}
+}

--- a/source/actionscript/Common/skyui/components/list/ButtonListEntry.as
+++ b/source/actionscript/Common/skyui/components/list/ButtonListEntry.as
@@ -1,0 +1,69 @@
+/*
+ *  A generic entry.
+ *  Sets this.selectIndicator visible for the selected entry, if defined.
+ *  Sets this.textField to obj.text.
+ *  Forwards to label obj.state, if defined.
+ */
+class skyui.components.list.ButtonListEntry extends skyui.components.list.BasicListEntry
+{
+  /* PRIVATE VARIABLES */
+
+
+  /* STAGE ELEMENTS */
+
+    public var activeIndicator: MovieClip;
+    public var selectIndicator: MovieClip;
+    public var textField: TextField;
+    public var icon: MovieClip;
+
+
+  /* PROPERTIES */
+
+    public static var defaultTextColor: Number = 0xffffff;
+    public static var activeTextColor: Number = 0xffffff;
+    public static var selectedTextColor: Number = 0xffffff;
+    public static var disabledTextColor: Number = 0x505050;
+
+
+  /* PUBLIC FUNCTIONS */
+
+    public function setEntry(a_entryObject: Object, a_state: ListState)
+    {
+        // Not using "enabled" directly, because we still want to be able to receive onMouseX events,
+        // even if we chose not to process them.
+        this.isEnabled = a_entryObject.enabled;
+        
+        var isSelected = a_entryObject == a_state.list.selectedEntry;
+        var isActive = (a_state.activeEntry != undefined && a_entryObject == a_state.activeEntry);
+
+        if (a_entryObject.state != undefined)
+            this.gotoAndPlay(a_entryObject.state);
+
+        if (this.textField != undefined) {
+            this.textField.autoSize = a_entryObject.align ? a_entryObject.align : "left";
+            
+            if (!a_entryObject.enabled)
+                this.textField.textColor = skyui.components.list.ButtonListEntry.disabledTextColor;
+            else if (isActive)
+                this.textField.textColor = skyui.components.list.ButtonListEntry.activeTextColor;
+            else if (isSelected)
+                this.textField.textColor = skyui.components.list.ButtonListEntry.selectedTextColor;
+            else
+                this.textField.textColor = skyui.components.list.ButtonListEntry.defaultTextColor;
+                
+            this.textField.SetText(a_entryObject.text ? a_entryObject.text : " ");
+        }
+        
+        if (this.selectIndicator != undefined)
+            this.selectIndicator._visible = isSelected;
+            
+        if (this.activeIndicator != undefined) {
+            this.activeIndicator._visible = isActive;
+            this.activeIndicator._x = this.textField._x - this.activeIndicator._width - 5;
+        }
+        
+        if (this.icon != undefined && a_entryObject.iconLabel != undefined) {
+            this.icon.gotoAndStop(a_entryObject.iconLabel);
+        }
+    }
+}

--- a/source/actionscript/Common/skyui/components/list/ColumnDescriptor.as
+++ b/source/actionscript/Common/skyui/components/list/ColumnDescriptor.as
@@ -1,0 +1,7 @@
+class skyui.components.list.ColumnDescriptor
+{
+    public var identifier: String;
+    public var longName: String;
+    public var hidden: Boolean;
+    public var type: Number;
+}

--- a/source/actionscript/Common/skyui/components/list/ColumnLayoutData.as
+++ b/source/actionscript/Common/skyui/components/list/ColumnLayoutData.as
@@ -1,0 +1,43 @@
+class skyui.components.list.ColumnLayoutData
+{
+	public var type: Number = -1;
+
+    // Entry  ---------------------------------
+
+    // Position relative to the entry.
+    public var x: Number = 0;
+    public var y: Number = 0;
+
+    public var width: Number = 0;
+    public var height: Number = 0;
+
+    // These are the names like textField0, equipIcon etc 
+    public var stageName: String;
+
+    // Only defined for text fields
+    public var entryValue: String;
+    public var textFormat: TextFormat;
+
+    public var colorAttribute: String; // support for dynamic entry coloring that overrides static textFormat
+
+    // Label ---------------------------------
+
+    public var labelX: Number = 0;
+
+    public var labelWidth: Number = 0;
+
+    public var labelArrowDown: Boolean = false;
+
+    public var labelValue: String;
+
+    public var labelTextFormat: TextFormat;
+
+    public function clear()
+    {
+        this.type = -1;
+        this.x = this.y = this.width = this.height = this.labelX = this.labelWidth = 0;
+        this.stageName = this.entryValue = this.labelValue = this.colorAttribute = null;
+        this.textFormat = this.labelTextFormat = null;
+        this.labelArrowDown = false;
+    }
+}

--- a/source/actionscript/Common/skyui/components/list/EntryClipManager.as
+++ b/source/actionscript/Common/skyui/components/list/EntryClipManager.as
@@ -1,0 +1,73 @@
+class skyui.components.list.EntryClipManager
+{ 
+  /* PRIVATE VARIABLES */
+
+    private var _clipPool: Array;
+    
+    private var _list: BasicList;
+    
+    private var _entryRenderer: String;
+    
+    private var _nextIndex: Number = 0;
+    
+    
+  /* PROPERTIES */
+    
+    private var _clipCount: Number = -1;
+    
+    public function get clipCount()
+    {
+        return this._clipCount;
+    }
+    
+    // Allocates the necessary number of clips in the pool, clears any existing clips for reuse.
+    public function set clipCount(a_clipCount: Number)
+    {
+        this._clipCount = a_clipCount;
+        
+        var d = a_clipCount - this._clipPool.length;
+        if (d > 0)
+            this.growPool(d);
+            
+        for (var i = 0; i < this._clipPool.length; i++) {
+            this._clipPool[i]._visible = false;
+            this._clipPool[i].itemIndex = undefined;
+        }
+    }
+    
+    
+  /* INITIALIZATION */
+
+    public function EntryClipManager(a_list: BasicList)
+    {
+        this._list = a_list;
+        this._clipPool = [];
+    }
+
+
+  /* PUBLIC FUNCTIONS */
+    
+    public function getClip(a_index: Number)
+    {
+        if (a_index >= this._clipCount)
+            return undefined;
+
+        return this._clipPool[a_index];
+    }
+    
+    
+  /* PRIVATE FUNCTIONS */
+    
+    private function growPool(a_size: Number)
+    {
+        var entryRenderer = this._list.entryRenderer;
+        
+        for (var i = 0; i < a_size; i++) {
+            var entryClip = this._list.attachMovie(entryRenderer, entryRenderer + this._nextIndex, this._list.getNextHighestDepth());
+            entryClip.initialize(this._nextIndex, this._list.listState);
+
+            this._clipPool[this._nextIndex] = entryClip;
+            this._nextIndex++;
+        }
+    }
+}

--- a/source/actionscript/Common/skyui/components/list/FilteredEnumeration.as
+++ b/source/actionscript/Common/skyui/components/list/FilteredEnumeration.as
@@ -1,0 +1,77 @@
+class skyui.components.list.FilteredEnumeration extends skyui.components.list.BasicEnumeration
+{
+  /* PRIVATE VARIABLES */
+
+    private var _filteredData: Array;
+    private var _filterChain: Array;
+
+
+  /* INITIALIZATION */
+
+    public function FilteredEnumeration(a_data: Array)
+    {
+        super(a_data);
+        
+        this._filterChain = [];
+        this._filteredData = [];
+    }
+
+
+  /* PUBLIC FUNCTIONS */
+
+    public function addFilter(a_filter: IFilter)
+    {
+        this._filterChain.push(a_filter);
+    }
+
+    // @override skyui.BasicEnumeration
+    public function size()
+    {
+        return this._filteredData.length;
+    }
+
+    // @override skyui.BasicEnumeration
+    public function at(a_index: Number)
+    {
+        return this._filteredData[a_index];
+    }
+
+    // @override skyui.IEntryEnumeration
+    public function lookupEntryIndex(a_enumIndex: Number)
+    {
+        return this._filteredData[a_enumIndex].itemIndex;
+    }
+
+    // @override skyui.IEntryEnumeration
+    public function lookupEnumIndex(a_entryIndex: Number)
+    {
+        return this._entryData[a_entryIndex].filteredIndex;
+    }
+
+    // The underlying entryData has been modified externally, so regenerate the enumeration.
+    public function invalidate()
+    {
+        this.applyFilters();
+    }
+
+
+  /* PRIVATE FUNCTIONS */
+
+    private function applyFilters()
+    {
+        this._filteredData.splice(0);
+        
+        // Copy the original list, add some helper attributes for easy mapping
+        for (var i = 0; i < this._entryData.length; i++) {
+            this._entryData[i].filteredIndex = undefined;
+            this._filteredData[i] = this._entryData[i];
+        }
+
+        // Apply filters
+        for (var i = 0; i < this._filterChain.length; i++)
+            this._filterChain[i].applyFilter(this._filteredData);
+
+        for (var i = 0; i < this._filteredData.length; i++)
+            this._filteredData[i].filteredIndex = i;
+    }
+}

--- a/source/actionscript/Common/skyui/components/list/IEntryEnumeration.as
+++ b/source/actionscript/Common/skyui/components/list/IEntryEnumeration.as
@@ -1,0 +1,20 @@
+/*
+ *  An enumeration of list entries.
+ */
+interface skyui.components.list.IEntryEnumeration
+{
+    // Returns the number of entries the enumeration contains.
+    // function size();
+
+    // Returns the ith element of the enumeration.
+    // function at(index: Number);
+
+    // Get the entry index associated with a given enum index for a given enum index.
+    // function lookupEntryIndex(enumIndex: Number);
+
+    // Get the entry index associated with a given enum index for a given entry index.
+    // function lookupEnumIndex(entryIndex: Number);
+
+    // The underlying data has been modified.
+    // function invalidate();
+}

--- a/source/actionscript/Common/skyui/components/list/IListProcessor.as
+++ b/source/actionscript/Common/skyui/components/list/IListProcessor.as
@@ -1,0 +1,4 @@
+interface skyui.components.list.IListProcessor
+{
+    // function processList(a_list: BasicList);
+}

--- a/source/actionscript/Common/skyui/components/list/ListLayout.as
+++ b/source/actionscript/Common/skyui/components/list/ListLayout.as
@@ -1,0 +1,619 @@
+/*
+ *  Encapsulates the list layout configuration.
+ */
+class skyui.components.list.ListLayout
+{
+  /* CONSTANTS */
+
+    private static var MAX_TEXTFIELD_INDEX = 10;
+
+    private static var LEFT = 0;
+    private static var RIGHT = 1;
+    private static var TOP = 2;
+    private static var BOTTOM = 3;
+
+    public static var COL_TYPE_ITEM_ICON = 0;
+    public static var COL_TYPE_EQUIP_ICON = 1;
+    public static var COL_TYPE_TEXT = 2;
+    public static var COL_TYPE_NAME = 3;
+
+
+  /* PRIVATE VARIABLES */
+
+    private var _activeViewIndex: Number = -1;
+        
+    private var _layoutData: Object;
+    private var _viewData: Object;
+    private var _columnData: Object;
+    private var _defaultsData: Object;
+
+    private var _lastViewIndex: Number = -1;
+
+    // viewIndex, columnIndex, stateIndex
+    private var _prefData: Object;
+
+    private var _stateData: Object;
+
+    private var _defaultEntryTextFormat: TextFormat;
+    private var _defaultLabelTextFormat: TextFormat;
+
+    // List of views in this layout (updated only when the config changes)
+    private var _viewList: Array;
+
+    // List of columns for the current view (updated when the view changes
+    private var _columnList: Array;
+
+    private var _lastFilterFlag: Number = -1;
+
+
+  /* PROPERTIES */
+
+    public function get currentView()
+    {
+        return this._viewList[this._activeViewIndex];
+    }
+
+    private var _activeColumnIndex: Number = -1;
+
+    public function get activeColumnIndex()
+    {
+        return this._activeColumnIndex;
+    }
+
+    public function get columnCount()
+    {
+        return this._columnLayoutData.length;
+    }
+
+    private var _activeColumnState: Number = 1;
+
+    public function get activeColumnState()
+    {
+        return this._activeColumnState;
+    }
+
+    private var _columnLayoutData: Array;
+
+    public function get columnLayoutData()
+    {
+        return this._columnLayoutData;
+    }
+
+    private var _hiddenStageNames: Array;
+
+    public function get hiddenStageNames()
+    {
+        return this._hiddenStageNames;
+    }
+
+    private var _entryWidth: Number;
+
+    public function get entryWidth()
+    {
+        return this._entryWidth;
+    }
+
+    public function set entryWidth(a_width: Number)
+    {
+        this._entryWidth = a_width;
+    }
+
+    private var _entryHeight: Number;
+
+    public function get entryHeight()
+    {
+        return this._entryHeight;
+    }
+
+    private var _layoutUpdateCount: Number = 1;
+
+    public function get layoutUpdateCount()
+    {
+        return this._layoutUpdateCount;
+    }
+
+    private var _columnDescriptors: Array;
+
+    public function get columnDescriptors()
+    {
+        return this._columnDescriptors;
+    }
+
+    private var _sortOptions: Array;
+
+    public function get sortOptions()
+    {
+        return this._sortOptions;
+    }
+
+    private var _sortAttributes: Array;
+
+    public function get sortAttributes()
+    {
+        return this._sortAttributes;
+    }
+
+
+
+  /* INITIALIZATION */
+
+    public function ListLayout(a_layoutData: Object, a_viewData: Object, a_columnData: Object, a_defaultsData: Object)
+    {
+        skyui.util.GlobalFunctions.addArrayFunctions();
+        
+        gfx.events.EventDispatcher.initialize(this);
+        
+        this._prefData = {column: null, stateIndex: 1};
+        this._viewList = [];
+        this._columnList = [];
+        this._columnLayoutData = [];
+        this._hiddenStageNames = [];
+        this._columnDescriptors = [];
+        
+        this._layoutData = a_layoutData;
+        this._viewData = a_viewData;
+        this._columnData = a_columnData;
+        this._defaultsData = a_defaultsData;
+
+        if (this._entryWidth == undefined)
+            this._entryWidth = this._defaultsData.entryWidth;
+        
+        this.updateViewList();
+        this.updateColumnList();
+        
+        // Initial textformats
+        this._defaultEntryTextFormat = new TextFormat(); 
+        this._defaultLabelTextFormat = new TextFormat();
+        
+        // Copy default textformat values from config
+        for (var prop in this._defaultsData.entry.textFormat)
+            if (this._defaultEntryTextFormat.hasOwnProperty(prop))
+                this._defaultEntryTextFormat[prop] = this._defaultsData.entry.textFormat[prop];
+        
+        for (var prop in this._defaultsData.label.textFormat)
+            if (this._defaultLabelTextFormat.hasOwnProperty(prop))
+                this._defaultLabelTextFormat[prop] = this._defaultsData.label.textFormat[prop];
+    }
+
+
+  /* PUBLIC FUNCTIONS */
+
+    // @mixin by gfx.events.EventDispatcher
+    public var dispatchEvent: Function;
+    public var dispatchQueue: Function;
+    public var hasEventListener: Function;
+    public var addEventListener: Function;
+    public var removeEventListener: Function;
+    public var removeAllEventListeners: Function;
+    public var cleanUpEvents: Function;
+
+    public function refresh()
+    {
+        this.updateViewList();
+        this._lastViewIndex = -1;
+        this.changeFilterFlag(this._lastFilterFlag);
+    }
+
+    public function changeFilterFlag(a_flag: Number)
+    {
+        this._lastFilterFlag = a_flag;
+        
+        // Find a matching view, or use last index
+        for (var i = 0; i < this._viewList.length; i++) {
+            
+            // Wrap in array for single category
+            var categories = ((this._viewList[i].category) instanceof Array) ? this._viewList[i].category : [this._viewList[i].category];
+            
+            if (categories.indexOf(a_flag) != undefined || i == this._viewList.length - 1) {
+                this._activeViewIndex = i;
+                break;
+            }
+        }
+        
+        if (this._activeViewIndex == -1 || this._lastViewIndex == this._activeViewIndex)
+            return;
+        
+        this._lastViewIndex = this._activeViewIndex;
+        
+        // Do this before restoring the pref state!
+        this.updateColumnList();
+        
+        // Restoring a previous state was not necessary or failed? Then use default
+        if (!this.restorePrefState()) {
+            this._activeColumnIndex = this.currentView.columns.indexOf(this.currentView.primaryColumn);
+            if (this._activeColumnIndex == undefined)
+                this._activeColumnIndex = 0;
+                
+            this._activeColumnState = 1;
+        }
+
+        this.updateLayout();
+    }
+
+    public function selectColumn(a_index: Number)
+    {
+        var listIndex = this.toColumnListIndex(a_index);
+        var col = this._columnList[listIndex];
+        
+        // Invalid column
+        if (col == null || col.passive)
+            return;
+            
+        if (this._activeColumnIndex != a_index) {
+            this._activeColumnIndex = a_index;
+            this._activeColumnState = 1;
+        } else {
+            if (this._activeColumnState < col.states)
+                this._activeColumnState++;
+            else
+                this._activeColumnState = 1;
+        }
+        
+        // Save as preferred state
+        this._prefData.column = col;
+        this._prefData.stateIndex = this._activeColumnState;
+            
+        this.updateLayout();
+    }
+
+    public function restoreColumnState(a_activeIndex: Number, a_activeState: Number)
+    {
+        var listIndex = this.toColumnListIndex(a_activeIndex);
+        var col = this._columnList[listIndex];
+        
+        // Invalid column
+        if (col == null || col.passive)
+            return;
+
+        if (a_activeState < 1 || a_activeState > col.states)
+            return;
+        
+        this._activeColumnIndex = a_activeIndex;
+        this._activeColumnState = a_activeState;
+        
+        // Save as preferred state
+        this._prefData.column = col;
+        this._prefData.stateIndex = this._activeColumnState;
+
+        this.updateLayout();
+    }
+
+
+    /* PRIVATE FUNCTIONS */
+
+    private function updateLayout()
+    {
+        this._layoutUpdateCount++;
+
+        var maxHeight = 0;
+        var textFieldIndex = 0;
+
+        this._hiddenStageNames.splice(0);
+        this._columnLayoutData.splice(0);
+        
+        // Set bit at position i if column is weighted
+        var weightedFlags = 0;
+        
+        var c = 0;
+        // Move some data from current state to root of the column so we can access single- and multi-state columns in the same manner.
+        // So this is a merge of defaults, column root and current state.
+        for (var i = 0; i < this._columnList.length; i++) {			
+            var col = this._columnList[i];
+            // Skip
+            if (col.hidden == true)
+                continue;
+                
+            var columnLayoutData = new skyui.components.list.ColumnLayoutData();
+            this._columnLayoutData[c] = columnLayoutData;
+                
+            // Non-active columns always use state 1
+            var stateData: Object;
+            if (c == this._activeColumnIndex) {
+                stateData = col["state" + this._activeColumnState];
+                this.updateSortParams(stateData);
+            } else {
+                stateData = col["state1"];
+            }
+                
+            columnLayoutData.type = col.type;
+            columnLayoutData.labelArrowDown = stateData.label.arrowDown ? true : false;
+            columnLayoutData.labelValue = stateData.label.text;
+            columnLayoutData.entryValue = stateData.entry.text;
+            columnLayoutData.colorAttribute = stateData.colorAttribute;
+            
+            c++;
+        }
+        
+        // Subtract arrow tip width
+        var weightedWidth = this._entryWidth - 12;
+        
+        var weightSum = 0;
+
+        var bEnableItemIcon = false;
+        var bEnableEquipIcon = false;
+
+        c = 0;
+        for (var i = 0; i < this._columnList.length; i++) {
+            var col = this._columnList[i];
+            // Skip
+            if (col.hidden == true)
+                continue;
+                
+            var columnLayoutData = this._columnLayoutData[c++];
+
+            // Calc total weighted width and set weighted flags
+            if (col.weight != undefined) {
+                weightSum += col.weight;
+                weightedFlags = (weightedFlags | 1) << 1;
+            } else {
+                weightedFlags = (weightedFlags | 0) << 1;
+            }
+            
+            if (col.indent != undefined)
+                weightedWidth -= col.indent;
+            
+            // Height including borders for maxHeight
+            var curHeight = 0;
+            
+            switch (col.type) {
+                // ITEM ICON + EQUIP ICON
+                case skyui.components.list.ListLayout.COL_TYPE_ITEM_ICON:
+                case skyui.components.list.ListLayout.COL_TYPE_EQUIP_ICON:
+                                
+                    if (col.type == skyui.components.list.ListLayout.COL_TYPE_ITEM_ICON) {
+                        columnLayoutData.stageName = "itemIcon";
+                        bEnableItemIcon = true;
+                    } else {
+                        columnLayoutData.stageName = "equipIcon";
+                        bEnableEquipIcon = true;
+                    }
+                    
+                    columnLayoutData.width = this._columnLayoutData[i].height = col.icon.size;
+                    weightedWidth -= col.icon.size;
+                        
+                    curHeight += col.icon.size;
+                    
+                    break;
+
+                // REST
+                default:
+                    columnLayoutData.stageName = "textField" + textFieldIndex++;
+                    
+                    if (col.width != undefined) {
+                        // Width >= 1 for absolute width, < 1 for percentage width
+                        columnLayoutData.width = col.width < 1 ? (col.width * this._entryWidth) : col.width;
+                        weightedWidth -= columnLayoutData.width;
+                    } else {
+                        columnLayoutData.width = 0;
+                    }
+                    
+                    if (col.height != undefined)
+                        // Height >= 1 for absolute height, < 1 for percentage height
+                        columnLayoutData.height = col.height < 1 ? (col.height * this._entryWidth) : col.height;
+                    else
+                        columnLayoutData.height = 0;
+                    
+                    if (col.entry.textFormat != undefined) {
+                        var customTextFormat = new TextFormat();
+
+                        // First clone default format
+                        for (var prop in this._defaultEntryTextFormat)
+                            customTextFormat[prop] = this._defaultEntryTextFormat[prop];
+                        
+                        // Then override if necessary
+                        for (var prop in col.entry.textFormat)
+                            if (customTextFormat.hasOwnProperty(prop))
+                                customTextFormat[prop] = col.entry.textFormat[prop];
+                        
+                        columnLayoutData.textFormat = customTextFormat;
+                    } else {
+                        columnLayoutData.textFormat = this._defaultEntryTextFormat;
+                    }
+                    
+                    if (col.label.textFormat != undefined) {
+                        var customTextFormat = new TextFormat();
+
+                        // First clone default format
+                        for (var prop in this._defaultLabelTextFormat)
+                            customTextFormat[prop] = this._defaultLabelTextFormat[prop];
+                    
+                        // Then override if necessary
+                        for (var prop in col.label.textFormat)
+                            if (customTextFormat.hasOwnProperty(prop))
+                                customTextFormat[prop] = col.label.textFormat[prop];
+                                
+                        columnLayoutData.labelTextFormat = customTextFormat;
+                    } else {
+                        columnLayoutData.labelTextFormat = this._defaultLabelTextFormat;
+                    }
+            }
+            
+            if (col.border != undefined) {
+                weightedWidth -= col.border[skyui.components.list.ListLayout.LEFT] + col.border[skyui.components.list.ListLayout.RIGHT];
+                curHeight += col.border[skyui.components.list.ListLayout.TOP] + col.border[skyui.components.list.ListLayout.BOTTOM];
+                columnLayoutData.y = col.border[skyui.components.list.ListLayout.TOP];
+            } else {
+                columnLayoutData.y = 0;
+            }
+            
+            if (curHeight > maxHeight)
+                maxHeight = curHeight;
+        }
+        
+        // Calculate the widths
+        if (weightSum > 0 && weightedWidth > 0 && weightedFlags != 0) {
+            c = this._columnLayoutData.length - 1;
+            for (var i = this._columnList.length - 1; i >= 0; i--) {
+                var col = this._columnList[i];
+                // Skip
+                if (col.hidden == true)
+                    continue;
+                    
+                var columnLayoutData = this._columnLayoutData[c--];
+                
+                if ((weightedFlags >>>= 1) & 1) {
+                    if (col.border != undefined)
+                        columnLayoutData.width += ((col.weight / weightSum) * weightedWidth) - col.border[skyui.components.list.ListLayout.LEFT] - col.border[skyui.components.list.ListLayout.RIGHT];
+                    else
+                        columnLayoutData.width += (col.weight / weightSum) * weightedWidth;
+                }
+            }
+        }
+        
+        // Set x positions based on calculated widths, and set label data
+        var xPos = 0;
+        c = 0;
+        for (var i = 0; i < this._columnList.length; i++) {
+            var col = _columnList[i];
+            // Skip
+            if (col.hidden == true)
+                continue;
+                
+            var columnLayoutData = this._columnLayoutData[c++];
+            
+            if (col.indent != undefined)
+                xPos += col.indent;
+
+            columnLayoutData.labelX = xPos;
+
+            if (col.border != undefined) {
+                columnLayoutData.labelWidth = columnLayoutData.width + col.border[skyui.components.list.ListLayout.LEFT] + col.border[skyui.components.list.ListLayout.RIGHT];
+                columnLayoutData.x = xPos;
+                xPos += col.border[skyui.components.list.ListLayout.LEFT];
+                columnLayoutData.x = xPos;
+                xPos += col.border[skyui.components.list.ListLayout.RIGHT] + columnLayoutData.width;
+            } else {
+                columnLayoutData.labelWidth = columnLayoutData.width;
+                columnLayoutData.x = xPos;
+                xPos += columnLayoutData.width;
+            }
+        }
+        
+        while (textFieldIndex < skyui.components.list.ListLayout.MAX_TEXTFIELD_INDEX)
+            this._hiddenStageNames.push("textField" + textFieldIndex++);
+        
+        if (!bEnableItemIcon)
+            this._hiddenStageNames.push("itemIcon");
+        
+        if (!bEnableEquipIcon)
+            this._hiddenStageNames.push("equipIcon");
+        
+        this._entryHeight = maxHeight;
+        
+        // sortChange might not always trigger an update, so we have to make sure the list is updated,
+        // even if that means we update it twice.
+        this.dispatchEvent({type: "layoutChange"});
+    }
+
+    private function updateSortParams(stateData: Object)
+    {
+        var sortAttributes = stateData.sortAttributes;
+        var sortOptions = stateData.sortOptions;
+        
+        if (!sortOptions) {
+            this._sortOptions = null;
+            this._sortAttributes = null;
+            return;
+        }
+        
+        // No attribute(s) set? Try to use entry value
+        if (!sortAttributes)
+            if (stateData.entry.text.charAt(0) == "@")
+                sortAttributes = [ stateData.entry.text.slice(1) ];
+        
+        if (!sortAttributes) {
+            this._sortOptions = null;
+            this._sortAttributes = null;
+            return;
+        }
+        
+        // Wrap single attribute in array
+        if (!(sortAttributes instanceof Array))
+            sortAttributes = [sortAttributes];
+            
+        if (!(sortOptions instanceof Array))
+            sortOptions = [sortOptions];
+            
+        this._sortOptions = sortOptions;
+        this._sortAttributes = sortAttributes;
+    }
+
+    private function restorePrefState()
+    {
+        // No preference to restore yet
+        if (!this._prefData.column)
+            return false;
+
+        var listIndex = this._columnList.indexOf(this._prefData.column);
+        var layoutDataIndex = this.toColumnLayoutDataIndex(listIndex);
+
+        if (listIndex > -1 && layoutDataIndex > -1) {
+            this._activeColumnIndex = layoutDataIndex;
+            this._activeColumnState = this._prefData.stateIndex;
+            return true;
+        }
+        
+        // Found no match, reset prefData and return false
+        this._prefData.column = null;
+        this._prefData.stateIndex = 1;
+        return false;
+    }
+
+    // columnLayoutData index (no hidden columns) -> columnList index (all columns for this view)
+    private function toColumnListIndex(a_index)
+    {
+        var c = 0;
+        for (var i = 0; i < this._columnList.length; i++) {
+            if (this._columnList[i].hidden == true)
+                continue;
+            if (c == a_index)
+                return i;
+            c++;
+        }
+        
+        return -1;
+    }
+
+    // columnList index (all columns for this view) -> columnLayoutData index (no hidden columns)
+    private function toColumnLayoutDataIndex(a_index)
+    {
+        var c = 0;
+        for (var i = 0; i < this._columnList.length; i++) {
+            if (this._columnList[i].hidden == true)
+                continue;
+            if (i == a_index)
+                return c;
+            c++;
+        }
+        
+        return -1;
+    }
+
+    private function updateViewList()
+    {
+        this._viewList.splice(0);
+        var viewNames = this._layoutData.views;
+        for (var i = 0; i < viewNames.length; i++)
+            this._viewList.push(this._viewData[viewNames[i]]);
+    }
+
+    private function updateColumnList()
+    {
+        this._columnList.splice(0);
+        this._columnDescriptors.splice(0);
+        
+        var columnNames = this.currentView.columns;
+        
+        for (var i = 0; i < columnNames.length; i++) {
+            var col = this._columnData[columnNames[i]];
+            var cd : ColumnDescriptor = new skyui.components.list.ColumnDescriptor();
+            cd.hidden = col.hidden;
+            cd.identifier = columnNames[i];
+            cd.longName = col.name;
+            cd.type = col.type;
+            
+            this._columnList.push(col);
+            this._columnDescriptors.push(cd);
+        }
+    }
+}

--- a/source/actionscript/Common/skyui/components/list/ListState.as
+++ b/source/actionscript/Common/skyui/components/list/ListState.as
@@ -1,0 +1,17 @@
+/*
+ * Used to dynamically add additional properties to a list that are passed
+ * along to IListEntry.setData(), i.e. activeEntry.
+ */
+
+class skyui.components.list.ListState
+{
+    public function ListState(a_list: BasicList)
+    {
+        this.list = a_list;
+    }
+
+    // Parent list
+    public var list: BasicList;
+
+    // ...
+}

--- a/source/actionscript/Common/skyui/components/list/SortedListHeader.as
+++ b/source/actionscript/Common/skyui/components/list/SortedListHeader.as
@@ -1,0 +1,147 @@
+class skyui.components.list.SortedListHeader extends MovieClip
+{
+  /* PRIVATE VARIABLES */
+
+    private var _columns: Array;
+
+
+  /* STAGE ELEMENTS */
+
+    public var sortIcon: MovieClip;
+    public var iconColumnIndicator: MovieClip;
+
+
+  /* PROPERTIES */ 
+
+    private var _layout: ListLayout;
+
+    public function get layout()
+    {
+        return this._layout;
+    }
+
+    public function set layout(a_layout: ListLayout)
+    {
+        if (this._layout)
+            this._layout.removeEventListener("layoutChange", this, "onLayoutChange");
+        this._layout = a_layout;
+        this._layout.addEventListener("layoutChange", this, "onLayoutChange");
+    }
+
+
+  /* INITIALIZATION */
+
+    public function SortedListHeader()
+    {
+        super();
+        
+        this._columns = new Array();
+    }
+
+
+  /* PUBLIC FUNCTIONS */
+
+    public function columnPress(a_columnIndex: Number)
+    {
+        this._layout.selectColumn(a_columnIndex);
+    }
+
+
+  /* PRIVATE FUNCTIONS */
+
+    // Hides all columns (but doesn't delete them since they can be re-used later).
+    private function clearColumns()
+    {
+        for (var i = 0; i < this._columns.length; i++)
+            this._columns[i]._visible = false;
+    }
+
+    private function addColumn(a_index: Number)
+    {
+        if (a_index < 0)
+            return undefined;
+        
+        var columnButton = this["Column" + a_index];
+
+        if (columnButton != undefined) {
+            this._columns[a_index] = columnButton;
+            this._columns[a_index]._visible = true;
+            return columnButton;
+        }
+        
+        // Create on-demand
+        columnButton = this.attachMovie("HeaderColumn", "Column" + a_index, this.getNextHighestDepth());
+
+
+
+        columnButton.columnIndex = a_index;
+
+        columnButton.onPress = function(a_mouseIndex, a_keyboardOrMouse, a_buttonIndex)
+        {
+            if (!this.columnIndex != undefined)
+                this._parent.columnPress(this.columnIndex);
+        };
+
+        columnButton.onPressAux = function(a_mouseIndex, a_keyboardOrMouse, a_buttonIndex)
+        {
+            if (!this.columnIndex != undefined)
+                this._parent.columnPress(this.columnIndex);
+        };
+
+        this._columns[a_index] = columnButton;
+        return columnButton;
+    }
+
+    private function onLayoutChange(event)
+    {
+        this.clearColumns();
+        
+        var activeIndex = this._layout.activeColumnIndex;
+            
+        for (var i = 0; i < this._layout.columnCount; i++) {
+            var columnLayoutData = this._layout.columnLayoutData[i];
+            var btn = this.addColumn(i);
+
+            btn.label._x = 0;
+
+            btn._x = columnLayoutData.labelX;
+            
+            btn.label._width = columnLayoutData.labelWidth;
+            btn.label.setTextFormat(columnLayoutData.labelTextFormat);
+            
+            btn.label.SetText(columnLayoutData.labelValue);
+            
+            if (activeIndex == i)
+                this.sortIcon.gotoAndStop(columnLayoutData.labelArrowDown ? "desc" : "asc");
+        }
+        
+        this.positionButtons();
+    }
+
+    // Places the buttonAreas around textfields and the sort indicator.
+    private function positionButtons()
+    {
+        var activeIndex = this._layout.activeColumnIndex;
+        for (var i = 0; i < this._columns.length; i++) {
+            var e = this._columns[i];
+            e.label._y = -e.label._height;
+            
+            e.buttonArea._x = e.label.getLineMetrics(0).x - 4;
+            e.buttonArea._width = e.label.getLineMetrics(0).width + 8;
+            e.buttonArea._y = e.label._y - 2;
+            e.buttonArea._height = e.label._height + 2;
+            
+            if (this._layout.columnLayoutData[i].type == skyui.components.list.ListLayout.COL_TYPE_ITEM_ICON) {
+                this.iconColumnIndicator._x = e._x + e.buttonArea._x + e.buttonArea._width;
+                this.iconColumnIndicator._y = -e._height + ((e._height - this.iconColumnIndicator._height) / 2);
+            }
+            
+            if (activeIndex == i) {
+                this.sortIcon._x = e._x + e.buttonArea._x + e.buttonArea._width;
+                this.sortIcon._y = -e._height + ((e._height - this.sortIcon._height) / 2) - 1;
+                
+                this.iconColumnIndicator._visible = this._layout.columnLayoutData[i].type != skyui.components.list.ListLayout.COL_TYPE_ITEM_ICON;
+            }
+        }
+    }
+}

--- a/source/actionscript/Common/skyui/components/list/TabularList.as
+++ b/source/actionscript/Common/skyui/components/list/TabularList.as
@@ -1,0 +1,97 @@
+class skyui.components.list.TabularList extends skyui.components.list.ScrollingList
+{
+  /* PRIVATE VARIABLES */
+
+    private var _previousColumnKey: Number = -1;
+    private var _nextColumnKey: Number = -1;
+    private var _sortOrderKey: Number = -1;
+
+  /* STAGE ELEMENTS */
+
+    public var header: SortedListHeader;
+
+
+  /* PROPERTIES */ 
+
+    private var _layout: ListLayout;
+
+    public function get layout()
+    {
+        return this._layout;
+    }
+
+    public function set layout(a_layout: ListLayout)
+    {
+        if (this._layout)
+            this._layout.removeEventListener("layoutChange", this, "onLayoutChange");
+        this._layout = a_layout;
+        this._layout.addEventListener("layoutChange", this, "onLayoutChange");
+        
+        if (this.header)
+            this.header.layout = a_layout;
+    }
+
+
+  /* INITIALIZATION */
+
+    public function TabularList()
+    {
+        super();
+        
+        skyui.util.ConfigManager.registerLoadCallback(this, "onConfigLoad");
+    }
+
+
+  /* PUBLIC FUNCTIONS */
+
+    // @GFx
+    public function handleInput(details: InputDetails, pathToFocus: Array)
+    {		
+        if (super.handleInput(details, pathToFocus))
+            return true;
+
+        if (!this.disableInput && this._platform != 0) {
+            if (Shared.GlobalFunc.IsKeyPressed(details)) {
+                if (details.skseKeycode == this._previousColumnKey) {
+                    this._layout.selectColumn(this._layout.activeColumnIndex - 1);
+                    return true;
+                } else if (details.skseKeycode == this._nextColumnKey) {
+                    this._layout.selectColumn(this._layout.activeColumnIndex + 1);
+                    return true;
+                } else if (details.skseKeycode == this._sortOrderKey) {
+                    this._layout.selectColumn(this._layout.activeColumnIndex);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+  /* PRIVATE FUNCTIONS */
+
+    private function onConfigLoad(event: Object)
+    {
+        var config = event.config;
+        
+        if (this._platform != 0) {
+            this._previousColumnKey = config["Input"].controls.gamepad.prevColumn;
+            this._nextColumnKey = config["Input"].controls.gamepad.nextColumn;
+            this._sortOrderKey = config["Input"].controls.gamepad.sortOrder;
+        }
+    }
+
+    private function onLayoutChange(event: Object)
+    {
+        this.entryHeight = this._layout.entryHeight;
+
+        this.header._x = this.leftBorder;
+        
+        this._maxListIndex = Math.floor((this._listHeight / this.entryHeight) + 0.05);
+        
+        if (this._layout.sortAttributes && this._layout.sortOptions)
+            this.dispatchEvent({type:"sortChange", attributes: this._layout.sortAttributes, options:  this._layout.sortOptions});
+        
+        this.requestUpdate();
+    }
+}


### PR DESCRIPTION
This pull request adds the existing scripts `skyui/components/list` in the SWF files to the project and adapts them for import via JPEXS for contextual understanding and further editing. (The scripts are taken from the original SkyUI repository and adapted for JPEXS.)
To test compatibility with JPEXS, I took the original decompiled script, then imported the original edited script into the SWF file, and then took the new decompiled script again. Using the "Compare active file with..." function in VS Code, I compared the two decompiled scripts. They should be identical (with a few exceptions concerning the numbers in the _locN_ variables).

The scripts are not yet imported (not included in swfsources.cmake), as there are no changes other than the original scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive list UI framework with support for customizable list layouts, column-based display, filtering, and sorting capabilities. Enhanced keyboard and mouse navigation for list interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->