### PR TITLE
fix: general minor ActionScript code fixes

### DIFF
--- a/source/actionscript/Common/skyui/components/list/BSList.as
+++ b/source/actionscript/Common/skyui/components/list/BSList.as
@@ -37,10 +37,11 @@ class skyui.components.list.BSList extends MovieClip
 	}
 	
 	
-  /* CONSTRUCTORS */
+  /* INITIALIZATION */
   
 	public function BSList()
 	{
+		super();
 		this._entryList = new Array();
 		this._selectedIndex = -1;
 	}

--- a/source/actionscript/Common/skyui/components/list/BasicListEntry.as
+++ b/source/actionscript/Common/skyui/components/list/BasicListEntry.as
@@ -11,6 +11,14 @@ class skyui.components.list.BasicListEntry extends MovieClip
     public var isEnabled: Boolean = true;
 
 
+  /* INITIALIZATION */
+
+    function BasicListEntry()
+    {
+        super();
+    }
+
+
   /* PUBLIC FUNCTIONS */
 
     // @override MovieClip

--- a/source/actionscript/Common/skyui/components/list/BasicListEntry.as
+++ b/source/actionscript/Common/skyui/components/list/BasicListEntry.as
@@ -57,12 +57,17 @@ class skyui.components.list.BasicListEntry extends MovieClip
             list.onItemPressAux(this.itemIndex, a_keyboardOrMouse, a_buttonIndex);
     }
 
-    // This is called after the object is added to the stage since the constructor does not accept any parameters.
-    public function initialize(a_index: Number, a_list: BasicList)
-    {
-        // Do nothing.
-    }
 
-    // @abstract
-    public function setEntry(a_entryObject: Object, a_state: ListState) {}
+    // # NOTE: Empty functions are intentionally commented out—they cause ColumnSelectDialog to break.
+    // JPEXS currently has issues with using empty functions.
+    // # See https://www.free-decompiler.com/flash/issues/2705
+
+    // // This is called after the object is added to the stage since the constructor does not accept any parameters.
+    // public function initialize(a_index: Number, a_list: BasicList)
+    // {
+    //     // Do nothing.
+    // }
+
+    // // @abstract
+    // public function setEntry(a_entryObject: Object, a_state: ListState) {}
 }

--- a/source/actionscript/Common/skyui/components/list/ButtonListEntry.as
+++ b/source/actionscript/Common/skyui/components/list/ButtonListEntry.as
@@ -25,6 +25,14 @@ class skyui.components.list.ButtonListEntry extends skyui.components.list.BasicL
     public static var disabledTextColor: Number = 0x505050;
 
 
+  /* INITIALIZATION */
+
+    function ButtonListEntry()
+    {
+        super();
+    }
+
+
   /* PUBLIC FUNCTIONS */
 
     public function setEntry(a_entryObject: Object, a_state: ListState)

