### PR TITLE
feat(crafting-menu): add reactive state saving and restoring

### DIFF
--- a/source/actionscript/CraftingMenu/CraftingMenu.as
+++ b/source/actionscript/CraftingMenu/CraftingMenu.as
@@ -45,8 +45,6 @@ class CraftingMenu extends MovieClip
    var _lastScrollPos = -1;
    var _lastColIdx = -1;
    var _lastColState = -1;
-   var _indicesChangedTime = 0;
-   var _pendingSave = false;
 
    function CraftingMenu()
    {
@@ -567,7 +565,6 @@ class CraftingMenu extends MovieClip
       
       if (abForceSave == true)
       {
-         this._pendingSave = false;
          var _loc2_ = new Array();
          _loc2_.push(catIdx);
          _loc2_.push(itemIdx);
@@ -587,14 +584,6 @@ class CraftingMenu extends MovieClip
          this._lastScrollPos = scrollPos;
          this._lastColIdx = colIdx;
          this._lastColState = colState;
-         
-         this._indicesChangedTime = getTimer(); 
-         this._pendingSave = true;
-      }
-      
-      if (this._pendingSave && (getTimer() - this._indicesChangedTime >= 300))
-      {
-         this._pendingSave = false;
          
          var _loc3_ = new Array();
          _loc3_.push(catIdx);

--- a/source/actionscript/CraftingMenu/CraftingMenu.as
+++ b/source/actionscript/CraftingMenu/CraftingMenu.as
@@ -38,6 +38,16 @@ class CraftingMenu extends MovieClip
    var _platform = 0;
    var currentMenuType = "";
    var dbgIntvl = 0;
+
+   // Save Indices vars
+   var _lastCatIdx = -1;
+   var _lastItemIdx = -1;
+   var _lastScrollPos = -1;
+   var _lastColIdx = -1;
+   var _lastColState = -1;
+   var _indicesChangedTime = 0;
+   var _pendingSave = false;
+
    function CraftingMenu()
    {
       super();
@@ -113,6 +123,7 @@ class CraftingMenu extends MovieClip
       };
       this.bCanCraft = false;
       this.positionFixedElements();
+      this.RestoreIndices();
    }
    function SetPartitionedFilterMode(a_bPartitioned)
    {
@@ -541,5 +552,102 @@ class CraftingMenu extends MovieClip
       {
          this.onItemsListInputCatcherClick();
       }
+   }
+
+   function saveIndices(abForceSave)
+   {
+      if (this._subtypeName == undefined || this.CategoryList == undefined || this.ItemList == undefined || this.ItemList.layout == undefined)
+         return;
+
+      var catIdx = this.CategoryList.CategoriesList.selectedIndex;
+      var itemIdx = this.ItemList.selectedIndex;
+      var scrollPos = this.ItemList.scrollPosition;
+      var colIdx = this.ItemList.layout.activeColumnIndex;
+      var colState = this.ItemList.layout.activeColumnState;
+      
+      if (abForceSave == true)
+      {
+         this._pendingSave = false;
+         var _loc2_ = new Array();
+         _loc2_.push(catIdx);
+         _loc2_.push(itemIdx);
+         _loc2_.push(scrollPos);
+         _loc2_.push(colIdx);
+         _loc2_.push(colState);
+         skse.StoreIndices(this._subtypeName, _loc2_);
+         return;
+      }
+      
+      if (this._lastCatIdx != catIdx || this._lastItemIdx != itemIdx || 
+          this._lastScrollPos != scrollPos || this._lastColIdx != colIdx || 
+          this._lastColState != colState)
+      {
+         this._lastCatIdx = catIdx;
+         this._lastItemIdx = itemIdx;
+         this._lastScrollPos = scrollPos;
+         this._lastColIdx = colIdx;
+         this._lastColState = colState;
+         
+         this._indicesChangedTime = getTimer(); 
+         this._pendingSave = true;
+      }
+      
+      if (this._pendingSave && (getTimer() - this._indicesChangedTime >= 300))
+      {
+         this._pendingSave = false;
+         
+         var _loc3_ = new Array();
+         _loc3_.push(catIdx);
+         _loc3_.push(itemIdx);
+         _loc3_.push(scrollPos);
+         _loc3_.push(colIdx);
+         _loc3_.push(colState);
+         skse.StoreIndices(this._subtypeName, _loc3_);
+      }
+   }
+
+   function RestoreIndices()
+   {
+      var _loc2_ = new Array();
+      skse.LoadIndices(this._subtypeName,_loc2_);
+      var _loc4_ = this.CategoryList.CategoriesList;
+      var _loc3_ = this.ItemList;
+      if(_loc2_.length == 5 && _loc2_[0] != -1)
+      {
+         _loc4_.listState.restoredItem = _loc2_[0];
+         _loc4_.onUnsuspend = function()
+         {
+            this.onItemPress(this.listState.restoredItem,0);
+            delete this.onUnsuspend;
+         };
+         _loc3_.listState.restoredScrollPosition = _loc2_[2];
+         _loc3_.listState.restoredSelectedIndex = _loc2_[1];
+         _loc3_.listState.restoredActiveColumnIndex = _loc2_[3];
+         _loc3_.listState.restoredActiveColumnState = _loc2_[4];
+         _loc3_.onUnsuspend = function()
+         {
+            this.onInvalidate = function()
+            {
+               this.scrollPosition = this.listState.restoredScrollPosition;
+               this.selectedIndex = this.listState.restoredSelectedIndex;
+               delete this.onInvalidate;
+            };
+            this.layout.restoreColumnState(this.listState.restoredActiveColumnIndex,this.listState.restoredActiveColumnState);
+            delete this.onUnsuspend;
+         };
+      }
+      else
+      {
+         _loc4_.onUnsuspend = function()
+         {
+            this.onItemPress(0,0);
+            delete this.onUnsuspend;
+         };
+      }
+   }
+
+   function onEnterFrame()
+   {
+      this.saveIndices(false);
    }
 }


### PR DESCRIPTION
Resolve #197.

This PR addresses an issue in the `CraftingMenu` where the menu state was not being preserved. The `InventoryMenu` utilizes a dedicated game-provided delegate for saving its state; however, the `CraftingMenu` is unique and lacks this delegate.
Consequently, a polling-based state-saving model has been implemented to work around difficulties in intercepting the `CraftingMenu` exit event. Since the Esc and Tab keys trigger prematurely, it is impossible to employ the standard state-saving model via a direct call to `saveIndices()`; as a result, attempts to intercept these specific key presses simply fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crafting menu state is now persisted. Your previously selected categories and items, scroll positions, and column layouts are automatically saved and restored when you reopen the menu. This enhancement ensures you can seamlessly resume your crafting activities from where you left off, eliminating the need to re-navigate through menus.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/doodlum/SkyUI-Community/pull/198)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->