### PR TITLE
fix(racemenu): non-clickable category

### DIFF
--- a/source/actionscript/Vanilla/RaceSexPanels.as
+++ b/source/actionscript/Vanilla/RaceSexPanels.as
@@ -72,6 +72,8 @@ class RaceSexPanels extends MovieClip
       _root.RaceSexMenuBaseInstance.BottomBarInstance.ButtonsInstance.Lock("L");
       _root.RaceSexMenuBaseInstance.BottomBarInstance.PlayerInfo_mc.Lock("R");
       _root.RaceSexMenuBaseInstance.CagetoryLockBaseInstance.Lock("T");
+      this._parent.LeftClickInstance.Lock("T");
+      this._parent.RightClickInstance.Lock("T");
       this._TextEntryField.SetupButtons();
       this._TextEntryField.TextInputInstance.maxChars = 26;
    }


### PR DESCRIPTION
With UltraWide support, clickable buttons for navigating between categories weren't adapted. PR pushes them to the top, just like `CagetoryLockBaseInstance`, so the buttons are also above `CagetoryLockBaseInstance`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu locking behavior to prevent additional clickable elements from responding to input when the race/sex selection menu is locked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->