--- a/source/actionscript/Common/skyui/components/list/ListLayout.as
+++ b/source/actionscript/Common/skyui/components/list/ListLayout.as
@@ -464,7 +464,7 @@ class skyui.components.list.ListLayout
         var xPos = 0;
         c = 0;
         for (var i = 0; i < this._columnList.length; i++) {
-            var col = _columnList[i];
+            var col = this._columnList[i];
             // Skip
             if (col.hidden == true)
                 continue;

--- a/source/actionscript/Common/skyui/components/list/TabularListEntry.as
+++ b/source/actionscript/Common/skyui/components/list/TabularListEntry.as
@@ -11,6 +11,14 @@ class skyui.components.list.TabularListEntry extends skyui.components.list.Basic
     public var selectIndicator: MovieClip;
 
 
+  /* INITIALIZATION */
+
+    function TabularListEntry()
+    {
+        super();
+    }
+
+
   /* PUBLIC FUNCTIONS */
 
     // @override BasicListEntry

--- a/source/actionscript/CraftingMenu/CraftingListEntry.as
+++ b/source/actionscript/CraftingMenu/CraftingListEntry.as
@@ -2,171 +2,179 @@ class CraftingListEntry extends skyui.components.list.TabularListEntry
 {
   /* CONSTANTS */
 
-   private static var STATES = ["None", "Equipped", "LeftEquip", "RightEquip", "LeftAndRightEquip"];
+    private static var STATES = ["None", "Equipped", "LeftEquip", "RightEquip", "LeftAndRightEquip"];
 
   /* PRIVATE VARIABLES */
-   
-   private var _iconLabel: String;
-   private var _iconColor: Number;
-   
+
+    private var _iconLabel: String;
+    private var _iconColor: Number;
+
   /* STAGE ELMENTS */
 
-   public var itemIcon: MovieClip;
-   public var equipIcon: MovieClip;
-   
-   public var poisonIcon: MovieClip;
-   public var stolenIcon: MovieClip;
-   
-   
+    public var itemIcon: MovieClip;
+    public var equipIcon: MovieClip;
+
+    public var poisonIcon: MovieClip;
+    public var stolenIcon: MovieClip;
+
+
+  /* CONSTRUCTOR */
+
+    function CraftingListEntry()
+    {
+        super();
+    }
+
+    
   /* INITIALIZATION */
-   
-   // @override TabularListEntry
-   public function initialize(a_index: Number, a_state: ListState)
-   {
-      super.initialize();
-      
-      var iconLoader = new MovieClipLoader();
-      iconLoader.addListener(this);
-      iconLoader.loadClip(a_state.iconSource, this.itemIcon);
-      
-      this.itemIcon._visible = false;
-      this.equipIcon._visible = false;
-      
-      for (var i = 0; this["textField" + i] != undefined; i++)
-         this["textField" + i]._visible = false;
-   }
-   
-   
+
+    // @override TabularListEntry
+    public function initialize(a_index: Number, a_state: ListState)
+    {
+        super.initialize();
+        
+        var iconLoader = new MovieClipLoader();
+        iconLoader.addListener(this);
+        iconLoader.loadClip(a_state.iconSource, this.itemIcon);
+        
+        this.itemIcon._visible = false;
+        this.equipIcon._visible = false;
+        
+        for (var i = 0; this["textField" + i] != undefined; i++)
+            this["textField" + i]._visible = false;
+    }
+
+
   /* PUBLIC FUNCTIONS */
-   
-   // @override TabularListEntry
-   public function setSpecificEntryLayout(a_entryObject: Object, a_state: ListState)
-   {
-      var iconY = skyui.components.list.TabularList(a_state.list).layout.entryHeight * 0.25;
-      var iconSize = skyui.components.list.TabularList(a_state.list).layout.entryHeight * 0.5;
-         
-      this.poisonIcon._height = this.poisonIcon._width = iconSize;
-      this.stolenIcon._height = this.stolenIcon._width = iconSize;
-         
-      this.poisonIcon._y = iconY;
-      this.stolenIcon._y = iconY;
-   }
 
-   // @override TabularListEntry
-   public function formatEquipIcon(a_entryField: Object, a_entryObject: Object, a_state: ListState)
-   {
-      if (a_entryObject != undefined && a_entryObject.equipState != undefined) {
-         a_entryField.gotoAndStop(CraftingListEntry.STATES[a_entryObject.equipState]);
-      } else {
-         a_entryField.gotoAndStop("None");
-      }
-   }
+    // @override TabularListEntry
+    public function setSpecificEntryLayout(a_entryObject: Object, a_state: ListState)
+    {
+        var iconY = skyui.components.list.TabularList(a_state.list).layout.entryHeight * 0.25;
+        var iconSize = skyui.components.list.TabularList(a_state.list).layout.entryHeight * 0.5;
+            
+        this.poisonIcon._height = this.poisonIcon._width = iconSize;
+        this.stolenIcon._height = this.stolenIcon._width = iconSize;
+            
+        this.poisonIcon._y = iconY;
+        this.stolenIcon._y = iconY;
+    }
 
-   // @override TabularListEntry
-   public function formatItemIcon(a_entryField: Object, a_entryObject: Object, a_state: ListState)
-   {
-      this._iconLabel = a_entryObject["iconLabel"] != undefined ? a_entryObject["iconLabel"] : "default_misc";
-      this._iconColor = a_entryObject["iconColor"];
+    // @override TabularListEntry
+    public function formatEquipIcon(a_entryField: Object, a_entryObject: Object, a_state: ListState)
+    {
+        if (a_entryObject != undefined && a_entryObject.equipState != undefined) {
+            a_entryField.gotoAndStop(CraftingListEntry.STATES[a_entryObject.equipState]);
+        } else {
+            a_entryField.gotoAndStop("None");
+        }
+    }
 
-      // Could return here if _iconLoaded is false
-      a_entryField.gotoAndStop(this._iconLabel);
-      this.changeIconColor(MovieClip(a_entryField), this._iconColor);
-   }
+    // @override TabularListEntry
+    public function formatItemIcon(a_entryField: Object, a_entryObject: Object, a_state: ListState)
+    {
+        this._iconLabel = a_entryObject["iconLabel"] != undefined ? a_entryObject["iconLabel"] : "default_misc";
+        this._iconColor = a_entryObject["iconColor"];
 
-   // @override TabularListEntry
-   public function formatName(a_entryField: Object, a_entryObject: Object, a_state: ListState)
-   {
-      if (a_entryObject.text == undefined) {
-         a_entryField.SetText(" ");
-         return;
-      }
+        // Could return here if _iconLoaded is false
+        a_entryField.gotoAndStop(this._iconLabel);
+        this.changeIconColor(MovieClip(a_entryField), this._iconColor);
+    }
 
-      // Text
-      var text = a_entryObject.text;
+    // @override TabularListEntry
+    public function formatName(a_entryField: Object, a_entryObject: Object, a_state: ListState)
+    {
+        if (a_entryObject.text == undefined) {
+            a_entryField.SetText(" ");
+            return;
+        }
 
-      if (a_entryObject.soulLVL != undefined) {
-         text = text + " (" + a_entryObject.soulLVL + ")";
-      }
+        // Text
+        var text = a_entryObject.text;
 
-      if (a_entryObject.count > 1) {
-         text = text + " (" + a_entryObject.count.toString() + ")";
-      }
+        if (a_entryObject.soulLVL != undefined) {
+            text = text + " (" + a_entryObject.soulLVL + ")";
+        }
 
-      if (text.length > a_state.maxTextLength) {
-         text = text.substr(0, a_state.maxTextLength - 3) + "...";
-      }
+        if (a_entryObject.count > 1) {
+            text = text + " (" + a_entryObject.count.toString() + ")";
+        }
 
-      a_entryField.autoSize = "left";
-      a_entryField.SetText(text);
-      
-      this.formatColor(a_entryField, a_entryObject, a_state);
+        if (text.length > a_state.maxTextLength) {
+            text = text.substr(0, a_state.maxTextLength - 3) + "...";
+        }
 
-      var iconPos = a_entryField._x + a_entryField._width + 5;
+        a_entryField.autoSize = "left";
+        a_entryField.SetText(text);
+        
+        this.formatColor(a_entryField, a_entryObject, a_state);
 
-      // All icons have the same size
-      var iconSpace = this.stolenIcon._width * 1.25;
+        var iconPos = a_entryField._x + a_entryField._width + 5;
 
-      // Poisoned Icon
-      if (a_entryObject.isPoisoned == true) {
-         this.poisonIcon._x = iconPos;
-         iconPos = iconPos + iconSpace;
-         this.poisonIcon.gotoAndStop("show");
-      } else {
-         this.poisonIcon.gotoAndStop("hide");
-      }
+        // All icons have the same size
+        var iconSpace = this.stolenIcon._width * 1.25;
 
-      // Stolen Icon
-      if ((a_entryObject.isStolen == true || a_entryObject.isStealing == true) && a_state.showStolenIcon == true) {
-         this.stolenIcon._x = iconPos;
-         iconPos = iconPos + iconSpace;
-         this.stolenIcon.gotoAndStop("show");
-      } else {
-         this.stolenIcon.gotoAndStop("hide");
-      }
-   }
-   
-   // @override TabularEntry
-   public function formatText(a_entryField: Object, a_entryObject: Object, a_state: ListState)
-   {
-      this.formatColor(a_entryField, a_entryObject, a_state);
-   }
-   
-   
+        // Poisoned Icon
+        if (a_entryObject.isPoisoned == true) {
+            this.poisonIcon._x = iconPos;
+            iconPos = iconPos + iconSpace;
+            this.poisonIcon.gotoAndStop("show");
+        } else {
+            this.poisonIcon.gotoAndStop("hide");
+        }
+
+        // Stolen Icon
+        if ((a_entryObject.isStolen == true || a_entryObject.isStealing == true) && a_state.showStolenIcon == true) {
+            this.stolenIcon._x = iconPos;
+            iconPos = iconPos + iconSpace;
+            this.stolenIcon.gotoAndStop("show");
+        } else {
+            this.stolenIcon.gotoAndStop("hide");
+        }
+    }
+
+    // @override TabularEntry
+    public function formatText(a_entryField: Object, a_entryObject: Object, a_state: ListState)
+    {
+        this.formatColor(a_entryField, a_entryObject, a_state);
+    }
+
+
   /* PRIVATE FUNCTIONS */
 
-   // @implements MovieClipLoader
-   private function onLoadInit(a_icon: MovieClip)
-   {
-      a_icon.gotoAndStop(this._iconLabel);
-      this.changeIconColor(a_icon, this._iconColor);
-   }
-   
-   private function formatColor(a_entryField: Object, a_entryObject: Object, a_state: ListState)
-   {			
-      // Stolen
-      if (a_entryObject.infoIsStolen == true || a_entryObject.isStealing == true)
-         a_entryField.textColor = a_entryObject.enabled == false ? a_state.stolenDisabledColor : a_state.stolenEnabledColor;
-         
-      // Default
-      else
-         a_entryField.textColor = a_entryObject.enabled == false ? a_state.defaultDisabledColor : a_state.defaultEnabledColor;
-   }
-   
-   private function changeIconColor(a_icon: MovieClip, a_rgb: Number)
-   {
-      var element: Object;
-      for (var e in a_icon) {
-         element = a_icon[e];
-         if (element instanceof MovieClip) {
-            //Note: Could check if all values of RGBA mult and .rgb are all the same then skip
-            var ct: ColorTransform = new flash.geom.ColorTransform();
-            var tf: Transform = new flash.geom.Transform(MovieClip(element));
-            // Could return here if (a_rgb == tf.colorTransform.rgb && a_rgb != undefined)
-            ct.rgb = (a_rgb == undefined) ? 0xFFFFFF : a_rgb;
-            tf.colorTransform = ct;
-            // Shouldn't be necessary to recurse since we don't expect multiple clip depths for an icon
-            //this.changeIconColor(element, a_rgb);
-         }
-      }
-   }
+    // @implements MovieClipLoader
+    private function onLoadInit(a_icon: MovieClip)
+    {
+        a_icon.gotoAndStop(this._iconLabel);
+        this.changeIconColor(a_icon, this._iconColor);
+    }
+
+    private function formatColor(a_entryField: Object, a_entryObject: Object, a_state: ListState)
+    {			
+        // Stolen
+        if (a_entryObject.infoIsStolen == true || a_entryObject.isStealing == true)
+            a_entryField.textColor = a_entryObject.enabled == false ? a_state.stolenDisabledColor : a_state.stolenEnabledColor;
+            
+        // Default
+        else
+            a_entryField.textColor = a_entryObject.enabled == false ? a_state.defaultDisabledColor : a_state.defaultEnabledColor;
+    }
+
+    private function changeIconColor(a_icon: MovieClip, a_rgb: Number)
+    {
+        var element: Object;
+        for (var e in a_icon) {
+            element = a_icon[e];
+            if (element instanceof MovieClip) {
+                //Note: Could check if all values of RGBA mult and .rgb are all the same then skip
+                var ct: ColorTransform = new flash.geom.ColorTransform();
+                var tf: Transform = new flash.geom.Transform(MovieClip(element));
+                // Could return here if (a_rgb == tf.colorTransform.rgb && a_rgb != undefined)
+                ct.rgb = (a_rgb == undefined) ? 0xFFFFFF : a_rgb;
+                tf.colorTransform = ct;
+                // Shouldn't be necessary to recurse since we don't expect multiple clip depths for an icon
+                //this.changeIconColor(element, a_rgb);
+            }
+        }
+    }
 }

--- a/source/actionscript/ItemMenus/InventoryListEntry.as
+++ b/source/actionscript/ItemMenus/InventoryListEntry.as
@@ -2,216 +2,224 @@ class InventoryListEntry extends skyui.components.list.TabularListEntry
 {
   /* CONSTANTS */
 
-   private static var STATES = ["None", "Equipped", "LeftEquip", "RightEquip", "LeftAndRightEquip"];
+    private static var STATES = ["None", "Equipped", "LeftEquip", "RightEquip", "LeftAndRightEquip"];
 
   /* PRIVATE VARIABLES */
-   
-   private var _iconLabel: String;
-   private var _iconColor: Number;
-   
+
+    private var _iconLabel: String;
+    private var _iconColor: Number;
+
   /* STAGE ELMENTS */
 
-   public var itemIcon: MovieClip;
-   public var equipIcon: MovieClip;
-   
-   public var bestIcon: MovieClip;
-   public var favoriteIcon: MovieClip;
-   public var poisonIcon: MovieClip;
-   public var stolenIcon: MovieClip;
-   public var enchIcon: MovieClip;
-   public var readIcon: MovieClip;
-   
-   
+    public var itemIcon: MovieClip;
+    public var equipIcon: MovieClip;
+
+    public var bestIcon: MovieClip;
+    public var favoriteIcon: MovieClip;
+    public var poisonIcon: MovieClip;
+    public var stolenIcon: MovieClip;
+    public var enchIcon: MovieClip;
+    public var readIcon: MovieClip;
+    
+
+  /* CONSTRUCTOR */
+
+    function InventoryListEntry()
+    {
+        super();
+    }
+
+
   /* INITIALIZATION */
-   
-   // @override TabularListEntry
-   public function initialize(a_index: Number, a_state: ListState)
-   {
-      super.initialize();
-      
-      var iconLoader = new MovieClipLoader();
-      iconLoader.addListener(this);
-      iconLoader.loadClip(a_state.iconSource, this.itemIcon);
-      
-      this.itemIcon._visible = false;
-      this.equipIcon._visible = false;
-      
-      for (var i = 0; this["textField" + i] != undefined; i++)
-         this["textField" + i]._visible = false;
-   }
-   
-   
+
+    // @override TabularListEntry
+    public function initialize(a_index: Number, a_state: ListState)
+    {
+        super.initialize();
+        
+        var iconLoader = new MovieClipLoader();
+        iconLoader.addListener(this);
+        iconLoader.loadClip(a_state.iconSource, this.itemIcon);
+        
+        this.itemIcon._visible = false;
+        this.equipIcon._visible = false;
+        
+        for (var i = 0; this["textField" + i] != undefined; i++)
+            this["textField" + i]._visible = false;
+    }
+
+
   /* PUBLIC FUNCTIONS */
-   
-   // @override TabularListEntry
-   public function setSpecificEntryLayout(a_entryObject: Object, a_state: ListState)
-   {
-      var iconY = skyui.components.list.TabularList(a_state.list).layout.entryHeight * 0.25;
-      var iconSize = skyui.components.list.TabularList(a_state.list).layout.entryHeight * 0.5;
-         
-      this.bestIcon._height = this.bestIcon._width = iconSize;
-      this.favoriteIcon._height = this.favoriteIcon._width = iconSize;
-      this.poisonIcon._height = this.poisonIcon._width = iconSize;
-      this.stolenIcon._height = this.stolenIcon._width = iconSize;
-      this.enchIcon._height = this.enchIcon._width = iconSize;
-      this.readIcon._height = this.readIcon._width = iconSize;
-         
-      this.bestIcon._y = iconY;
-      this.favoriteIcon._y = iconY;
-      this.poisonIcon._y = iconY;
-      this.stolenIcon._y = iconY;
-      this.enchIcon._y = iconY;
-      this.readIcon._y = iconY;
-   }
 
-   // @override TabularListEntry
-   public function formatEquipIcon(a_entryField: Object, a_entryObject: Object, a_state: ListState)
-   {
-      if (a_entryObject != undefined && a_entryObject.equipState != undefined) {
-         a_entryField.gotoAndStop(InventoryListEntry.STATES[a_entryObject.equipState]);
-      } else {
-         a_entryField.gotoAndStop("None");
-      }
-   }
+    // @override TabularListEntry
+    public function setSpecificEntryLayout(a_entryObject: Object, a_state: ListState)
+    {
+        var iconY = skyui.components.list.TabularList(a_state.list).layout.entryHeight * 0.25;
+        var iconSize = skyui.components.list.TabularList(a_state.list).layout.entryHeight * 0.5;
+            
+        this.bestIcon._height = this.bestIcon._width = iconSize;
+        this.favoriteIcon._height = this.favoriteIcon._width = iconSize;
+        this.poisonIcon._height = this.poisonIcon._width = iconSize;
+        this.stolenIcon._height = this.stolenIcon._width = iconSize;
+        this.enchIcon._height = this.enchIcon._width = iconSize;
+        this.readIcon._height = this.readIcon._width = iconSize;
+            
+        this.bestIcon._y = iconY;
+        this.favoriteIcon._y = iconY;
+        this.poisonIcon._y = iconY;
+        this.stolenIcon._y = iconY;
+        this.enchIcon._y = iconY;
+        this.readIcon._y = iconY;
+    }
 
-   // @override TabularListEntry
-   public function formatItemIcon(a_entryField: Object, a_entryObject: Object, a_state: ListState)
-   {
-      this._iconLabel = a_entryObject["iconLabel"] != undefined ? a_entryObject["iconLabel"] : "default_misc";
-      this._iconColor = a_entryObject["iconColor"];
+    // @override TabularListEntry
+    public function formatEquipIcon(a_entryField: Object, a_entryObject: Object, a_state: ListState)
+    {
+        if (a_entryObject != undefined && a_entryObject.equipState != undefined) {
+            a_entryField.gotoAndStop(InventoryListEntry.STATES[a_entryObject.equipState]);
+        } else {
+            a_entryField.gotoAndStop("None");
+        }
+    }
 
-      // Could return here if _iconLoaded is false
-      a_entryField.gotoAndStop(this._iconLabel);
-      this.changeIconColor(MovieClip(a_entryField), this._iconColor);
-   }
+    // @override TabularListEntry
+    public function formatItemIcon(a_entryField: Object, a_entryObject: Object, a_state: ListState)
+    {
+        this._iconLabel = a_entryObject["iconLabel"] != undefined ? a_entryObject["iconLabel"] : "default_misc";
+        this._iconColor = a_entryObject["iconColor"];
 
-   // @override TabularListEntry
-   public function formatName(a_entryField: Object, a_entryObject: Object, a_state: ListState)
-   {
-      if (a_entryObject.text == undefined) {
-         a_entryField.SetText(" ");
-         return;
-      }
+        // Could return here if _iconLoaded is false
+        a_entryField.gotoAndStop(this._iconLabel);
+        this.changeIconColor(MovieClip(a_entryField), this._iconColor);
+    }
 
-      // Text
-      var text = a_entryObject.text;
+    // @override TabularListEntry
+    public function formatName(a_entryField: Object, a_entryObject: Object, a_state: ListState)
+    {
+        if (a_entryObject.text == undefined) {
+            a_entryField.SetText(" ");
+            return;
+        }
 
-      if (a_entryObject.soulLVL != undefined) {
-         text = text + " (" + a_entryObject.soulLVL + ")";
-      }
+        // Text
+        var text = a_entryObject.text;
 
-      if (a_entryObject.count > 1) {
-         text = text + " (" + a_entryObject.count.toString() + ")";
-      }
+        if (a_entryObject.soulLVL != undefined) {
+            text = text + " (" + a_entryObject.soulLVL + ")";
+        }
 
-      if (text.length > a_state.maxTextLength) {
-         text = text.substr(0, a_state.maxTextLength - 3) + "...";
-      }
+        if (a_entryObject.count > 1) {
+            text = text + " (" + a_entryObject.count.toString() + ")";
+        }
 
-      a_entryField.autoSize = "left";
-      a_entryField.SetText(text);
-      
-      this.formatColor(a_entryField, a_entryObject, a_state);
+        if (text.length > a_state.maxTextLength) {
+            text = text.substr(0, a_state.maxTextLength - 3) + "...";
+        }
 
-      // BestInClass icon
-      var iconPos = a_entryField._x + a_entryField._width + 5;
+        a_entryField.autoSize = "left";
+        a_entryField.SetText(text);
+        
+        this.formatColor(a_entryField, a_entryObject, a_state);
 
-      // All icons have the same size
-      var iconSpace = this.bestIcon._width * 1.25;
+        // BestInClass icon
+        var iconPos = a_entryField._x + a_entryField._width + 5;
 
-      if (a_entryObject.bestInClass == true) {
-         this.bestIcon._x = iconPos;
-         iconPos = iconPos + iconSpace;
+        // All icons have the same size
+        var iconSpace = this.bestIcon._width * 1.25;
 
-         this.bestIcon.gotoAndStop("show");
-      } else {
-         this.bestIcon.gotoAndStop("hide");
-      }
+        if (a_entryObject.bestInClass == true) {
+            this.bestIcon._x = iconPos;
+            iconPos = iconPos + iconSpace;
 
-      // Fav icon
-      if (a_entryObject.favorite == true) {
-         this.favoriteIcon._x = iconPos;
-         iconPos = iconPos + iconSpace;
-         this.favoriteIcon.gotoAndStop("show");
-      } else {
-         this.favoriteIcon.gotoAndStop("hide");
-      }
+            this.bestIcon.gotoAndStop("show");
+        } else {
+            this.bestIcon.gotoAndStop("hide");
+        }
 
-      // Poisoned Icon
-      if (a_entryObject.isPoisoned == true) {
-         this.poisonIcon._x = iconPos;
-         iconPos = iconPos + iconSpace;
-         this.poisonIcon.gotoAndStop("show");
-      } else {
-         this.poisonIcon.gotoAndStop("hide");
-      }
+        // Fav icon
+        if (a_entryObject.favorite == true) {
+            this.favoriteIcon._x = iconPos;
+            iconPos = iconPos + iconSpace;
+            this.favoriteIcon.gotoAndStop("show");
+        } else {
+            this.favoriteIcon.gotoAndStop("hide");
+        }
 
-      // Stolen Icon
-      if ((a_entryObject.isStolen == true || a_entryObject.isStealing == true) && a_state.showStolenIcon == true) {
-         this.stolenIcon._x = iconPos;
-         iconPos = iconPos + iconSpace;
-         this.stolenIcon.gotoAndStop("show");
-      } else {
-         this.stolenIcon.gotoAndStop("hide");
-      }
+        // Poisoned Icon
+        if (a_entryObject.isPoisoned == true) {
+            this.poisonIcon._x = iconPos;
+            iconPos = iconPos + iconSpace;
+            this.poisonIcon.gotoAndStop("show");
+        } else {
+            this.poisonIcon.gotoAndStop("hide");
+        }
 
-      // Enchanted Icon
-      if (a_entryObject.isEnchanted == true) {
-         this.enchIcon._x = iconPos;
-         iconPos = iconPos + iconSpace;
-         this.enchIcon.gotoAndStop("show");
-      } else {
-         this.enchIcon.gotoAndStop("hide");
-      }
+        // Stolen Icon
+        if ((a_entryObject.isStolen == true || a_entryObject.isStealing == true) && a_state.showStolenIcon == true) {
+            this.stolenIcon._x = iconPos;
+            iconPos = iconPos + iconSpace;
+            this.stolenIcon.gotoAndStop("show");
+        } else {
+            this.stolenIcon.gotoAndStop("hide");
+        }
 
-      // Enchanted Icon
-      if (a_entryObject.isRead == true) {
-         this.readIcon._x = iconPos;
-         iconPos = iconPos + iconSpace;
-         this.readIcon.gotoAndStop("show");
-      } else {
-         this.readIcon.gotoAndStop("hide");
-      }
-   }
-   
-   // @override TabularEntry
-   public function formatText(a_entryField: Object, a_entryObject: Object, a_state: ListState)
-   {
-      this.formatColor(a_entryField, a_entryObject, a_state);
-      a_entryField.autoSize = a_entryField.getTextFormat().align;
-   }
-   
-   
-  /* PRIVATE FUNCTIONS */
+        // Enchanted Icon
+        if (a_entryObject.isEnchanted == true) {
+            this.enchIcon._x = iconPos;
+            iconPos = iconPos + iconSpace;
+            this.enchIcon.gotoAndStop("show");
+        } else {
+            this.enchIcon.gotoAndStop("hide");
+        }
 
-   // @implements MovieClipLoader
-   private function onLoadInit(a_icon: MovieClip)
-   {
-      a_icon.gotoAndStop(this._iconLabel);
-      this.changeIconColor(a_icon, this._iconColor);
-   }
-   
-   private function formatColor(a_entryField: Object, a_entryObject: Object, a_state: ListState)
-   {
-      // Negative Effect
-      if (a_entryObject.negativeEffect == true)
-         a_entryField.textColor = a_entryObject.enabled == false ? a_state.negativeDisabledColor : a_state.negativeEnabledColor;
-         
-      // Stolen
-      else if (a_entryObject.infoIsStolen == true || a_entryObject.isStealing == true)
-         a_entryField.textColor = a_entryObject.enabled == false ? a_state.stolenDisabledColor : a_state.stolenEnabledColor;
-         
-      // Default
-      else
-         a_entryField.textColor = a_entryObject.enabled == false ? a_state.defaultDisabledColor : a_state.defaultEnabledColor;
-   }
-   
-   private function changeIconColor(a_icon: MovieClip, a_rgb: Number)
-   {
-      var element: Object;
-      for (var e in a_icon) {
-         element = a_icon[e];
-         if (element instanceof MovieClip) {
+        // Enchanted Icon
+        if (a_entryObject.isRead == true) {
+            this.readIcon._x = iconPos;
+            iconPos = iconPos + iconSpace;
+            this.readIcon.gotoAndStop("show");
+        } else {
+            this.readIcon.gotoAndStop("hide");
+        }
+    }
+
+    // @override TabularEntry
+    public function formatText(a_entryField: Object, a_entryObject: Object, a_state: ListState)
+    {
+        this.formatColor(a_entryField, a_entryObject, a_state);
+        a_entryField.autoSize = a_entryField.getTextFormat().align;
+    }
+
+
+    /* PRIVATE FUNCTIONS */
+
+    // @implements MovieClipLoader
+    private function onLoadInit(a_icon: MovieClip)
+    {
+        a_icon.gotoAndStop(this._iconLabel);
+        this.changeIconColor(a_icon, this._iconColor);
+    }
+
+    private function formatColor(a_entryField: Object, a_entryObject: Object, a_state: ListState)
+    {
+        // Negative Effect
+        if (a_entryObject.negativeEffect == true)
+            a_entryField.textColor = a_entryObject.enabled == false ? a_state.negativeDisabledColor : a_state.negativeEnabledColor;
+            
+        // Stolen
+        else if (a_entryObject.infoIsStolen == true || a_entryObject.isStealing == true)
+            a_entryField.textColor = a_entryObject.enabled == false ? a_state.stolenDisabledColor : a_state.stolenEnabledColor;
+            
+        // Default
+        else
+            a_entryField.textColor = a_entryObject.enabled == false ? a_state.defaultDisabledColor : a_state.defaultEnabledColor;
+    }
+
+    private function changeIconColor(a_icon: MovieClip, a_rgb: Number)
+    {
+        var element: Object;
+        for (var e in a_icon) {
+            element = a_icon[e];
+            if (element instanceof MovieClip) {
             //Note: Could check if all values of RGBA mult and .rgb are all the same then skip
             var ct: ColorTransform = new flash.geom.ColorTransform();
             var tf: Transform = new flash.geom.Transform(MovieClip(element));
@@ -220,7 +228,7 @@ class InventoryListEntry extends skyui.components.list.TabularListEntry
             tf.colorTransform = ct;
             // Shouldn't be necessary to recurse since we don't expect multiple clip depths for an icon
             //this.changeIconColor(element, a_rgb);
-         }
-      }
-   }
+            }
+        }
+    }
 }

--- a/source/swfsources.cmake
+++ b/source/swfsources.cmake
@@ -121,10 +121,7 @@ Add_SWF(craftingmenu
     Common/skyui/filter/ItemTypeFilter.as
     Common/skyui/filter/NameFilter.as
     Common/skyui/filter/SortFilter.as
-    # NOTE: BasicListEntry.as is intentionally NOT re-injected — re-importing it
-    # via JPEXS breaks ColumnSelectDialog. The base SWF already contains it.
-    # See https://www.free-decompiler.com/flash/issues/2705
-    # Common/skyui/components/list/BasicListEntry.as
+    Common/skyui/components/list/BasicListEntry.as
     Common/skyui/components/list/TabularListEntry.as
     Common/skyui/components/list/ScrollingList.as
     CraftingMenu/CraftingDataSetter.as
@@ -484,10 +481,7 @@ Add_SWF(skyui_inventorylists
     Common/skyui/filter/ItemTypeFilter.as
     Common/skyui/filter/NameFilter.as
     Common/skyui/filter/SortFilter.as
-    # NOTE: BasicListEntry.as is intentionally NOT re-injected — re-importing it
-    # via JPEXS breaks ColumnSelectDialog. The base SWF already contains it.
-    # See https://www.free-decompiler.com/flash/issues/2705
-    # Common/skyui/components/list/BasicListEntry.as
+    Common/skyui/components/list/BasicListEntry.as
     Common/skyui/components/list/TabularListEntry.as
     Common/skyui/components/list/ScrollingList.as
     ItemMenus/CategoryList.as

--- a/source/swfsources.cmake
+++ b/source/swfsources.cmake
@@ -123,6 +123,7 @@ Add_SWF(craftingmenu
     Common/skyui/filter/SortFilter.as
     # Common/skyui/components/list/BasicListEntry.as
     Common/skyui/components/list/TabularListEntry.as
+    Common/skyui/components/list/ScrollingList.as
     CraftingMenu/CraftingDataSetter.as
     CraftingMenu/CraftingIconSetter.as
     CraftingMenu/CraftingListEntry.as

--- a/source/swfsources.cmake
+++ b/source/swfsources.cmake
@@ -121,7 +121,7 @@ Add_SWF(craftingmenu
     Common/skyui/filter/ItemTypeFilter.as
     Common/skyui/filter/NameFilter.as
     Common/skyui/filter/SortFilter.as
-    Common/skyui/components/list/BasicListEntry.as
+    # Common/skyui/components/list/BasicListEntry.as
     Common/skyui/components/list/TabularListEntry.as
     CraftingMenu/CraftingDataSetter.as
     CraftingMenu/CraftingIconSetter.as
@@ -480,7 +480,7 @@ Add_SWF(skyui_inventorylists
     Common/skyui/filter/ItemTypeFilter.as
     Common/skyui/filter/NameFilter.as
     Common/skyui/filter/SortFilter.as
-    Common/skyui/components/list/BasicListEntry.as
+    # Common/skyui/components/list/BasicListEntry.as
     Common/skyui/components/list/TabularListEntry.as
     Common/skyui/components/list/ScrollingList.as
     ItemMenus/CategoryList.as

--- a/source/swfsources.cmake
+++ b/source/swfsources.cmake
@@ -121,6 +121,9 @@ Add_SWF(craftingmenu
     Common/skyui/filter/ItemTypeFilter.as
     Common/skyui/filter/NameFilter.as
     Common/skyui/filter/SortFilter.as
+    # NOTE: BasicListEntry.as is intentionally NOT re-injected — re-importing it
+    # via JPEXS breaks ColumnSelectDialog. The base SWF already contains it.
+    # See https://www.free-decompiler.com/flash/issues/2705
     # Common/skyui/components/list/BasicListEntry.as
     Common/skyui/components/list/TabularListEntry.as
     Common/skyui/components/list/ScrollingList.as
@@ -481,6 +484,9 @@ Add_SWF(skyui_inventorylists
     Common/skyui/filter/ItemTypeFilter.as
     Common/skyui/filter/NameFilter.as
     Common/skyui/filter/SortFilter.as
+    # NOTE: BasicListEntry.as is intentionally NOT re-injected — re-importing it
+    # via JPEXS breaks ColumnSelectDialog. The base SWF already contains it.
+    # See https://www.free-decompiler.com/flash/issues/2705
     # Common/skyui/components/list/BasicListEntry.as
     Common/skyui/components/list/TabularListEntry.as
     Common/skyui/components/list/ScrollingList.as


### PR DESCRIPTION
1) Minor fixes to add a `super();` call, as was present in the original decompiled SkyUI 5.2 script code.
2) Enabled `ScrollingList.as` import for `CraftingMenu`.
3) Added missing this to `ListLayout.as`.

Currently, for some reason, importing the same `BasicListEntry.as` script into `inventorylists.swf` via JPEXS with the same code breaks the `ColumnSelectDialog`. Empty functions in `BasicListEntry.as` have been commented out until the next version of JPEXS:
https://www.free-decompiler.com/flash/issues/2705-the-dialog-box-breaks-when-importing-the-same-script

P.S.
The problem was with empty `initialize()` and `setEntry()` methods in `BasicListEntry.as`. JPEXS incorrectly interpreted the empty methods. The problem was resolved in:
https://github.com/jindrapetrik/jpexs-decompiler/releases/tag/nightly3499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added explicit constructors to list component classes for proper initialization.
  * Reorganized code formatting and indentation across multiple component files.
  * Adjusted build configuration to update source file inclusion for SWF generation.

* **Bug Fixes**
  * Fixed variable scope reference in layout update logic to ensure correct data source usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->