### PR TITLE
fix(start-menu): buttons broke after the StartMenu update

### DIFF
--- a/source/actionscript/Vanilla/SaveLoadPanel.as
+++ b/source/actionscript/Vanilla/SaveLoadPanel.as
@@ -4,6 +4,7 @@ class SaveLoadPanel extends MovieClip
    var BackMouseButton;
    var CharacterSelectionHint_mc;
    var List_mc;
+   var PS3Switch;
    var PlayerInfoText;
    var SaveLoadList_mc;
    var ScreenShotRect_mc;
@@ -88,9 +89,11 @@ class SaveLoadPanel extends MovieClip
    {
       return this.iPlatform;
    }
-   function set platform(aiPlatform)
+   function SetPlatform(aiPlatform, abPS3Switch)
    {
+      trace("SaveLoadPanel::SetPlatform " + aiPlatform.toString() + ", abPS3Switch = " + abPS3Switch.toString());
       this.iPlatform = aiPlatform;
+      this.PS3Switch = abPS3Switch;
       var _loc2_;
       if(this.iPlatform == SaveLoadPanel.CONTROLLER_PC)
       {
@@ -103,8 +106,8 @@ class SaveLoadPanel extends MovieClip
       }
       else
       {
-         this.BackGamepadButton.SetPlatform(this.iPlatform);
-         this.SelectGamepadButton.SetPlatform(this.iPlatform);
+         this.BackGamepadButton.SetPlatform(this.iPlatform,this.PS3Switch);
+         this.SelectGamepadButton.SetPlatform(this.iPlatform,this.PS3Switch);
       }
       this.BackMouseButton._visible = this.SelectMouseButton._visible = this.iPlatform == SaveLoadPanel.CONTROLLER_PC;
       this.BackGamepadButton._visible = this.SelectGamepadButton._visible = this.iPlatform != SaveLoadPanel.CONTROLLER_PC;


### PR DESCRIPTION
Properly fixed a regression following the `StartMenu` update. The code in `SaveLoadPanel.as` has been updated to version 1170.
https://github.com/doodlum/SkyUI-Community/pull/174/changes#diff-a82db40ca89516e80c5ebb719d3122dd887d9eb95c701ef0975cafe0e0720b3dL824

<img width="697" height="319" alt="image" src="https://github.com/user-attachments/assets/513af611-17d7-4d2b-abcc-82e757a6fb84" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced the Save/Load panel's platform and gamepad configuration to better handle device-specific settings, particularly for improved gamepad button UI behavior across different platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/doodlum/SkyUI-Community/pull/199)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->