### PR TITLE
perf(scrolling-list): add pagination

### DIFF
--- a/source/actionscript/Common/skyui/components/list/ScrollingList.as
+++ b/source/actionscript/Common/skyui/components/list/ScrollingList.as
@@ -67,6 +67,11 @@ class skyui.components.list.ScrollingList extends skyui.components.list.BasicLis
             this.scrollbar.height = this._listHeight;
     }
 
+    public function get maxListIndex()
+    {
+        return this._maxListIndex;
+    }
+
 
   /* INITIALIZATION */
 
@@ -139,6 +144,8 @@ class skyui.components.list.ScrollingList extends skyui.components.list.BasicLis
             this._bRequestUpdate = true;
             return;
         }
+
+        this.dispatchEvent({type: "listUpdate"});
         
         // Prepare clips
         this.setClipCount(this._maxListIndex);

--- a/source/actionscript/CraftingMenu/CraftingDataSetter.as
+++ b/source/actionscript/CraftingMenu/CraftingDataSetter.as
@@ -6,21 +6,44 @@ class CraftingDataSetter implements skyui.components.list.IListProcessor
    }
    function processList(a_list)
    {
-      var _loc4_ = a_list.entryList;
-      var _loc3_ = 0;
-      var _loc2_;
-      while(_loc3_ < _loc4_.length)
-      {
-         _loc2_ = _loc4_[_loc3_];
-         if(!_loc2_.skyui_itemDataProcessed)
-         {
-            _loc2_.skyui_itemDataProcessed = true;
-            this.fixSKSEExtendedObject(_loc2_);
-            this.processEntry(_loc2_);
-         }
-         _loc3_ = _loc3_ + 1;
+      if (this._list != a_list) {
+         if (this._list)
+            this._list.removeEventListener("listUpdate", this, "onListUpdate");
+
+         this._list = a_list;
+         this._list.addEventListener("listUpdate", this, "onListUpdate");
       }
    }
+
+   function onListUpdate(event: Object)
+   {
+      var listEnum = this._list.listEnumeration;
+      if (listEnum == undefined) return;
+
+      var maxVisible = this._list.maxListIndex;
+      var batchSize = maxVisible * 2;
+      
+      var startIdx = this._list.scrollPosition;
+      var endIdx = Math.min(startIdx + maxVisible, listEnum.size());
+      
+      for (var i = startIdx; i < endIdx; i++) {
+         var entry = listEnum.at(i);
+         if (entry != undefined && !entry.skyui_itemDataProcessed && entry.filterFlag != 0) {
+            var chunkEnd = Math.min(i + batchSize, listEnum.size());
+            
+            for (var j = i; j < chunkEnd; j++) {
+               var batchEntry = listEnum.at(j);
+               if (batchEntry != undefined && !batchEntry.skyui_itemDataProcessed) {
+                  batchEntry.skyui_itemDataProcessed = true;
+                  this.fixSKSEExtendedObject(batchEntry);
+                  this.processEntry(batchEntry);
+               }
+            }
+            break;
+         }
+      }
+   }
+
    function processEntry(a_entryObject)
    {
       a_entryObject.baseId = a_entryObject.formId & 0xFFFFFF;

--- a/source/actionscript/CraftingMenu/CraftingDataSetter.as
+++ b/source/actionscript/CraftingMenu/CraftingDataSetter.as
@@ -6,13 +6,10 @@ class CraftingDataSetter implements skyui.components.list.IListProcessor
    }
    function processList(a_list)
    {
-      if (this._list != a_list) {
-         if (this._list)
-            this._list.removeEventListener("listUpdate", this, "onListUpdate");
-
-         this._list = a_list;
-         this._list.addEventListener("listUpdate", this, "onListUpdate");
-      }
+      if (this._list == a_list) return;
+      if (this._list) this._list.removeEventListener("listUpdate", this, "onListUpdate");
+      this._list = a_list;
+      if (this._list) this._list.addEventListener("listUpdate", this, "onListUpdate");
    }
 
    function onListUpdate(event: Object)
@@ -20,11 +17,11 @@ class CraftingDataSetter implements skyui.components.list.IListProcessor
       var listEnum = this._list.listEnumeration;
       if (listEnum == undefined) return;
 
-      var maxVisible = this._list.maxListIndex;
-      var batchSize = maxVisible * 2;
+      var visibleCount = Math.max(1, this._list.maxListIndex + 1);
+      var batchSize = visibleCount * 2;
       
       var startIdx = this._list.scrollPosition;
-      var endIdx = Math.min(startIdx + maxVisible, listEnum.size());
+      var endIdx = Math.min(startIdx + visibleCount, listEnum.size());
       
       for (var i = startIdx; i < endIdx; i++) {
          var entry = listEnum.at(i);

--- a/source/actionscript/CraftingMenu/CraftingIconSetter.as
+++ b/source/actionscript/CraftingMenu/CraftingIconSetter.as
@@ -9,14 +9,10 @@ class CraftingIconSetter implements skyui.components.list.IListProcessor
    }
    function processList(a_list)
    {
-      if (this._list != a_list)
-      {
-         if (this._list)
-            this._list.removeEventListener("listUpdate", this, "onListUpdate");
-
-         this._list = a_list;
-         this._list.addEventListener("listUpdate", this, "onListUpdate");
-      }
+      if (this._list == a_list) return;
+      if (this._list) this._list.removeEventListener("listUpdate", this, "onListUpdate");
+      this._list = a_list;
+      if (this._list) this._list.addEventListener("listUpdate", this, "onListUpdate");
    }
 
    function onListUpdate(event: Object)
@@ -24,11 +20,11 @@ class CraftingIconSetter implements skyui.components.list.IListProcessor
       var listEnum = this._list.listEnumeration;
       if (listEnum == undefined) return;
 
-      var maxVisible = this._list.maxListIndex;
-      var batchSize = maxVisible * 2;
+      var visibleCount = Math.max(1, this._list.maxListIndex + 1);
+      var batchSize = visibleCount * 2;
       
       var startIdx = this._list.scrollPosition;
-      var endIdx = Math.min(startIdx + maxVisible, listEnum.size());
+      var endIdx = Math.min(startIdx + visibleCount, listEnum.size());
       
       var totalEntries = listEnum.size();
 

--- a/source/actionscript/CraftingMenu/CraftingIconSetter.as
+++ b/source/actionscript/CraftingMenu/CraftingIconSetter.as
@@ -1,20 +1,55 @@
 class CraftingIconSetter implements skyui.components.list.IListProcessor
 {
    var _noIconColors;
+   var _list;
+
    function CraftingIconSetter(a_configAppearance)
    {
       this._noIconColors = a_configAppearance.icons.item.noColor;
    }
    function processList(a_list)
    {
-      var _loc3_ = a_list.entryList;
-      var _loc2_ = 0;
-      while(_loc2_ < _loc3_.length)
+      if (this._list != a_list)
       {
-         this.processEntry(_loc3_[_loc2_]);
-         _loc2_ = _loc2_ + 1;
+         if (this._list)
+            this._list.removeEventListener("listUpdate", this, "onListUpdate");
+
+         this._list = a_list;
+         this._list.addEventListener("listUpdate", this, "onListUpdate");
       }
    }
+
+   function onListUpdate(event: Object)
+   {
+      var listEnum = this._list.listEnumeration;
+      if (listEnum == undefined) return;
+
+      var maxVisible = this._list.maxListIndex;
+      var batchSize = maxVisible * 2;
+      
+      var startIdx = this._list.scrollPosition;
+      var endIdx = Math.min(startIdx + maxVisible, listEnum.size());
+      
+      var totalEntries = listEnum.size();
+
+      for (var i = startIdx; i < endIdx; i++) {
+         var entry = listEnum.at(i);
+         
+         if (entry != undefined && !entry.skyui_iconProcessed && entry.skyui_itemDataProcessed) {
+            var chunkEnd = Math.min(i + batchSize, totalEntries);
+               
+            for (var j = i; j < chunkEnd; j++) {
+               var batchEntry = listEnum.at(j);
+               if (batchEntry != undefined && !batchEntry.skyui_iconProcessed && batchEntry.skyui_itemDataProcessed) {
+                  this.processEntry(batchEntry);
+                  batchEntry.skyui_iconProcessed = true;
+               }
+            }
+            break;
+         }
+      }
+   }
+
    function processEntry(a_entryObject)
    {
       switch(a_entryObject.formType)

--- a/source/actionscript/CraftingMenu/CustomConstructDataSetter.as
+++ b/source/actionscript/CraftingMenu/CustomConstructDataSetter.as
@@ -6,18 +6,44 @@ class CustomConstructDataSetter implements skyui.components.list.IListProcessor
    }
    function processList(a_list)
    {
-      var _loc4_ = a_list.entryList;
-      var _loc3_ = 0;
-      var _loc2_;
-      while(_loc3_ < _loc4_.length)
-      {
-         _loc2_ = _loc4_[_loc3_];
-         if(!(_loc2_.oldFilterFlag != undefined || _loc2_.filterFlag == 0))
-         {
-            _loc2_.oldFilterFlag = _loc2_.filterFlag;
-            this.processEntry(_loc2_);
+      if (this._list != a_list) {
+         if (this._list)
+            this._list.removeEventListener("listUpdate", this, "onListUpdate");
+            
+         this._list = a_list;
+         this._list.addEventListener("listUpdate", this, "onListUpdate");
+      }
+   }
+   
+   function onListUpdate(event: Object)
+   {
+      var listEnum = this._list.listEnumeration;
+      if (listEnum == undefined) return;
+
+      var maxVisible = this._list.maxListIndex;
+      var batchSize = maxVisible * 2;
+      
+      var startIdx = this._list.scrollPosition;
+      var endIdx = Math.min(startIdx + maxVisible, listEnum.size());
+      
+      var totalEntries = listEnum.size();
+
+      for (var i = startIdx; i < endIdx; i++) {
+         var entry = listEnum.at(i);
+         
+         if (entry != undefined && entry.oldFilterFlag == undefined && entry.filterFlag != 0) {
+            var chunkEnd = Math.min(i + batchSize, totalEntries);
+            
+            for (var j = i; j < chunkEnd; j++) {
+               var batchEntry = listEnum.at(j);
+               
+               if (batchEntry != undefined && batchEntry.oldFilterFlag == undefined && batchEntry.filterFlag != 0) {
+                  batchEntry.oldFilterFlag = batchEntry.filterFlag;
+                  this.processEntry(batchEntry);
+               }
+            }
+            break;
          }
-         _loc3_ = _loc3_ + 1;
       }
    }
    function processEntry(a_entryObject)

--- a/source/actionscript/CraftingMenu/CustomConstructDataSetter.as
+++ b/source/actionscript/CraftingMenu/CustomConstructDataSetter.as
@@ -6,13 +6,10 @@ class CustomConstructDataSetter implements skyui.components.list.IListProcessor
    }
    function processList(a_list)
    {
-      if (this._list != a_list) {
-         if (this._list)
-            this._list.removeEventListener("listUpdate", this, "onListUpdate");
-            
-         this._list = a_list;
-         this._list.addEventListener("listUpdate", this, "onListUpdate");
-      }
+      if (this._list == a_list) return;
+      if (this._list) this._list.removeEventListener("listUpdate", this, "onListUpdate");
+      this._list = a_list;
+      if (this._list) this._list.addEventListener("listUpdate", this, "onListUpdate");
    }
    
    function onListUpdate(event: Object)
@@ -20,11 +17,11 @@ class CustomConstructDataSetter implements skyui.components.list.IListProcessor
       var listEnum = this._list.listEnumeration;
       if (listEnum == undefined) return;
 
-      var maxVisible = this._list.maxListIndex;
-      var batchSize = maxVisible * 2;
+      var visibleCount = Math.max(1, this._list.maxListIndex + 1);
+      var batchSize = visibleCount * 2;
       
       var startIdx = this._list.scrollPosition;
-      var endIdx = Math.min(startIdx + maxVisible, listEnum.size());
+      var endIdx = Math.min(startIdx + visibleCount, listEnum.size());
       
       var totalEntries = listEnum.size();
 

--- a/source/actionscript/ItemMenus/InventoryIconSetter.as
+++ b/source/actionscript/ItemMenus/InventoryIconSetter.as
@@ -9,14 +9,10 @@ class InventoryIconSetter implements skyui.components.list.IListProcessor
    }
    function processList(a_list)
    {
-      if (this._list != a_list)
-      {
-         if (this._list)
-            this._list.removeEventListener("listUpdate", this, "onListUpdate");
-
-         this._list = a_list;
-         this._list.addEventListener("listUpdate", this, "onListUpdate");
-      }
+      if (this._list == a_list) return;
+      if (this._list) this._list.removeEventListener("listUpdate", this, "onListUpdate");
+      this._list = a_list;
+      if (this._list) this._list.addEventListener("listUpdate", this, "onListUpdate");
    }
 
    function onListUpdate(event: Object)
@@ -24,11 +20,11 @@ class InventoryIconSetter implements skyui.components.list.IListProcessor
       var listEnum = this._list.listEnumeration;
       if (listEnum == undefined) return;
 
-      var maxVisible = this._list.maxListIndex;
-      var batchSize = maxVisible * 2;
+      var visibleCount = Math.max(1, this._list.maxListIndex + 1);
+      var batchSize = visibleCount * 2;
       
       var startIdx = this._list.scrollPosition;
-      var endIdx = Math.min(startIdx + maxVisible, listEnum.size());
+      var endIdx = Math.min(startIdx + visibleCount, listEnum.size());
       
       var totalEntries = listEnum.size();
 

--- a/source/actionscript/ItemMenus/InventoryIconSetter.as
+++ b/source/actionscript/ItemMenus/InventoryIconSetter.as
@@ -1,20 +1,55 @@
 class InventoryIconSetter implements skyui.components.list.IListProcessor
 {
    var _noIconColors;
+   var _list;
+
    function InventoryIconSetter(a_configAppearance)
    {
       this._noIconColors = a_configAppearance.icons.item.noColor;
    }
    function processList(a_list)
    {
-      var _loc3_ = a_list.entryList;
-      var _loc2_ = 0;
-      while(_loc2_ < _loc3_.length)
+      if (this._list != a_list)
       {
-         this.processEntry(_loc3_[_loc2_]);
-         _loc2_ = _loc2_ + 1;
+         if (this._list)
+            this._list.removeEventListener("listUpdate", this, "onListUpdate");
+
+         this._list = a_list;
+         this._list.addEventListener("listUpdate", this, "onListUpdate");
       }
    }
+
+   function onListUpdate(event: Object)
+   {
+      var listEnum = this._list.listEnumeration;
+      if (listEnum == undefined) return;
+
+      var maxVisible = this._list.maxListIndex;
+      var batchSize = maxVisible * 2;
+      
+      var startIdx = this._list.scrollPosition;
+      var endIdx = Math.min(startIdx + maxVisible, listEnum.size());
+      
+      var totalEntries = listEnum.size();
+
+      for (var i = startIdx; i < endIdx; i++) {
+         var entry = listEnum.at(i);
+         
+         if (entry != undefined && !entry.skyui_iconProcessed && entry.skyui_itemDataProcessed) {
+            var chunkEnd = Math.min(i + batchSize, totalEntries);
+               
+            for (var j = i; j < chunkEnd; j++) {
+               var batchEntry = listEnum.at(j);
+               if (batchEntry != undefined && !batchEntry.skyui_iconProcessed && batchEntry.skyui_itemDataProcessed) {
+                  this.processEntry(batchEntry);
+                  batchEntry.skyui_iconProcessed = true;
+               }
+            }
+            break;
+         }
+      }
+   }
+   
    function processEntry(a_entryObject)
    {
       switch(a_entryObject.formType)

--- a/source/actionscript/ItemMenus/ItemcardDataExtender.as
+++ b/source/actionscript/ItemMenus/ItemcardDataExtender.as
@@ -3,6 +3,8 @@ class ItemcardDataExtender implements skyui.components.list.IListProcessor
    var _itemInfo;
    var _requestItemInfo;
    var _selectedIndex;
+   var _list;
+
    function ItemcardDataExtender()
    {
       this._requestItemInfo = function(a_target, a_index)
@@ -19,20 +21,47 @@ class ItemcardDataExtender implements skyui.components.list.IListProcessor
    }
    function processList(a_list)
    {
-      var _loc4_ = a_list.entryList;
-      var _loc3_ = 0;
-      var _loc2_;
-      while(_loc3_ < _loc4_.length)
+      if (this._list != a_list)
       {
-         _loc2_ = _loc4_[_loc3_];
-         if(!(_loc2_.skyui_itemDataProcessed || _loc2_.filterFlag == 0))
-         {
-            _loc2_.skyui_itemDataProcessed = true;
-            this.fixSKSEExtendedObject(_loc2_);
-            this._requestItemInfo.apply(a_list,[this,_loc3_]);
-            this.processEntry(_loc2_,this._itemInfo);
+         if (this._list)
+            this._list.removeEventListener("listUpdate", this, "onListUpdate");
+         
+         this._list = a_list;
+         this._list.addEventListener("listUpdate", this, "onListUpdate");
+      }
+   }
+
+   function onListUpdate(event: Object)
+   {
+      var listEnum = this._list.listEnumeration;
+      if (listEnum == undefined) return;
+
+      var maxVisible = this._list.maxListIndex;
+      var batchSize = maxVisible * 2;
+      
+      var startIdx = this._list.scrollPosition;
+      var endIdx = Math.min(startIdx + maxVisible, listEnum.size());
+      
+      var totalEntries = listEnum.size();
+      
+      for (var i = startIdx; i < endIdx; i++) {
+         var entry = listEnum.at(i);
+         
+         if (entry != undefined && !entry.skyui_itemDataProcessed && entry.filterFlag != 0) {
+               var chunkEnd = Math.min(i + batchSize, totalEntries);
+               
+            for (var j = i; j < chunkEnd; j++) {
+               var batchEntry = listEnum.at(j);
+               if (batchEntry != undefined && !batchEntry.skyui_itemDataProcessed) {
+                  batchEntry.skyui_itemDataProcessed = true;
+                  
+                  this.fixSKSEExtendedObject(batchEntry);
+                  this._requestItemInfo.apply(this._list, [this, batchEntry.itemIndex]);
+                  this.processEntry(batchEntry, this._itemInfo);
+               }
+            }
+            break;
          }
-         _loc3_ = _loc3_ + 1;
       }
    }
    function processEntry(a_entryObject, a_itemInfo)

--- a/source/actionscript/ItemMenus/ItemcardDataExtender.as
+++ b/source/actionscript/ItemMenus/ItemcardDataExtender.as
@@ -21,14 +21,10 @@ class ItemcardDataExtender implements skyui.components.list.IListProcessor
    }
    function processList(a_list)
    {
-      if (this._list != a_list)
-      {
-         if (this._list)
-            this._list.removeEventListener("listUpdate", this, "onListUpdate");
-         
-         this._list = a_list;
-         this._list.addEventListener("listUpdate", this, "onListUpdate");
-      }
+      if (this._list == a_list) return;
+      if (this._list) this._list.removeEventListener("listUpdate", this, "onListUpdate");
+      this._list = a_list;
+      if (this._list) this._list.addEventListener("listUpdate", this, "onListUpdate");
    }
 
    function onListUpdate(event: Object)
@@ -36,11 +32,11 @@ class ItemcardDataExtender implements skyui.components.list.IListProcessor
       var listEnum = this._list.listEnumeration;
       if (listEnum == undefined) return;
 
-      var maxVisible = this._list.maxListIndex;
-      var batchSize = maxVisible * 2;
+      var visibleCount = Math.max(1, this._list.maxListIndex + 1);
+      var batchSize = visibleCount * 2;
       
       var startIdx = this._list.scrollPosition;
-      var endIdx = Math.min(startIdx + maxVisible, listEnum.size());
+      var endIdx = Math.min(startIdx + visibleCount, listEnum.size());
       
       var totalEntries = listEnum.size();
       

--- a/source/actionscript/ItemMenus/MagicIconSetter.as
+++ b/source/actionscript/ItemMenus/MagicIconSetter.as
@@ -1,18 +1,52 @@
 class MagicIconSetter implements skyui.components.list.IListProcessor
 {
    var _noIconColors;
+   var _list;
+
    function MagicIconSetter(a_configAppearance)
    {
       this._noIconColors = a_configAppearance.icons.item.noColor;
    }
    function processList(a_list)
    {
-      var _loc3_ = a_list.entryList;
-      var _loc2_ = 0;
-      while(_loc2_ < _loc3_.length)
+      if (this._list != a_list)
       {
-         this.processEntry(_loc3_[_loc2_]);
-         _loc2_ = _loc2_ + 1;
+         if (this._list)
+            this._list.removeEventListener("listUpdate", this, "onListUpdate");
+            
+         this._list = a_list;
+         this._list.addEventListener("listUpdate", this, "onListUpdate");
+      }
+   }
+
+   function onListUpdate(event: Object)
+   {
+      var listEnum = this._list.listEnumeration;
+      if (listEnum == undefined) return;
+
+      var maxVisible = this._list.maxListIndex;
+      var batchSize = maxVisible * 2;
+      
+      var startIdx = this._list.scrollPosition;
+      var endIdx = Math.min(startIdx + maxVisible, listEnum.size());
+      
+      var totalEntries = listEnum.size();
+
+      for (var i = startIdx; i < endIdx; i++) {
+         var entry = listEnum.at(i);
+         
+         if (entry != undefined && !entry.skyui_iconProcessed && entry.skyui_itemDataProcessed) {
+               var chunkEnd = Math.min(i + batchSize, totalEntries);
+               
+               for (var j = i; j < chunkEnd; j++) {
+                  var batchEntry = listEnum.at(j);
+                  if (batchEntry != undefined && !batchEntry.skyui_iconProcessed && batchEntry.skyui_itemDataProcessed) {
+                     this.processEntry(batchEntry);
+                     batchEntry.skyui_iconProcessed = true;
+                  }
+               }
+               break;
+         }
       }
    }
    function processEntry(a_entryObject)

--- a/source/actionscript/ItemMenus/MagicIconSetter.as
+++ b/source/actionscript/ItemMenus/MagicIconSetter.as
@@ -9,14 +9,10 @@ class MagicIconSetter implements skyui.components.list.IListProcessor
    }
    function processList(a_list)
    {
-      if (this._list != a_list)
-      {
-         if (this._list)
-            this._list.removeEventListener("listUpdate", this, "onListUpdate");
-            
-         this._list = a_list;
-         this._list.addEventListener("listUpdate", this, "onListUpdate");
-      }
+      if (this._list == a_list) return;
+      if (this._list) this._list.removeEventListener("listUpdate", this, "onListUpdate");
+      this._list = a_list;
+      if (this._list) this._list.addEventListener("listUpdate", this, "onListUpdate");
    }
 
    function onListUpdate(event: Object)
@@ -24,11 +20,11 @@ class MagicIconSetter implements skyui.components.list.IListProcessor
       var listEnum = this._list.listEnumeration;
       if (listEnum == undefined) return;
 
-      var maxVisible = this._list.maxListIndex;
-      var batchSize = maxVisible * 2;
+      var visibleCount = Math.max(1, this._list.maxListIndex + 1);
+      var batchSize = visibleCount * 2;
       
       var startIdx = this._list.scrollPosition;
-      var endIdx = Math.min(startIdx + maxVisible, listEnum.size());
+      var endIdx = Math.min(startIdx + visibleCount, listEnum.size());
       
       var totalEntries = listEnum.size();
 


### PR DESCRIPTION
Experimenting with pagination. This reduces inventory opening time, but since InventoryLists are sorted by columns, processing all items is unavoidable. It's still necessary to retrieve all item information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Menus (inventory, crafting, magic, item cards) now process items incrementally in visible-window batches for smoother scrolling and reduced hitching.
  * Icon and data loading are deferred and batched as lists update, improving responsiveness with large collections.
  * List updates now reliably notify listeners so visible items refresh promptly when the view changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/doodlum/SkyUI-Community/pull/196)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->