### PR TITLE
build(cmake): refactor `Add_SWF` for hierarchical source listing

### DIFF
--- a/source/swfsources.cmake
+++ b/source/swfsources.cmake
@@ -11,9 +11,14 @@ macro(Add_SWF _TARGET_NAME _SWF_REL _XML_PATH)
     foreach(_token IN LISTS _RAW_SOURCES)
         if("${_token}" STREQUAL "SKIP_IN_RELEASE")
             set(_SKIP_IN_RELEASE TRUE)
+            set(_LAST_TOKEN "") # Keywords cannot be directory names
         elseif("${_token}" STREQUAL "{")
-            # If we encounter '{', then the previous token was a folder.
-            # Remove it from the file list and add it to the directory stack.
+            # Validation: Check if the preceding token is a valid folder name
+            if("${_LAST_TOKEN}" STREQUAL "" OR "${_LAST_TOKEN}" STREQUAL "{" OR "${_LAST_TOKEN}" STREQUAL "}")
+                message(FATAL_ERROR "Add_SWF(${_TARGET_NAME}): '{' must be preceded by a directory name. Found: '${_LAST_TOKEN}'")
+            endif()
+
+            # The directory name was added to _SOURCES in the 'else' branch; remove it
             list(LENGTH _SOURCES _len)
             if(_len GREATER 0)
                 math(EXPR _last_idx "${_len} - 1")
@@ -22,30 +27,42 @@ macro(Add_SWF _TARGET_NAME _SWF_REL _XML_PATH)
             
             list(APPEND _PREFIX_STACK "${_LAST_TOKEN}")
             string(REPLACE ";" "/" _CURRENT_PREFIX "${_PREFIX_STACK}")
+            set(_LAST_TOKEN "") # Reset to prevent nested push of same token
         elseif("${_token}" STREQUAL "}")
-            # If we encounter '}', we exit the current folder (remove the last element from the stack).
+            # Validation: Check for stack underflow
             list(LENGTH _PREFIX_STACK _len)
-            if(_len GREATER 0)
-                math(EXPR _last_idx "${_len} - 1")
-                list(REMOVE_AT _PREFIX_STACK ${_last_idx})
+            if(_len EQUAL 0)
+                message(FATAL_ERROR "Add_SWF(${_TARGET_NAME}): Unexpected '}' found without matching '{'.")
             endif()
+
+            # Pop from stack
+            math(EXPR _last_idx "${_len} - 1")
+            list(REMOVE_AT _PREFIX_STACK ${_last_idx})
             
             if(_PREFIX_STACK)
                 string(REPLACE ";" "/" _CURRENT_PREFIX "${_PREFIX_STACK}")
             else()
                 set(_CURRENT_PREFIX "")
             endif()
+            set(_LAST_TOKEN "") # Reset after closing a block
         else()
-            # Add the file to the list with the current prefix (if any)
+            # Regular file or a potential directory name
             if(_CURRENT_PREFIX)
                 list(APPEND _SOURCES "${_CURRENT_PREFIX}/${_token}")
             else()
                 list(APPEND _SOURCES "${_token}")
             endif()
+            set(_LAST_TOKEN "${_token}")
         endif()
-        set(_LAST_TOKEN "${_token}")
     endforeach()
 
+    # Validation: Check for unmatched open braces
+    list(LENGTH _PREFIX_STACK _len)
+    if(_len GREATER 0)
+        message(FATAL_ERROR "Add_SWF(${_TARGET_NAME}): Missing closing '}' for directories: ${_PREFIX_STACK}")
+    endif()
+
+    # --- Logic for build starts here ---
     if(NOT (_SKIP_IN_RELEASE AND CMAKE_BUILD_TYPE STREQUAL "Release"))
         set(_BASE_SWF "${CMAKE_CURRENT_BINARY_DIR}/interface/base/${_SWF_REL}")
         set(_FINAL_SWF "${CMAKE_CURRENT_BINARY_DIR}/interface/${_SWF_REL}")

--- a/source/swfsources.cmake
+++ b/source/swfsources.cmake
@@ -1,11 +1,50 @@
 macro(Add_SWF _TARGET_NAME _SWF_REL _XML_PATH)
     set(_SKIP_IN_RELEASE FALSE)
