### PR TITLE
feat(inventory-list): add Shift-reverse, Ctrl-reset, and RBM state cycling columns

### DIFF
--- a/source/actionscript/Common/skyui/components/list/ListLayout.as
+++ b/source/actionscript/Common/skyui/components/list/ListLayout.as
@@ -304,6 +304,18 @@ class skyui.components.list.ListLayout
         this.updateLayout();
     }
 
+    public function clearSorting()
+    {
+        this._activeColumnIndex = this.currentView.columns.indexOf(this.currentView.primaryColumn);
+        if (this._activeColumnIndex == undefined || this._activeColumnIndex < 0)
+            this._activeColumnIndex = 0;
+            
+        this._activeColumnState = 1;
+        this._prefData.column = this._columnList[this.toColumnListIndex(this._activeColumnIndex)];
+        this._prefData.stateIndex = 1;
+        this.updateLayout();
+    }
+
 
     /* PRIVATE FUNCTIONS */
 
@@ -490,7 +502,7 @@ class skyui.components.list.ListLayout
         var xPos = 0;
         c = 0;
         for (var i = 0; i < this._columnList.length; i++) {
-            var col = _columnList[i];
+            var col = this._columnList[i];
             // Skip
             if (col.hidden == true)
                 continue;

--- a/source/actionscript/Common/skyui/components/list/ListLayout.as
+++ b/source/actionscript/Common/skyui/components/list/ListLayout.as
@@ -319,6 +319,7 @@ class skyui.components.list.ListLayout
 
     public function clearSorting()
     {
+        this._forceReverse = false;
         this._activeColumnIndex = this.currentView.columns.indexOf(this.currentView.primaryColumn);
         if (this._activeColumnIndex == undefined || this._activeColumnIndex < 0)
             this._activeColumnIndex = 0;
@@ -374,7 +375,7 @@ class skyui.components.list.ListLayout
             }
                 
             columnLayoutData.type = col.type;
-            
+
             columnLayoutData.labelValue = stateData.label.text;
             columnLayoutData.entryValue = stateData.entry.text;
             columnLayoutData.colorAttribute = stateData.colorAttribute;

--- a/source/actionscript/Common/skyui/components/list/ListLayout.as
+++ b/source/actionscript/Common/skyui/components/list/ListLayout.as
@@ -45,6 +45,8 @@ class skyui.components.list.ListLayout
 
     private var _lastFilterFlag: Number = -1;
 
+    private var _forceReverse: Boolean = false;
+
 
   /* PROPERTIES */
 
@@ -230,7 +232,7 @@ class skyui.components.list.ListLayout
         this.updateLayout();
     }
 
