### PR TITLE
feat(inventory-list): add item counter

### DIFF
--- a/data/interface/skyui/config.txt
+++ b/data/interface/skyui/config.txt
@@ -30,6 +30,7 @@ itemcard.yOffset = 0
 [ItemList] 
 ; =====================================================================================================================
 quantityMenu.minCount = 6 ; Number of items required to trigger quantity dialog. 0 is disabled
+itemCountMode = 1         ; 0: Hide, 1: Number of items (without stacks), 2: Number of items (with stacks)
 
 
 ; =====================================================================================================================

--- a/data/interface/skyui/config.txt
+++ b/data/interface/skyui/config.txt
@@ -30,7 +30,7 @@ itemcard.yOffset = 0
 [ItemList] 
 ; =====================================================================================================================
 quantityMenu.minCount = 6 ; Number of items required to trigger quantity dialog. 0 is disabled
-itemCountMode = 2         ; 0: Hide, 1: Number of items (without stacks), 2: Number of items (with stacks)
+itemCount.mode = 2        ; 0: Hide, 1: Number of items (without stacks), 2: Number of items (with stacks)
 
 
 ; =====================================================================================================================

--- a/data/interface/skyui/config.txt
+++ b/data/interface/skyui/config.txt
@@ -30,7 +30,7 @@ itemcard.yOffset = 0
 [ItemList] 
 ; =====================================================================================================================
 quantityMenu.minCount = 6 ; Number of items required to trigger quantity dialog. 0 is disabled
-itemCountMode = 1         ; 0: Hide, 1: Number of items (without stacks), 2: Number of items (with stacks)
+itemCountMode = 2         ; 0: Hide, 1: Number of items (without stacks), 2: Number of items (with stacks)
 
 
 ; =====================================================================================================================

--- a/source/actionscript/Common/skyui/components/list/SortedListHeader.as
+++ b/source/actionscript/Common/skyui/components/list/SortedListHeader.as
@@ -3,6 +3,8 @@ class skyui.components.list.SortedListHeader extends MovieClip
   /* PRIVATE VARIABLES */
 
     private var _columns: Array;
+    private var _itemCount: Number = 0;
+    private var _countColumn: MovieClip;
 
 
   /* STAGE ELEMENTS */
@@ -44,6 +46,19 @@ class skyui.components.list.SortedListHeader extends MovieClip
     public function columnPress(a_columnIndex: Number)
     {
         this._layout.selectColumn(a_columnIndex);
+    }
+    
+    public function updateItemCount(a_count: Number)
+    {
+        this._itemCount = a_count;
+        
+        if (a_count < 0) {
+            if (this._countColumn != undefined)
+                this._countColumn._visible = false;
+            return;
+        }
+        
+        this.positionButtons();
     }
 
 
@@ -141,6 +156,30 @@ class skyui.components.list.SortedListHeader extends MovieClip
                 this.sortIcon._y = -e._height + ((e._height - this.sortIcon._height) / 2) - 1;
                 
                 this.iconColumnIndicator._visible = this._layout.columnLayoutData[i].type != skyui.components.list.ListLayout.COL_TYPE_ITEM_ICON;
+            }
+
+            if (this._layout.columnLayoutData[i].type == skyui.components.list.ListLayout.COL_TYPE_NAME  && this._itemCount >= 0) {
+                
+                if (this._countColumn == undefined) {
+                    this._countColumn = this.attachMovie("HeaderColumn", "CountColumn", this.getNextHighestDepth());
+                    this._countColumn.buttonArea._visible = false;
+                    this._countColumn.label.autoSize = "left";
+                }
+                
+                var fmt: TextFormat = this._layout.columnLayoutData[i].labelTextFormat;
+                this._countColumn.label.setTextFormat(fmt);
+                this._countColumn.label.SetText("(" + this._itemCount + ")");
+                
+                if (activeIndex == i)
+                    this._countColumn._x = this.sortIcon._x + this.sortIcon._width + 4;
+                else
+                    this._countColumn._x = e._x + e.buttonArea._x + e.buttonArea._width + 4;
+                
+                this._countColumn._y = e._y;
+                this._countColumn.label._y = e.label._y;
+                this._countColumn._visible = true;
+                
+                e.buttonArea._width = (this._countColumn._x + this._countColumn.label._width) - (e._x + e.buttonArea._x);
             }
         }
     }