-    set(_SOURCES ${ARGN})
-    list(FIND _SOURCES "SKIP_IN_RELEASE" _idx)
-    if(_idx GREATER -1)
-        set(_SKIP_IN_RELEASE TRUE)
-        list(REMOVE_AT _SOURCES ${_idx})
-    endif()
+    set(_RAW_SOURCES ${ARGN})
+    set(_SOURCES "")
+    
+    # A stack to keep track of the current path prefix
+    set(_PREFIX_STACK "")
+    set(_CURRENT_PREFIX "")
+    set(_LAST_TOKEN "")
+
+    foreach(_token IN LISTS _RAW_SOURCES)
+        if("${_token}" STREQUAL "SKIP_IN_RELEASE")
+            set(_SKIP_IN_RELEASE TRUE)
+        elseif("${_token}" STREQUAL "{")
+            # If we encounter '{', then the previous token was a folder.
+            # Remove it from the file list and add it to the directory stack.
+            list(LENGTH _SOURCES _len)
+            if(_len GREATER 0)
+                math(EXPR _last_idx "${_len} - 1")
+                list(REMOVE_AT _SOURCES ${_last_idx})
+            endif()
+            
+            list(APPEND _PREFIX_STACK "${_LAST_TOKEN}")
+            string(REPLACE ";" "/" _CURRENT_PREFIX "${_PREFIX_STACK}")
+        elseif("${_token}" STREQUAL "}")
+            # If we encounter '}', we exit the current folder (remove the last element from the stack).
+            list(LENGTH _PREFIX_STACK _len)
+            if(_len GREATER 0)
+                math(EXPR _last_idx "${_len} - 1")
+                list(REMOVE_AT _PREFIX_STACK ${_last_idx})
+            endif()
+            
+            if(_PREFIX_STACK)
+                string(REPLACE ";" "/" _CURRENT_PREFIX "${_PREFIX_STACK}")
+            else()
+                set(_CURRENT_PREFIX "")
+            endif()
+        else()
+            # Add the file to the list with the current prefix (if any)
+            if(_CURRENT_PREFIX)
+                list(APPEND _SOURCES "${_CURRENT_PREFIX}/${_token}")
+            else()
+                list(APPEND _SOURCES "${_token}")
+            endif()
+        endif()
+        set(_LAST_TOKEN "${_token}")
+    endforeach()
 
     if(NOT (_SKIP_IN_RELEASE AND CMAKE_BUILD_TYPE STREQUAL "Release"))
         set(_BASE_SWF "${CMAKE_CURRENT_BINARY_DIR}/interface/base/${_SWF_REL}")