-    public function selectColumn(a_index: Number)
+    public function selectColumn(a_index: Number, a_bShift: Boolean)
     {
         var listIndex = this.toColumnListIndex(a_index);
         var col = this._columnList[listIndex];
@@ -238,15 +240,21 @@ class skyui.components.list.ListLayout
         // Invalid column
         if (col == null || col.passive)
             return;
-            
-        if (this._activeColumnIndex != a_index) {
+
+        if (this._activeColumnIndex == a_index) {
+            if (a_bShift) {
+                this._forceReverse = !this._forceReverse;
+            } else {
+                this._forceReverse = false;
+                if (this._activeColumnState < col.states)
+                    this._activeColumnState++;
+                else
+                    this._activeColumnState = 1;
+            }
+        } else {
             this._activeColumnIndex = a_index;
             this._activeColumnState = 1;
-        } else {
-            if (this._activeColumnState < col.states)
-                this._activeColumnState++;
-            else
-                this._activeColumnState = 1;
+            this._forceReverse = (a_bShift == true);
         }
         
         // Save as preferred state
@@ -256,7 +264,7 @@ class skyui.components.list.ListLayout
         this.updateLayout();
     }
 
-    public function selectColumnPrev(a_index: Number)
+    public function selectColumnPrev(a_index: Number, a_bShift: Boolean)
     {
         var listIndex = this.toColumnListIndex(a_index);
         var col = this._columnList[listIndex];
@@ -264,17 +272,22 @@ class skyui.components.list.ListLayout
         // Invalid column
         if (col == null || col.passive)
             return;
-            
-        if (this._activeColumnIndex != a_index) {
+
+        if (this._activeColumnIndex == a_index) {
+            if (a_bShift) {
+                this._forceReverse = !this._forceReverse;
+            } else {
+                this._forceReverse = false;
+                if (this._activeColumnState > 1)
+                    this._activeColumnState--;
+                else
+                    this._activeColumnState = col.states;
+            }
+        } else {
             this._activeColumnIndex = a_index;
             this._activeColumnState = col.states;
-        } else {
-            if (this._activeColumnState > 1)
-                this._activeColumnState--;
-            else
-                this._activeColumnState = col.states;
+            this._forceReverse = (a_bShift == true);
         }
-        
         // Save as preferred state
         this._prefData.column = col;
         this._prefData.stateIndex = this._activeColumnState;
@@ -349,12 +362,19 @@ class skyui.components.list.ListLayout
             if (c == this._activeColumnIndex) {
                 stateData = col["state" + this._activeColumnState];
                 this.updateSortParams(stateData);
+                
+                var defaultArrow: Boolean = stateData.label.arrowDown ? true : false;
+                if (col.type == skyui.components.list.ListLayout.COL_TYPE_NAME && this._forceReverse)
+                    columnLayoutData.labelArrowDown = !defaultArrow;
+                else
+                    columnLayoutData.labelArrowDown = defaultArrow;
             } else {
                 stateData = col["state1"];
+                columnLayoutData.labelArrowDown = stateData.label.arrowDown ? true : false;
             }
                 
             columnLayoutData.type = col.type;
-            columnLayoutData.labelArrowDown = stateData.label.arrowDown ? true : false;
+            
             columnLayoutData.labelValue = stateData.label.text;
             columnLayoutData.entryValue = stateData.entry.text;
             columnLayoutData.colorAttribute = stateData.colorAttribute;
@@ -548,32 +568,29 @@ class skyui.components.list.ListLayout
         var sortAttributes = stateData.sortAttributes;
         var sortOptions = stateData.sortOptions;
         
-        if (!sortOptions) {
-            this._sortOptions = null;
-            this._sortAttributes = null;
-            return;
-        }
-        
         // No attribute(s) set? Try to use entry value
-        if (!sortAttributes)
-            if (stateData.entry.text.charAt(0) == "@")
-                sortAttributes = [ stateData.entry.text.slice(1) ];
-        
-        if (!sortAttributes) {
+        if (!sortAttributes && stateData.entry.text.charAt(0) == "@")
+            sortAttributes = [ stateData.entry.text.slice(1) ];
+
+        if (!sortOptions || !sortAttributes) {
             this._sortOptions = null;
             this._sortAttributes = null;
             return;
         }
         
         // Wrap single attribute in array
-        if (!(sortAttributes instanceof Array))
-            sortAttributes = [sortAttributes];
-            
-        if (!(sortOptions instanceof Array))
-            sortOptions = [sortOptions];
-            
-        this._sortOptions = sortOptions;
-        this._sortAttributes = sortAttributes;
+        this._sortAttributes = (sortAttributes instanceof Array) ? sortAttributes : [sortAttributes];
+        var optionsCopy = (sortOptions instanceof Array) ? sortOptions.concat() : [sortOptions];
+
+        var col = this._columnList[this.toColumnListIndex(this._activeColumnIndex)];
+        if (col.type == skyui.components.list.ListLayout.COL_TYPE_NAME && this._forceReverse) {
+            var DESCENDING = 2;
+            for (var i = 0; i < optionsCopy.length; i++) {
+                optionsCopy[i] = optionsCopy[i] ^ DESCENDING; 
+            }
+        }
+        
+        this._sortOptions = optionsCopy;
     }
 
     private function restorePrefState()

--- a/source/actionscript/Common/skyui/components/list/ListLayout.as
+++ b/source/actionscript/Common/skyui/components/list/ListLayout.as
@@ -256,6 +256,32 @@ class skyui.components.list.ListLayout
         this.updateLayout();
     }
 
+    public function selectColumnPrev(a_index: Number)
+    {
+        var listIndex = this.toColumnListIndex(a_index);
+        var col = this._columnList[listIndex];
+        
+        // Invalid column
+        if (col == null || col.passive)
+            return;
+            
+        if (this._activeColumnIndex != a_index) {
+            this._activeColumnIndex = a_index;
+            this._activeColumnState = col.states;
+        } else {
+            if (this._activeColumnState > 1)
+                this._activeColumnState--;
+            else
+                this._activeColumnState = col.states;
+        }
+        
+        // Save as preferred state
+        this._prefData.column = col;
+        this._prefData.stateIndex = this._activeColumnState;
+            
+        this.updateLayout();
+    }
+
     public function restoreColumnState(a_activeIndex: Number, a_activeState: Number)
     {
         var listIndex = this.toColumnListIndex(a_activeIndex);

--- a/source/actionscript/Common/skyui/components/list/SortedListHeader.as
+++ b/source/actionscript/Common/skyui/components/list/SortedListHeader.as
@@ -51,6 +51,11 @@ class skyui.components.list.SortedListHeader extends MovieClip
         this._layout.selectColumnPrev(a_columnIndex);
     }
 
+    public function columnCtrlPress(a_columnIndex: Number)
+    {
+        this._layout.clearSorting();
+    }
+
 
   /* PRIVATE FUNCTIONS */
 
@@ -83,8 +88,12 @@ class skyui.components.list.SortedListHeader extends MovieClip
 
         columnButton.onPress = function(a_mouseIndex, a_keyboardOrMouse, a_buttonIndex)
         {
-            if (!this.columnIndex != undefined)
-                this._parent.columnPress(this.columnIndex);
+            if (!this.columnIndex != undefined) {
+                if (Key.isDown(Key.CONTROL))
+                    this._parent.columnCtrlPress(this.columnIndex);
+                else
+                    this._parent.columnPress(this.columnIndex);
+            }
         };
 
         columnButton.onPressAux = function(a_mouseIndex, a_keyboardOrMouse, a_buttonIndex)

--- a/source/actionscript/Common/skyui/components/list/SortedListHeader.as
+++ b/source/actionscript/Common/skyui/components/list/SortedListHeader.as
@@ -41,14 +41,14 @@ class skyui.components.list.SortedListHeader extends MovieClip
 
   /* PUBLIC FUNCTIONS */
 
-    public function columnPress(a_columnIndex: Number)
+    public function columnPress(a_columnIndex: Number, a_bShift: Boolean)
     {
-        this._layout.selectColumn(a_columnIndex);
+        this._layout.selectColumn(a_columnIndex, a_bShift);
     }
 
-    public function columnRightPress(a_columnIndex: Number)
+    public function columnRightPress(a_columnIndex: Number, a_bShift: Boolean)
     {
-        this._layout.selectColumnPrev(a_columnIndex);
+        this._layout.selectColumnPrev(a_columnIndex, a_bShift);
     }
 
     public function columnCtrlPress(a_columnIndex: Number)
@@ -92,14 +92,14 @@ class skyui.components.list.SortedListHeader extends MovieClip
                 if (Key.isDown(Key.CONTROL))
                     this._parent.columnCtrlPress(this.columnIndex);
                 else
-                    this._parent.columnPress(this.columnIndex);
+                    this._parent.columnPress(this.columnIndex, Key.isDown(Key.SHIFT));
             }
         };
 
         columnButton.onPressAux = function(a_mouseIndex, a_keyboardOrMouse, a_buttonIndex)
         {
             if (!this.columnIndex != undefined && a_buttonIndex == 1)
-                this._parent.columnRightPress(this.columnIndex);
+                this._parent.columnRightPress(this.columnIndex, Key.isDown(Key.SHIFT));
         };
 
         this._columns[a_index] = columnButton;