--- a/source/actionscript/Common/skyui/components/list/SortedListHeader.as
+++ b/source/actionscript/Common/skyui/components/list/SortedListHeader.as
@@ -3,7 +3,7 @@ class skyui.components.list.SortedListHeader extends MovieClip
   /* PRIVATE VARIABLES */
 
     private var _columns: Array;
-    private var _itemCount: Number = 0;
+    private var _itemCount: Number = -1;
     private var _countColumn: MovieClip;
 
 
@@ -55,6 +55,8 @@ class skyui.components.list.SortedListHeader extends MovieClip
         if (a_count < 0) {
             if (this._countColumn != undefined)
                 this._countColumn._visible = false;
+            if (this._layout != undefined)
+                this.positionButtons();
             return;
         }
         

--- a/source/actionscript/Common/skyui/components/list/TabularList.as
+++ b/source/actionscript/Common/skyui/components/list/TabularList.as
@@ -116,8 +116,19 @@ class skyui.components.list.TabularList extends skyui.components.list.ScrollingL
     {
         var config = event.config;
         
-        if (config.ItemList.itemCountMode != undefined)
-            this._itemCountMode = Number(config.ItemList.itemCountMode);
+        if (config.ItemList.itemCountMode != undefined) {
+            var mode = Number(config.ItemList.itemCountMode);
+            
+            if (mode > 2) {
+                mode = 2;
+            } else if (mode < 0 || isNaN(mode)) {
+                mode = 0;
+            }
+            
+            this._itemCountMode = mode;
+        } else {
+            this._itemCountMode = 0;
+        }
 
         if (this._platform != 0) {
             this._previousColumnKey = config["Input"].controls.gamepad.prevColumn;

--- a/source/actionscript/Common/skyui/components/list/TabularList.as
+++ b/source/actionscript/Common/skyui/components/list/TabularList.as
@@ -76,14 +76,14 @@ class skyui.components.list.TabularList extends skyui.components.list.ScrollingL
         if (this.header == undefined || this.listEnumeration == undefined)
             return;
 
-        if (this._itemCountMode <= 0) {
+        if (this._itemCountMode <= 0 || this._layout == undefined || this._layout.columnLayoutData == undefined) {
             this.header.updateItemCount(-1);
             return;
         }
 
         var totalRows = this.listEnumeration.size();
         var totalItemsCount = 0;
-        
+
         var activeColIdx = this._layout.activeColumnIndex;
         var isActiveColName = (this._layout.columnLayoutData[activeColIdx].type == skyui.components.list.ListLayout.COL_TYPE_NAME);
         

--- a/source/actionscript/Common/skyui/components/list/TabularList.as
+++ b/source/actionscript/Common/skyui/components/list/TabularList.as
@@ -5,6 +5,7 @@ class skyui.components.list.TabularList extends skyui.components.list.ScrollingL
     private var _previousColumnKey: Number = -1;
     private var _nextColumnKey: Number = -1;
     private var _sortOrderKey: Number = -1;
+    private var _itemCountMode: Number = 0;
 
   /* STAGE ELEMENTS */
 
@@ -67,6 +68,47 @@ class skyui.components.list.TabularList extends skyui.components.list.ScrollingL
         return false;
     }
 
+    // @override ScrollingList
+    public function UpdateList()
+    {
+        super.UpdateList();
+        
+        if (this.header == undefined || this.listEnumeration == undefined)
+            return;
+
+        if (this._itemCountMode <= 0) {
+            this.header.updateItemCount(-1);
+            return;
+        }
+
+        var totalRows = this.listEnumeration.size();
+        var totalItemsCount = 0;
+        
+        var activeColIdx = this._layout.activeColumnIndex;
+        var isActiveColName = (this._layout.columnLayoutData[activeColIdx].type == skyui.components.list.ListLayout.COL_TYPE_NAME);
+        
+        var primaryAttr: String;
+        if (this._layout && this._layout.sortAttributes && this._layout.sortAttributes.length > 0) {
+            primaryAttr = this._layout.sortAttributes[0];
+        }
+
+        for (var i = 0; i < totalRows; i++) {
+            var entry = this.listEnumeration.at(i);
+            if (entry != undefined) {
+                var amountToAdd = (this._itemCountMode == 2 && entry.count != undefined && entry.count > 0) ? entry.count : 1;
+                
+                if (isActiveColName) {
+                    if (primaryAttr == undefined || primaryAttr == "text" || entry[primaryAttr]) {
+                        totalItemsCount += amountToAdd;
+                    }
+                } else {
+                    totalItemsCount += amountToAdd;
+                }
+            }
+        }
+        
+        this.header.updateItemCount(totalItemsCount);
+    }
 
   /* PRIVATE FUNCTIONS */
 
@@ -74,6 +116,9 @@ class skyui.components.list.TabularList extends skyui.components.list.ScrollingL
     {
         var config = event.config;
         
+        if (config.ItemList.itemCountMode != undefined)
+            this._itemCountMode = Number(config.ItemList.itemCountMode);
+
         if (this._platform != 0) {
             this._previousColumnKey = config["Input"].controls.gamepad.prevColumn;
             this._nextColumnKey = config["Input"].controls.gamepad.nextColumn;

--- a/source/actionscript/Common/skyui/components/list/TabularList.as
+++ b/source/actionscript/Common/skyui/components/list/TabularList.as
@@ -116,8 +116,8 @@ class skyui.components.list.TabularList extends skyui.components.list.ScrollingL
     {
         var config = event.config;
         
-        if (config.ItemList.itemCountMode != undefined) {
-            var mode = Number(config.ItemList.itemCountMode);
+        if (config.ItemList.itemCount.mode != undefined) {
+            var mode = Number(config.ItemList.itemCount.mode);
             
             if (mode > 2) {
                 mode = 2;

--- a/source/swfsources.cmake
+++ b/source/swfsources.cmake
@@ -122,7 +122,9 @@ Add_SWF(craftingmenu
     Common/skyui/filter/NameFilter.as
     Common/skyui/filter/SortFilter.as
     Common/skyui/components/list/BasicListEntry.as
+    Common/skyui/components/list/TabularList.as
     Common/skyui/components/list/TabularListEntry.as
+    Common/skyui/components/list/SortedListHeader.as
     CraftingMenu/CraftingDataSetter.as
     CraftingMenu/CraftingIconSetter.as
     CraftingMenu/CraftingListEntry.as
@@ -481,8 +483,10 @@ Add_SWF(skyui_inventorylists
     Common/skyui/filter/NameFilter.as
     Common/skyui/filter/SortFilter.as
     Common/skyui/components/list/BasicListEntry.as
+    Common/skyui/components/list/TabularList.as
     Common/skyui/components/list/TabularListEntry.as
     Common/skyui/components/list/ScrollingList.as
+    Common/skyui/components/list/SortedListHeader.as
     ItemMenus/CategoryList.as
     ItemMenus/CategoryListEntry.as
     ItemMenus/InventoryListEntry.as


### PR DESCRIPTION
Resolve #185.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable item-count display modes for inventory lists: hidden, per-row counts, or stacked totals (default: stacked).
  * List headers now show the item count beside the name column when enabled.
  * Counts update dynamically with list refreshes and respect active sorting and filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->