@@ -36,128 +75,171 @@ endmacro()
 Add_SWF(bartermenu
     bartermenu.swf
     bartermenu.xml
-    Common/skyui/defines/Actor.as
-    Common/skyui/defines/Armor.as
-    Common/skyui/defines/Form.as
-    Common/skyui/defines/Input.as
-    Common/skyui/defines/Inventory.as
-    Common/skyui/defines/Item.as
-    Common/skyui/defines/Magic.as
-    Common/skyui/defines/Material.as
-    Common/skyui/defines/Weapon.as
-    Common/skyui/filter/ItemTypeFilter.as
-    Common/skyui/filter/NameFilter.as
-    Common/skyui/filter/SortFilter.as
-    ItemMenus/BarterDataSetter.as
-    ItemMenus/BarterMenu.as
-    ItemMenus/BottomBar.as
-    ItemMenus/CategoryList.as
-    ItemMenus/InventoryDataSetter.as
-    ItemMenus/InventoryIconSetter.as
-    ItemMenus/InventoryLists.as
-    ItemMenus/ItemMenu.as
-    ItemMenus/ItemcardDataExtender.as
-    Vanilla/Components/Meter.as
-    Vanilla/Shared/GlobalFunc.as
+    Common/skyui/defines {
+        Actor.as
+        Armor.as
+        Form.as
+        Input.as
+        Inventory.as
+        Item.as
+        Magic.as
+        Material.as
+        Weapon.as
+    }
+    Common/skyui/filter {
+        ItemTypeFilter.as
+        NameFilter.as
+        SortFilter.as
+    }
+    ItemMenus {
+        BarterDataSetter.as
+        BarterMenu.as
+        BottomBar.as
+        CategoryList.as
+        InventoryDataSetter.as
+        InventoryIconSetter.as
+        InventoryLists.as
+        ItemMenu.as
+        ItemcardDataExtender.as
+    }
+    Vanilla {
+        Components/Meter.as
+        Shared/GlobalFunc.as
+    }
 )
 
 Add_SWF(bookmenu
     bookmenu.swf
     bookmenu.xml
     ItemMenus/BottomBar.as
-    Vanilla/BookBottomBar.as
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/Proxy.as
+    Vanilla {
+        BookBottomBar.as
+        Components/CrossPlatformButtons.as
+        Shared {
+            ButtonChange.as
+            GlobalFunc.as
+            Proxy.as
+        }
+    }
 )
 
 Add_SWF(console
     console.swf
     console.xml
-    Vanilla/Console.as
-    Vanilla/Shared/GlobalFunc.as
+    Vanilla {
+        Console.as
+        Shared/GlobalFunc.as
+    }
 )
 
 Add_SWF(containermenu
     containermenu.swf
     containermenu.xml
-    Common/skyui/defines/Actor.as
-    Common/skyui/defines/Armor.as
-    Common/skyui/defines/Form.as
-    Common/skyui/defines/Input.as
-    Common/skyui/defines/Inventory.as
-    Common/skyui/defines/Item.as
-    Common/skyui/defines/Magic.as
-    Common/skyui/defines/Material.as
-    Common/skyui/defines/Weapon.as
-    Common/skyui/filter/ItemTypeFilter.as
-    Common/skyui/filter/NameFilter.as
-    Common/skyui/filter/SortFilter.as
-    ItemMenus/BottomBar.as
-    ItemMenus/CategoryList.as
-    ItemMenus/ContainerMenu.as
-    ItemMenus/InventoryDataSetter.as
-    ItemMenus/InventoryIconSetter.as
-    ItemMenus/InventoryLists.as
-    ItemMenus/ItemMenu.as
-    ItemMenus/ItemcardDataExtender.as
-    Vanilla/Components/Meter.as
-    Vanilla/Shared/GlobalFunc.as
+    Common/skyui/defines {
+        Actor.as
+        Armor.as
+        Form.as
+        Input.as
+        Inventory.as
+        Item.as
+        Magic.as
+        Material.as
+        Weapon.as
+    }
+    Common/skyui/filter {
+        ItemTypeFilter.as
+        NameFilter.as
+        SortFilter.as
+    }
+    ItemMenus {
+        BottomBar.as
+        CategoryList.as
+        ContainerMenu.as
+        InventoryDataSetter.as
+        InventoryIconSetter.as
+        InventoryLists.as
+        ItemMenu.as
+        ItemcardDataExtender.as
+    }
+    Vanilla {
+        Components/Meter.as
+        Shared/GlobalFunc.as
+    }
 )
 
 Add_SWF(craftingmenu
     craftingmenu.swf
     craftingmenu.xml
-    Common/skyui/defines/Actor.as
-    Common/skyui/defines/Armor.as
-    Common/skyui/defines/Form.as
-    Common/skyui/defines/Input.as
-    Common/skyui/defines/Inventory.as
-    Common/skyui/defines/Item.as
-    Common/skyui/defines/Magic.as
-    Common/skyui/defines/Material.as
-    Common/skyui/defines/Weapon.as
-    Common/skyui/filter/ItemTypeFilter.as
-    Common/skyui/filter/NameFilter.as
-    Common/skyui/filter/SortFilter.as
-    Common/skyui/components/list/BasicListEntry.as
-    Common/skyui/components/list/TabularListEntry.as
-    CraftingMenu/CraftingDataSetter.as
-    CraftingMenu/CraftingIconSetter.as
-    CraftingMenu/CraftingListEntry.as
-    CraftingMenu/CraftingLists.as
-    CraftingMenu/CraftingMenu.as
-    CraftingMenu/IconTabList.as
-    CraftingMenu/IconTabListEntry.as
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/GlobalFunc.as
+    Common/skyui/defines {
+        Actor.as
+        Armor.as
+        Form.as
+        Input.as
+        Inventory.as
+        Item.as
+        Magic.as
+        Material.as
+        Weapon.as
+    }
+    Common/skyui/filter {
+        ItemTypeFilter.as
+        NameFilter.as
+        SortFilter.as
+    }
+    Common/skyui/components/list {
+        BasicListEntry.as
+        TabularListEntry.as
+        ScrollingList.as
+    }
+    CraftingMenu {
+        CraftingDataSetter.as
+        CraftingIconSetter.as
+        CraftingListEntry.as
+        CraftingLists.as
+        CraftingMenu.as
+        IconTabList.as
+        IconTabListEntry.as
+    }
+    Vanilla {
+        Components/CrossPlatformButtons.as
+        Shared {
+            ButtonChange.as
+            GlobalFunc.as
+        }
+    }
 )
 
 Add_SWF(creditsmenu
     creditsmenu.swf
     creditsmenu.xml
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/CreditsMenu.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/Proxy.as
+    Vanilla {
+        Components/CrossPlatformButtons.as
+        CreditsMenu.as
+        Shared {
+            ButtonChange.as
+            GlobalFunc.as
+            Proxy.as
+        }
+    }
 )
 
 Add_SWF(dialoguemenu
     dialoguemenu.swf
     dialoguemenu.xml
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/DialogueCenteredList.as
-    Vanilla/DialogueMenu.as
-    Vanilla/Shared/BSScrollingList.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/ButtonMapping.as
-    Vanilla/Shared/CenteredScrollingList.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/ListFilterer.as
-    Vanilla/Shared/Proxy.as
+    Vanilla {
+        Components/CrossPlatformButtons.as
+        DialogueCenteredList.as
+        DialogueMenu.as
+        Shared {
+            BSScrollingList.as
+            ButtonChange.as
+            ButtonMapping.as
+            CenteredScrollingList.as
+            GlobalFunc.as
+            ListFilterer.as
+            Proxy.as
+        }
+    }
 )
 
 Add_SWF(exported_skyui_widgetloader
@@ -175,115 +257,149 @@ Add_SWF(exported_skyui_icons_effect_psychosteve
 Add_SWF(exported_widgets_skyui_activeeffects
     exported/widgets/skyui/activeeffects.swf
     exported/widgets/skyui/activeeffects.xml
-    Common/skyui/defines/Actor.as
-    Common/skyui/defines/Magic.as
-    HUDWidgets/skyui/widgets/WidgetBase.as
-    HUDWidgets/skyui/widgets/activeeffects/ActiveEffect.as
-    HUDWidgets/skyui/widgets/activeeffects/ActiveEffectsGroup.as
-    HUDWidgets/skyui/widgets/activeeffects/ActiveEffectsWidget.as
+    Common/skyui/defines {
+        Actor.as
+        Magic.as
+    }
+    HUDWidgets/skyui/widgets {
+        WidgetBase.as
+        activeeffects {
+            ActiveEffect.as
+            ActiveEffectsGroup.as
+            ActiveEffectsWidget.as
+        }
+    }
     Vanilla/Shared/GlobalFunc.as
 )
 
 Add_SWF(fadermenu
     fadermenu.swf
     fadermenu.xml
-    Vanilla/FaderMenu.as
-    Vanilla/Shared/GlobalFunc.as
+    Vanilla {
+        FaderMenu.as
+        Shared/GlobalFunc.as
+    }
 )
 
 Add_SWF(favoritesmenu
     favoritesmenu.swf
     favoritesmenu.xml
-    Common/skyui/defines/Actor.as
-    Common/skyui/defines/Armor.as
-    Common/skyui/defines/Form.as
-    Common/skyui/defines/Input.as
-    Common/skyui/defines/Item.as
-    Common/skyui/defines/Weapon.as
-    Common/skyui/filter/ItemTypeFilter.as
-    Common/skyui/filter/SortFilter.as
-    FavoritesMenu/FavoritesIconSetter.as
-    FavoritesMenu/FavoritesListEntry.as
-    FavoritesMenu/FavoritesMenu.as
-    FavoritesMenu/FilterDataExtender.as
-    FavoritesMenu/GroupButton.as
-    FavoritesMenu/GroupDataExtender.as
+    Common/skyui/defines {
+        Actor.as
+        Armor.as
+        Form.as
+        Input.as
+        Item.as
+        Weapon.as
+    }
+    Common/skyui/filter {
+        ItemTypeFilter.as
+        SortFilter.as
+    }
+    FavoritesMenu {
+        FavoritesIconSetter.as
+        FavoritesListEntry.as
+        FavoritesMenu.as
+        FilterDataExtender.as
+        GroupButton.as
+        GroupDataExtender.as
+    }
     Vanilla/Shared/GlobalFunc.as
 )
 
 Add_SWF(giftmenu
     giftmenu.swf
     giftmenu.xml
-    Common/skyui/defines/Actor.as
-    Common/skyui/defines/Armor.as
-    Common/skyui/defines/Form.as
-    Common/skyui/defines/Input.as
-    Common/skyui/defines/Inventory.as
-    Common/skyui/defines/Item.as
-    Common/skyui/defines/Magic.as
-    Common/skyui/defines/Material.as
-    Common/skyui/defines/Weapon.as
-    Common/skyui/filter/ItemTypeFilter.as
-    Common/skyui/filter/NameFilter.as
-    Common/skyui/filter/SortFilter.as
-    ItemMenus/BottomBar.as
-    ItemMenus/CategoryList.as
-    ItemMenus/GiftMenu.as
-    ItemMenus/InventoryDataSetter.as
-    ItemMenus/InventoryIconSetter.as
-    ItemMenus/InventoryLists.as
-    ItemMenus/ItemMenu.as
-    ItemMenus/ItemcardDataExtender.as
-    Vanilla/Components/Meter.as
-    Vanilla/Shared/GlobalFunc.as
+    Common/skyui/defines {
+        Actor.as
+        Armor.as
+        Form.as
+        Input.as
+        Inventory.as
+        Item.as
+        Magic.as
+        Material.as
+        Weapon.as
+    }
+    Common/skyui/filter {
+        ItemTypeFilter.as
+        NameFilter.as
+        SortFilter.as
+    }
+    ItemMenus {
+        BottomBar.as
+        CategoryList.as
+        GiftMenu.as
+        InventoryDataSetter.as
+        InventoryIconSetter.as
+        InventoryLists.as
+        ItemMenu.as
+        ItemcardDataExtender.as
+    }
+    Vanilla {
+        Components/Meter.as
+        Shared/GlobalFunc.as
+    }
 )
 
 Add_SWF(hudmenu
     hudmenu.swf
     hudmenu.xml
-    Vanilla/AnimatedLetter.as
-    Vanilla/Components/BlinkOnDemandMeter.as
-    Vanilla/Components/BlinkOnDemandPenaltyMeter.as
-    Vanilla/Components/BlinkOnEmptyMeter.as
-    Vanilla/Components/BlinkOnEmptyPenaltyMeter.as
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/Components/Meter.as
-    Vanilla/Components/UniformTimeMeter.as
-    Vanilla/HUDMenu.as
-    Vanilla/Messages.as
-    Vanilla/ObjectiveText.as
-    Vanilla/QuestNotification.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/ButtonTextArtHolder.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/PlatformChangeUser.as
-    Vanilla/Shared/Proxy.as
-    Vanilla/ShoutMeter.as
+    Vanilla {
+        AnimatedLetter.as
+        Components {
+            BlinkOnDemandMeter.as
+            BlinkOnDemandPenaltyMeter.as
+            BlinkOnEmptyMeter.as
+            BlinkOnEmptyPenaltyMeter.as
+            CrossPlatformButtons.as
+            Meter.as
+            UniformTimeMeter.as
+        }
+        HUDMenu.as
+        Messages.as
+        ObjectiveText.as
+        QuestNotification.as
+        Shared {
+            ButtonChange.as
+            ButtonTextArtHolder.as
+            GlobalFunc.as
+            PlatformChangeUser.as
+            Proxy.as
+        }
+        ShoutMeter.as
+    }
 )
 
 Add_SWF(inventorymenu
     inventorymenu.swf
     inventorymenu.xml
-    Common/skyui/defines/Actor.as
-    Common/skyui/defines/Armor.as
-    Common/skyui/defines/Form.as
-    Common/skyui/defines/Input.as
-    Common/skyui/defines/Inventory.as
-    Common/skyui/defines/Item.as
-    Common/skyui/defines/Magic.as
-    Common/skyui/defines/Material.as
-    Common/skyui/defines/Weapon.as
-    Common/skyui/filter/ItemTypeFilter.as
-    Common/skyui/filter/NameFilter.as
-    Common/skyui/filter/SortFilter.as
-    ItemMenus/BottomBar.as
-    ItemMenus/CategoryList.as
-    ItemMenus/InventoryDataSetter.as
-    ItemMenus/InventoryIconSetter.as
-    ItemMenus/InventoryLists.as
-    ItemMenus/InventoryMenu.as
-    ItemMenus/ItemMenu.as
-    ItemMenus/ItemcardDataExtender.as
+    Common/skyui/defines {
+        Actor.as
+        Armor.as
+        Form.as
+        Input.as
+        Inventory.as
+        Item.as
+        Magic.as
+        Material.as
+        Weapon.as
+    }
+    Common/skyui/filter {
+        ItemTypeFilter.as
+        NameFilter.as
+        SortFilter.as
+    }
+    ItemMenus {
+        BottomBar.as
+        CategoryList.as
+        InventoryDataSetter.as
+        InventoryIconSetter.as
+        InventoryLists.as
+        InventoryMenu.as
+        ItemMenu.as
+        ItemcardDataExtender.as
+    }
 )
 
 Add_SWF(levelupmenu
@@ -295,131 +411,169 @@ Add_SWF(levelupmenu
 Add_SWF(loadingmenu
     loadingmenu.swf
     loadingmenu.xml
-    Vanilla/Components/Meter.as
-    Vanilla/LoadingMenu.as
-    Vanilla/Shared/GlobalFunc.as
+    Vanilla {
+        Components/Meter.as
+        LoadingMenu.as
+        Shared/GlobalFunc.as
+    }
 )
 
 Add_SWF(loadwaitspinner
     loadwaitspinner.swf
     loadwaitspinner.xml
-    Vanilla/LoadWaitSpinner.as
-    Vanilla/Shared/GlobalFunc.as
+    Vanilla {
+        LoadWaitSpinner.as
+        Shared/GlobalFunc.as
+    }
 )
 
 Add_SWF(lockpickingmenu
     lockpickingmenu.swf
     lockpickingmenu.xml
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/Components/Meter.as
-    Vanilla/LockpickingMenu.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/Proxy.as
+    Vanilla {
+        Components {
+            CrossPlatformButtons.as
+            Meter.as
+        }
+        LockpickingMenu.as
+        Shared {
+            ButtonChange.as
+            GlobalFunc.as
+            Proxy.as
+        }
+    }
 )
 
 Add_SWF(magicmenu
     magicmenu.swf
     magicmenu.xml
-    Common/skyui/defines/Actor.as
-    Common/skyui/defines/Armor.as
-    Common/skyui/defines/Form.as
-    Common/skyui/defines/Input.as
-    Common/skyui/defines/Inventory.as
-    Common/skyui/defines/Item.as
-    Common/skyui/defines/Magic.as
-    Common/skyui/defines/Material.as
-    Common/skyui/defines/Weapon.as
-    Common/skyui/filter/ItemTypeFilter.as
-    Common/skyui/filter/NameFilter.as
-    Common/skyui/filter/SortFilter.as
-    ItemMenus/BottomBar.as
-    ItemMenus/CategoryList.as
-    ItemMenus/InventoryLists.as
-    ItemMenus/ItemMenu.as
-    ItemMenus/ItemcardDataExtender.as
-    ItemMenus/MagicDataSetter.as
-    ItemMenus/MagicIconSetter.as
-    ItemMenus/MagicMenu.as
+    Common/skyui/defines {
+        Actor.as
+        Armor.as
+        Form.as
+        Input.as
+        Inventory.as
+        Item.as
+        Magic.as
+        Material.as
+        Weapon.as
+    }
+    Common/skyui/filter {
+        ItemTypeFilter.as
+        NameFilter.as
+        SortFilter.as
+    }
+    ItemMenus {
+        BottomBar.as
+        CategoryList.as
+        InventoryLists.as
+        ItemMenu.as
+        ItemcardDataExtender.as
+        MagicDataSetter.as
+        MagicIconSetter.as
+        MagicMenu.as
+    }
 )
 
 Add_SWF(map
     map.swf
     map.xml
     Common/skyui/defines/Input.as
-    Common/skyui/filter/NameFilter.as
-    Common/skyui/filter/SortFilter.as
-    MapMenu/Map/LocalMap.as
-    MapMenu/Map/LocationFinder.as
-    MapMenu/Map/LocationListEntry.as
-    MapMenu/Map/MapMarker.as
-    MapMenu/Map/MapMenu.as
-    MapMenu/Map/MarkerDescription.as
+    Common/skyui/filter {
+        NameFilter.as
+        SortFilter.as
+    }
+    MapMenu/Map {
+        LocalMap.as
+        LocationFinder.as
+        LocationListEntry.as
+        MapMarker.as
+        MapMenu.as
+        MarkerDescription.as
+    }
 )
 
 Add_SWF(messagebox
     messagebox.swf
     messagebox.xml
-    Vanilla/MessageBox.as
-    Vanilla/Shared/GlobalFunc.as
+    Vanilla {
+        MessageBox.as
+        Shared/GlobalFunc.as
+    }
 )
 
 Add_SWF(quest_journal
     quest_journal.swf
     quest_journal.xml
     Common/skyui/defines/Input.as
-    PauseMenu/InputMappingList.as
-    PauseMenu/JournalBottomBar.as
-    PauseMenu/JournalSaveLoadList.as
-    PauseMenu/ObjectiveScrollingList.as
-    PauseMenu/OptionsList.as
-    PauseMenu/QuestCenteredList.as
-    PauseMenu/Quest_Journal.as
-    PauseMenu/QuestsPage.as
-    Vanilla/SaveLoadPanel.as
-    PauseMenu/SettingsOptionItem.as
-    PauseMenu/StatsList.as
-    PauseMenu/StatsPage.as
-    PauseMenu/SystemPage.as
-    Vanilla/Components/Meter.as
-    Vanilla/Shared/BSScrollingList.as
-    Vanilla/Shared/ButtonTextArtHolder.as
-    Vanilla/Shared/CenteredScrollingList.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/ListFilterer.as
+    PauseMenu {
+        InputMappingList.as
+        JournalBottomBar.as
+        JournalSaveLoadList.as
+        ObjectiveScrollingList.as
+        OptionsList.as
+        QuestCenteredList.as
+        Quest_Journal.as
+        QuestsPage.as
+        SettingsOptionItem.as
+        StatsList.as
+        StatsPage.as
+        SystemPage.as
+    }
+    Vanilla {
+        Components/Meter.as
+        SaveLoadPanel.as
+        Shared {
+            BSScrollingList.as
+            ButtonTextArtHolder.as
+            CenteredScrollingList.as
+            GlobalFunc.as
+            ListFilterer.as
+        }
+    }
 )
 
 Add_SWF(racesex_menu
     racesex_menu.swf
     racesex_menu.xml
     ItemMenus/CategoryList.as
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/FilteredList.as
-    Vanilla/RaceNarrowPanel.as
-    Vanilla/RaceSexPanels.as
-    Vanilla/RaceWidePanel.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/CenteredList.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/Proxy.as
-    Vanilla/Shared/VerticalCenteredList.as
+    Vanilla {
+        Components/CrossPlatformButtons.as
+        FilteredList.as
+        RaceNarrowPanel.as
+        RaceSexPanels.as
+        RaceWidePanel.as
+        Shared {
+            ButtonChange.as
+            CenteredList.as
+            GlobalFunc.as
+            Proxy.as
+            VerticalCenteredList.as
+        }
+    }
 )
 
 Add_SWF(sharedcomponents
     sharedcomponents.swf
     sharedcomponents.xml
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/Shared/ButtonChange.as
+    Vanilla {
+        Components/CrossPlatformButtons.as
+        Shared/ButtonChange.as
+    }
 )
 
 Add_SWF(skyui_bottombar
     skyui/bottombar.swf
     skyui/bottombar.xml
-    Common/skyui/defines/Input.as
-    Common/skyui/defines/Inventory.as
+    Common/skyui/defines {
+        Input.as
+        Inventory.as
+    }
     ItemMenus/BottomBar.as
-    Vanilla/Components/Meter.as
-    Vanilla/Shared/GlobalFunc.as
+    Vanilla {
+        Components/Meter.as
+        Shared/GlobalFunc.as
+    }
 )
 
 Add_SWF(skyui_buttonart
@@ -431,21 +585,27 @@ Add_SWF(skyui_configpanel
     skyui/configpanel.swf
     skyui/configpanel.xml
     Common/skyui/defines/Input.as
-    ModConfigPanel/ColorDialog.as
-    ModConfigPanel/ConfigPanel.as
-    ModConfigPanel/MenuDialog.as
-    ModConfigPanel/MessageDialog.as
-    ModConfigPanel/ModListPanel.as
-    ModConfigPanel/MultiColumnScrollBar.as
-    ModConfigPanel/MultiColumnScrollingList.as
-    ModConfigPanel/OptionDialog.as
-    ModConfigPanel/OptionsListEntry.as
-    ModConfigPanel/SliderDialog.as
-    ModConfigPanel/TextInputDialog.as
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/ModListEntry.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/GlobalFunc.as
+    ModConfigPanel {
+        ColorDialog.as
+        ConfigPanel.as
+        MenuDialog.as
+        MessageDialog.as
+        ModListPanel.as
+        MultiColumnScrollBar.as
+        MultiColumnScrollingList.as
+        OptionDialog.as
+        OptionsListEntry.as
+        SliderDialog.as
+        TextInputDialog.as
+    }
+    Vanilla {
+        Components/CrossPlatformButtons.as
+        ModListEntry.as
+        Shared {
+            ButtonChange.as
+            GlobalFunc.as
+        }
+    }
 )
 
 Add_SWF(skyui_icons_category_celtic
@@ -477,34 +637,52 @@ Add_SWF(skyui_inventorylists
     skyui/inventorylists.swf
     skyui/inventorylists.xml
     Common/skyui/defines/Input.as
-    Common/skyui/filter/ItemTypeFilter.as
-    Common/skyui/filter/NameFilter.as
-    Common/skyui/filter/SortFilter.as
-    Common/skyui/components/list/BasicListEntry.as
-    Common/skyui/components/list/TabularListEntry.as
-    Common/skyui/components/list/ScrollingList.as
-    ItemMenus/CategoryList.as
-    ItemMenus/CategoryListEntry.as
-    ItemMenus/InventoryListEntry.as
-    ItemMenus/InventoryLists.as
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/GlobalFunc.as
+    Common/skyui/filter {
+        ItemTypeFilter.as
+        NameFilter.as
+        SortFilter.as
+    }
+    Common/skyui/components/list {
+        BasicListEntry.as
+        TabularListEntry.as
+        ScrollingList.as
+    }
+    ItemMenus {
+        CategoryList.as
+        CategoryListEntry.as
+        InventoryListEntry.as
+        InventoryLists.as
+    }
+    Vanilla {
+        Components/CrossPlatformButtons.as
+        Shared {
+            ButtonChange.as
+            GlobalFunc.as
+        }
+    }
 )
 
 Add_SWF(skyui_itemcard
     skyui/itemcard.swf
     skyui/itemcard.xml
-    Common/skyui/defines/Input.as
-    Common/skyui/defines/Inventory.as
+    Common/skyui/defines {
+        Input.as
+        Inventory.as
+    }
     ItemMenus/ItemCard.as
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/Components/Meter.as
-    Vanilla/Shared/BSScrollingList.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/CenteredScrollingList.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/ListFilterer.as
+    Vanilla {
+        Components {
+            CrossPlatformButtons.as
+            Meter.as
+        }
+        Shared {
+            BSScrollingList.as
+            ButtonChange.as
+            CenteredScrollingList.as
+            GlobalFunc.as
+            ListFilterer.as
+        }
+    }
 )
 
 Add_SWF(skyui_mapmarkerart
@@ -520,57 +698,77 @@ Add_SWF(skyui_mcm_splash
 Add_SWF(skyui_skyui_splash
     skyui/skyui_splash.swf
     skyui/skyui_splash.xml
-    ModConfigPanel/ParticleEmitter.as
-    ModConfigPanel/SkyUISplash.as
-    ModConfigPanel/SnowEffect.as
+    ModConfigPanel {
+        ParticleEmitter.as
+        SkyUISplash.as
+        SnowEffect.as
+    }
 )
 
 Add_SWF(sleepwaitmenu
     sleepwaitmenu.swf
     sleepwaitmenu.xml
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/Proxy.as
-    Vanilla/SleepWaitMenu.as
+    Vanilla {
+        Components/CrossPlatformButtons.as
+        Shared {
+            ButtonChange.as
+            GlobalFunc.as
+            Proxy.as
+        }
+        SleepWaitMenu.as
+    }
 )
 
 Add_SWF(startmenu
     startmenu.swf
     startmenu.xml
-    Vanilla/SaveLoadPanel.as
-    Vanilla/BethesdaNetLogin.as
-    Vanilla/BottomButtons.as
-    Vanilla/CharacterSelectHintButtons.as
-    Vanilla/MainSaveLoadList.as
-    Vanilla/Shared/BSScrollingList.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/CenteredScrollingList.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/ListFilterer.as
-    Vanilla/Shared/Proxy.as
-    Vanilla/StartMenu.as
+    Vanilla {
+        BethesdaNetLogin.as
+        BottomButtons.as
+        CharacterSelectHintButtons.as
+        MainSaveLoadList.as
+        SaveLoadPanel.as
+        StartMenu.as
+        Shared {
+            BSScrollingList.as
+            ButtonChange.as
+            CenteredScrollingList.as
+            GlobalFunc.as
+            ListFilterer.as
+            Proxy.as
+        }
+    }
 )
 
 Add_SWF(statsmenu
     statsmenu.swf
     statsmenu.xml
-    Vanilla/AnimatedSkillText.as
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/Components/Meter.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/Proxy.as
-    Vanilla/StatsMenu.as
+    Vanilla {
+        AnimatedSkillText.as
+        Components {
+            CrossPlatformButtons.as
+            Meter.as
+        }
+        Shared {
+            ButtonChange.as
+            GlobalFunc.as
+            Proxy.as
+        }
+        StatsMenu.as
+    }
 )
 
 Add_SWF(textentry
     textentry.swf
     textentry.xml
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/Proxy.as
-    Vanilla/TextEntryField.as
+    Vanilla {
+        Components/CrossPlatformButtons.as
+        Shared {
+            ButtonChange.as
+            Proxy.as
+        }
+        TextEntryField.as
+    }
 )
 
 Add_SWF(titles
@@ -581,35 +779,51 @@ Add_SWF(titles
 Add_SWF(trainingmenu
     trainingmenu.swf
     trainingmenu.xml
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/Components/Meter.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/Proxy.as
-    Vanilla/TrainingMenu.as
+    Vanilla {
+        Components {
+            CrossPlatformButtons.as
+            Meter.as
+        }
+        Shared {
+            ButtonChange.as
+            GlobalFunc.as
+            Proxy.as
+        }
+        TrainingMenu.as
+    }
 )
 
 Add_SWF(tutorialmenu
     tutorialmenu.swf
     tutorialmenu.xml
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/ButtonMapping.as
-    Vanilla/Shared/ButtonTextArtHolder.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/Proxy.as
-    Vanilla/TutorialMenu.as
+    Vanilla {
+        Components/CrossPlatformButtons.as
+        Shared {
+            ButtonChange.as
+            ButtonMapping.as
+            ButtonTextArtHolder.as
+            GlobalFunc.as
+            Proxy.as
+        }
+        TutorialMenu.as
+    }
 )
 
 Add_SWF(tweenmenu
     tweenmenu.swf
     tweenmenu.xml
     TweenMenu/TweenMenu.as
-    Vanilla/Components/CrossPlatformButtons.as
-    Vanilla/Components/Meter.as
-    Vanilla/Shared/ButtonChange.as
-    Vanilla/Shared/GlobalFunc.as
-    Vanilla/Shared/Proxy.as
+    Vanilla {
+        Components {
+            CrossPlatformButtons.as
+            Meter.as
+        }
+        Shared {
+            ButtonChange.as
+            GlobalFunc.as
+            Proxy.as
+        }
+    }
 )
 
 # Only for design debug mode


### PR DESCRIPTION
A more convenient way to write `.as` script imports. Visual correspondence between the script import structure and the visual representation in the JPEXS UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved build system source file organization structure to use nested directory notation instead of flat file lists, with no impact on final output or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->