--- a/source/actionscript/Common/skyui/components/list/SortedListHeader.as
+++ b/source/actionscript/Common/skyui/components/list/SortedListHeader.as
@@ -46,6 +46,11 @@ class skyui.components.list.SortedListHeader extends MovieClip
         this._layout.selectColumn(a_columnIndex);
     }
 
+    public function columnRightPress(a_columnIndex: Number)
+    {
+        this._layout.selectColumnPrev(a_columnIndex);
+    }
+
 
   /* PRIVATE FUNCTIONS */
 
@@ -84,8 +89,8 @@ class skyui.components.list.SortedListHeader extends MovieClip
 
         columnButton.onPressAux = function(a_mouseIndex, a_keyboardOrMouse, a_buttonIndex)
         {
-            if (!this.columnIndex != undefined)
-                this._parent.columnPress(this.columnIndex);
+            if (!this.columnIndex != undefined && a_buttonIndex == 1)
+                this._parent.columnRightPress(this.columnIndex);
         };
 
         this._columns[a_index] = columnButton;

--- a/source/swfsources.cmake
+++ b/source/swfsources.cmake
@@ -122,6 +122,8 @@ Add_SWF(craftingmenu
     Common/skyui/filter/NameFilter.as
     Common/skyui/filter/SortFilter.as
     Common/skyui/components/list/BasicListEntry.as
+    Common/skyui/components/list/ListLayout.as
+    Common/skyui/components/list/SortedListHeader.as
     Common/skyui/components/list/TabularListEntry.as
     CraftingMenu/CraftingDataSetter.as
     CraftingMenu/CraftingIconSetter.as
@@ -483,6 +485,8 @@ Add_SWF(skyui_inventorylists
     Common/skyui/components/list/BasicListEntry.as
     Common/skyui/components/list/TabularListEntry.as
     Common/skyui/components/list/ScrollingList.as
+    Common/skyui/components/list/SortedListHeader.as
+    Common/skyui/components/list/ListLayout.as
     ItemMenus/CategoryList.as
     ItemMenus/CategoryListEntry.as
     ItemMenus/InventoryListEntry.as


### PR DESCRIPTION
This PR enhances the tabular list header navigation and sorting logic to provide a more flexible "DataGrid-like" experience:

1. **Shift + LBM/RBM**: Toggles the sorting direction (Ascending <-> Descending) for the Name column state without cycling to the next category.
2. **Right Click (RBM)**: Cycles through column Name states in reverse (e.g., Name <- Enchanted <- Stolen).
3. **Ctrl + LBM**: Clears custom sorting and resets the list to the default primary column and direction (Name, Ascending).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shift-modified column clicks toggle an alternate reverse/sort direction; auxiliary/right-click cycles selection backward; Ctrl clears sorting. Column header presses now honor Shift/Ctrl and auxiliary button input.
  * Sorting/selection is persisted so chosen column and direction remain across views.

* **Bug Fixes**
  * Column sort indicator now correctly reflects the alternate reverse state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->