### PR TITLE
refactor(item-menus): restore scripts from decompiled to source version

### DIFF
--- a/source/actionscript/CraftingMenu/CraftingDataSetter.as
+++ b/source/actionscript/CraftingMenu/CraftingDataSetter.as
@@ -1,1267 +1,1398 @@
 class CraftingDataSetter implements skyui.components.list.IListProcessor
 {
-   function CraftingDataSetter()
-   {
-      super();
-   }
-   function processList(a_list)
-   {
-      var _loc4_ = a_list.entryList;
-      var _loc3_ = 0;
-      var _loc2_;
-      while(_loc3_ < _loc4_.length)
-      {
-         _loc2_ = _loc4_[_loc3_];
-         if(!_loc2_.skyui_itemDataProcessed)
-         {
-            _loc2_.skyui_itemDataProcessed = true;
-            this.fixSKSEExtendedObject(_loc2_);
-            this.processEntry(_loc2_);
-         }
-         _loc3_ = _loc3_ + 1;
-      }
-   }
-   function processEntry(a_entryObject)
-   {
-      a_entryObject.baseId = a_entryObject.formId & 0xFFFFFF;
-      a_entryObject.eslId = a_entryObject.formId & 0xFFF;
-      a_entryObject.isEquipped = a_entryObject.equipState > 0;
-      a_entryObject.infoValue = a_entryObject.value <= 0 ? null : Math.round(a_entryObject.value * 100) / 100;
-      a_entryObject.infoWeight = a_entryObject.weight <= 0 ? null : Math.round(a_entryObject.weight * 100) / 100;
-      a_entryObject.infoValueWeight = !(a_entryObject.weight > 0 && a_entryObject.value > 0) ? null : Math.round(a_entryObject.value / a_entryObject.weight * 100) / 100;
-      switch(a_entryObject.formType)
-      {
-         case skyui.defines.Form.TYPE_SCROLLITEM:
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Scroll");
-            a_entryObject.duration = a_entryObject.duration <= 0 ? null : Math.round(a_entryObject.duration * 100) / 100;
-            a_entryObject.magnitude = a_entryObject.magnitude <= 0 ? null : Math.round(a_entryObject.magnitude * 100) / 100;
-            break;
-         case skyui.defines.Form.TYPE_ARMOR:
-            a_entryObject.infoArmor = a_entryObject.armor <= 0 ? null : Math.round(a_entryObject.armor * 100) / 100;
-            this.processArmorClass(a_entryObject);
-            this.processArmorPartMask(a_entryObject);
-            this.processMaterialKeywords(a_entryObject);
-            this.processArmorOther(a_entryObject);
-            this.processArmorBaseId(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_BOOK:
-            this.processBookType(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_INGREDIENT:
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingredient");
-            break;
-         case skyui.defines.Form.TYPE_LIGHT:
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Torch");
-            break;
-         case skyui.defines.Form.TYPE_MISC:
-            this.processMiscType(a_entryObject);
-            this.processMiscBaseId(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_WEAPON:
-            a_entryObject.infoDamage = a_entryObject.damage <= 0 ? null : Math.round(a_entryObject.damage * 100) / 100;
-            this.processWeaponType(a_entryObject);
-            this.processMaterialKeywords(a_entryObject);
-            this.processWeaponBaseId(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_AMMO:
-            a_entryObject.infoDamage = a_entryObject.damage <= 0 ? null : Math.round(a_entryObject.damage * 100) / 100;
-            this.processAmmoType(a_entryObject);
-            this.processMaterialKeywords(a_entryObject);
-            this.processAmmoBaseId(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_KEY:
-            this.processKeyType(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_POTION:
-            a_entryObject.duration = a_entryObject.duration <= 0 ? null : Math.round(a_entryObject.duration * 100) / 100;
-            a_entryObject.magnitude = a_entryObject.magnitude <= 0 ? null : Math.round(a_entryObject.magnitude * 100) / 100;
-            this.processPotionType(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_SOULGEM:
-            this.processSoulGemType(a_entryObject);
-            this.processSoulGemStatus(a_entryObject);
-            this.processSoulGemBaseId(a_entryObject);
-         default:
-            return;
-      }
-   }
-   function processArmorClass(a_entryObject)
-   {
-      if(a_entryObject.weightClass == skyui.defines.Armor.WEIGHT_NONE)
-      {
-         a_entryObject.weightClass = null;
-      }
-      a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Other");
-      switch(a_entryObject.weightClass)
-      {
-         case skyui.defines.Armor.WEIGHT_LIGHT:
-            a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Light");
-            return;
-         case skyui.defines.Armor.WEIGHT_HEAVY:
-            a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Heavy");
-            return;
-         default:
-            if(a_entryObject.keywords == undefined)
-            {
-               return;
-            }
-            if(a_entryObject.keywords.VendorItemClothing != undefined)
-            {
-               a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_CLOTHING;
-               a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Clothing");
-               return;
-            }
-            if(a_entryObject.keywords.VendorItemJewelry != undefined)
-            {
-               a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
-               a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
-               return;
-            }
-            return;
-      }
-   }
-   function processMaterialKeywords(a_entryObject)
-   {
-      a_entryObject.material = null;
-      a_entryObject.materialDisplay = skyui.util.Translator.translate("$Other");
-      if(a_entryObject.keywords == undefined)
-      {
-         return undefined;
-      }
+  /* INITIALIZATION */
 
-      if(a_entryObject.keywords.ArmorMaterialDaedric != undefined || a_entryObject.keywords.WeapMaterialDaedric != undefined || a_entryObject.keywords.ccBGSSSE025_ArmorMaterialDark != undefined || a_entryObject.keywords.ccBGSSSE025_WeapMaterialDark != undefined || a_entryObject.keywords.ccBGSSSE025_ArmorMaterialGolden != undefined || a_entryObject.keywords.ccBGSSSE025_WeapMaterialGolden != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.DAEDRIC;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Daedric");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialDragonplate != undefined || a_entryObject.keywords.ArmorMaterialDragonscale != undefined || a_entryObject.keywords.DLC1WeapMaterialDragonbone != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.DRAGON;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dragon");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialDwarven != undefined || a_entryObject.keywords.WeapMaterialDwarven != undefined || a_entryObject.keywords.DLC1LD_CraftingMaterialAetherium != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.DWARVEN;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialEbony != undefined || a_entryObject.keywords.WeapMaterialEbony != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.EBONY;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ebony");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialElven != undefined || a_entryObject.keywords.WeapMaterialElven != undefined || a_entryObject.keywords.ArmorMaterialElvenGilded != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.ELVEN;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialGlass != undefined || a_entryObject.keywords.WeapMaterialGlass != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.GLASS;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Glass");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialHide != undefined || a_entryObject.keywords.ArmorMaterialScaled != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.HIDE;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Hide");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialStormcloak != undefined || a_entryObject.keywords.ArmorMaterialBearStormcloak != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.STORMCLOAK;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Stormcloak");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialImperialHeavy != undefined || a_entryObject.keywords.ArmorMaterialImperialLight != undefined || a_entryObject.keywords.WeapMaterialImperial != undefined || a_entryObject.keywords.ArmorMaterialImperialStudded != undefined || a_entryObject.keywords.ArmorMaterialStudded != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.IMPERIAL;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Imperial");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialIron != undefined || a_entryObject.keywords.WeapMaterialIron != undefined || a_entryObject.keywords.ArmorMaterialIronBanded != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.IRON;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialLeather != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.LEATHER;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Leather");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialOrcish != undefined || a_entryObject.keywords.WeapMaterialOrcish != undefined || a_entryObject.keywords.ccBGSSSE055_ArmorMaterialOrcishLight != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.ORCISH;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Orcish");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialSteel != undefined || a_entryObject.keywords.WeapMaterialSteel != undefined || a_entryObject.keywords.ArmorMaterialSteelPlate != undefined || a_entryObject.keywords.WeapMaterialDraugr != undefined || a_entryObject.keywords.WeapMaterialDraugrHoned != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.STEEL;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
-      }
-      else if(a_entryObject.keywords.WeapMaterialSilver != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.SILVER;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Silver");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialFalmer != undefined || a_entryObject.keywords.DLC1ArmorMaterialFalmerHardened != undefined || a_entryObject.keywords.DLC1ArmorMaterielFalmerHeavy != undefined || a_entryObject.keywords.DLC1ArmorMaterielFalmerHeavyOriginal != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.FALMER;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
-      }
-      else if(a_entryObject.keywords.DLC2ArmorMaterialBonemoldHeavy != undefined || a_entryObject.keywords.DLC2ArmorMaterialBonemoldLight != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.BONEMOLD;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Bonemold");
-      }
-      else if(a_entryObject.keywords.DLC2ArmorMaterialChitinHeavy != undefined || a_entryObject.keywords.DLC2ArmorMaterialChitinLight != undefined || a_entryObject.keywords.DLC2ArmorMaterialMoragTong != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.CHITIN;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Chitin");
-      }
-      else if(a_entryObject.keywords.DLC2ArmorMaterialNordicHeavy != undefined || a_entryObject.keywords.DLC2ArmorMaterialNordicLight != undefined || a_entryObject.keywords.DLC2WeaponMaterialNordic != undefined || a_entryObject.keywords.ccEDHSSE001_NordicJewelryKeyword != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.NORDIC;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Nordic");
-      }
-      else if(a_entryObject.keywords.DLC2ArmorMaterialStalhrimHeavy != undefined || a_entryObject.keywords.DLC2ArmorMaterialStalhrimLight != undefined || a_entryObject.keywords.DLC2WeaponMaterialStalhrim != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.STALHRIM;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Stalhrim");
-      }
-      else if(a_entryObject.keywords.WeapMaterialFalmer != undefined || a_entryObject.keywords.WeapMaterialFalmerHoned != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.FALMER;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
-      }
-      else if(a_entryObject.keywords.ccASVSSE001_ArmorOrdinator != undefined || a_entryObject.keywords.ccASVSSE001_ArmorOrdinatorIndoril != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.ORDINATOR;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ordinator");
-      }
-      else if(a_entryObject.keywords.ccBGSSSE025_ArmorMaterialAmber != undefined || a_entryObject.keywords.ccBGSSSE025_WeapMaterialAmber != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.AMBER;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Amber");
-      }
-      else if(a_entryObject.keywords.ccBGSSSE025_ArmorMaterialMadness != undefined || a_entryObject.keywords.ccBGSSSE025_WeapMaterialMadness != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.MADNESS;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Madness");
-      }
-      else if(a_entryObject.keywords.WeapMaterialWood != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.WOOD;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Wood");
-      }
-   }
-   function processWeaponType(a_entryObject)
-   {
-      a_entryObject.subType = null;
-      a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Weapon");
-      switch(a_entryObject.weaponType)
-      {
-         case skyui.defines.Weapon.ANIM_HANDTOHANDMELEE:
-         case skyui.defines.Weapon.ANIM_H2H:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_MELEE;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Melee");
-            break;
-         case skyui.defines.Weapon.ANIM_ONEHANDSWORD:
-         case skyui.defines.Weapon.ANIM_1HS:
-            if(a_entryObject.keywords != undefined && a_entryObject.keywords.ccBGSSSE001_FishingPoleKW != undefined)
-            {
-               a_entryObject.subType = skyui.defines.Weapon.TYPE_FISHINGROD;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$FishingRod");
-               return;
-            }
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_SWORD;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Sword");
-            break;
-         case skyui.defines.Weapon.ANIM_ONEHANDDAGGER:
-         case skyui.defines.Weapon.ANIM_1HD:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_DAGGER;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Dagger");
-            break;
-         case skyui.defines.Weapon.ANIM_ONEHANDAXE:
-         case skyui.defines.Weapon.ANIM_1HA:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_WARAXE;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$War Axe");
-            break;
-         case skyui.defines.Weapon.ANIM_ONEHANDMACE:
-         case skyui.defines.Weapon.ANIM_1HM:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_MACE;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Mace");
-            break;
-         case skyui.defines.Weapon.ANIM_TWOHANDSWORD:
-         case skyui.defines.Weapon.ANIM_2HS:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_GREATSWORD;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Greatsword");
-            break;
-         case skyui.defines.Weapon.ANIM_TWOHANDAXE:
-         case skyui.defines.Weapon.ANIM_2HA:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_BATTLEAXE;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Battleaxe");
-            if(a_entryObject.keywords != undefined && a_entryObject.keywords.WeapTypeWarhammer != undefined)
-            {
-               a_entryObject.subType = skyui.defines.Weapon.TYPE_WARHAMMER;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Warhammer");
-            }
-            break;
-         case skyui.defines.Weapon.ANIM_BOW:
-         case skyui.defines.Weapon.ANIM_BOW2:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_BOW;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Bow");
-            break;
-         case skyui.defines.Weapon.ANIM_STAFF:
-         case skyui.defines.Weapon.ANIM_STAFF2:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_STAFF;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Staff");
-            break;
-         case skyui.defines.Weapon.ANIM_CROSSBOW:
-         case skyui.defines.Weapon.ANIM_CBOW:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_CROSSBOW;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Crossbow");
-         default:
-            return;
-      }
-   }
-   function processWeaponBaseId(a_entryObject)
-   {
-      switch(a_entryObject.formId >>> 24)
-      {
-         case 0x00:
-            switch(a_entryObject.baseId)
-            {
-               case skyui.defines.Form.FORMID_WEAPPICKAXE:
-               case skyui.defines.Form.FORMID_SSDROCKSPLINTERPICKAXE:
-               case skyui.defines.Form.FORMID_DUNVOLUNRUUDPICKAXE:
-                  a_entryObject.subType = skyui.defines.Weapon.TYPE_PICKAXE;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Pickaxe");
-                  break;
-               case skyui.defines.Form.FORMID_AXE01:
-               case skyui.defines.Form.FORMID_DUNHALTEDSTREAMPOACHERSAXE:
-                  a_entryObject.subType = skyui.defines.Weapon.TYPE_WOODAXE;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Wood Axe");
-                  break;
-               case skyui.defines.Form.FORMID_LONGBOW:
-               case skyui.defines.Form.FORMID_HUNTINGBOW:
-               case skyui.defines.Form.FORMID_DRAVINSBOW:
-                  a_entryObject.material = skyui.defines.Material.WOOD;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Wood");
-                  break;
-               case skyui.defines.Form.FORMID_FORSWORNAXE:
-               case skyui.defines.Form.FORMID_FORSWORNBOW:
-               case skyui.defines.Form.FORMID_FORSWORNSTAFF:
-               case skyui.defines.Form.FORMID_FORSWORNSWORD:
-                  break;
-            }
-            return;
-         case 0x04:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_DLC2PICKAXE1:
-               case skyui.defines.Form.FORMID_DLC2PICKAXE2:
-               case skyui.defines.Form.FORMID_DLC2PICKAXE3:
-                  a_entryObject.subType = skyui.defines.Weapon.TYPE_PICKAXE;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Pickaxe");
-                  a_entryObject.material = skyui.defines.Material.STEEL;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
-                  break;
-            }
-            return;
-         default:
-            return;
-      }
-   }
-   function processArmorPartMask(a_entryObject)
-   {
-      if(a_entryObject.partMask == undefined)
-      {
-         return undefined;
-      }
-      var _loc2_ = 0;
-      while(_loc2_ < skyui.defines.Armor.PARTMASK_PRECEDENCE.length)
-      {
-         if(a_entryObject.partMask & skyui.defines.Armor.PARTMASK_PRECEDENCE[_loc2_])
-         {
-            a_entryObject.mainPartMask = skyui.defines.Armor.PARTMASK_PRECEDENCE[_loc2_];
-            break;
-         }
-         _loc2_ = _loc2_ + 1;
-      }
-      if(a_entryObject.mainPartMask == undefined)
-      {
-         return undefined;
-      }
-      switch(a_entryObject.mainPartMask)
-      {
-         case skyui.defines.Armor.PARTMASK_HEAD:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_HEAD;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Head");
-            return;
-         case skyui.defines.Armor.PARTMASK_HAIR:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_HAIR;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Head");
-            return;
-         case skyui.defines.Armor.PARTMASK_LONGHAIR:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_LONGHAIR;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Head");
-            return;
-         case skyui.defines.Armor.PARTMASK_BODY:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_BODY;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Body");
-            return;
-         case skyui.defines.Armor.PARTMASK_HANDS:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_HANDS;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Hands");
-            return;
-         case skyui.defines.Armor.PARTMASK_FOREARMS:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_FOREARMS;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Forearms");
-            return;
-         case skyui.defines.Armor.PARTMASK_AMULET:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_AMULET;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Amulet");
-            return;
-         case skyui.defines.Armor.PARTMASK_RING:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_RING;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ring");
-            return;
-         case skyui.defines.Armor.PARTMASK_FEET:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_FEET;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Feet");
-            return;
-         case skyui.defines.Armor.PARTMASK_CALVES:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_CALVES;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Calves");
-            return;
-         case skyui.defines.Armor.PARTMASK_SHIELD:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_SHIELD;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Shield");
-            return;
-         case skyui.defines.Armor.PARTMASK_CIRCLET:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_CIRCLET;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Circlet");
-            return;
-         case skyui.defines.Armor.PARTMASK_EARS:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_EARS;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ears");
-            return;
-         case skyui.defines.Armor.PARTMASK_TAIL:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_TAIL;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Tail");
-            return;
-         case skyui.defines.Armor.PARTMASK_CLOAK:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_CLOAK;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ClothingCloak");
-            return;
-         case skyui.defines.Armor.PARTMASK_BACKPACK:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_BACKPACK;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Backpack");
-            return;
-         default:
-            a_entryObject.subType = a_entryObject.mainPartMask;
-            return;
-      }
-   }
-   function processArmorOther(a_entryObject)
-   {
-      if(a_entryObject.weightClass != null)
-      {
-         return undefined;
-      }
-      switch(a_entryObject.mainPartMask)
-      {
-         case skyui.defines.Armor.PARTMASK_HEAD:
-         case skyui.defines.Armor.PARTMASK_HAIR:
-         case skyui.defines.Armor.PARTMASK_LONGHAIR:
-         case skyui.defines.Armor.PARTMASK_BODY:
-         case skyui.defines.Armor.PARTMASK_HANDS:
-         case skyui.defines.Armor.PARTMASK_FOREARMS:
-         case skyui.defines.Armor.PARTMASK_FEET:
-         case skyui.defines.Armor.PARTMASK_CALVES:
-         case skyui.defines.Armor.PARTMASK_SHIELD:
-         case skyui.defines.Armor.PARTMASK_TAIL:
-         case skyui.defines.Armor.PARTMASK_BACKPACK:
-            a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_CLOTHING;
-            a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Clothing");
-            break;
-         case skyui.defines.Armor.PARTMASK_AMULET:
-         case skyui.defines.Armor.PARTMASK_RING:
-         case skyui.defines.Armor.PARTMASK_CIRCLET:
-         case skyui.defines.Armor.PARTMASK_EARS:
-            a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
-            a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
-         default:
-            return;
-      }
-   }
-   function processArmorBaseId(a_entryObject)
-   {
-      switch(a_entryObject.formId >>> 24)
-      {
-         case 0x00:
-            if(a_entryObject.baseId == skyui.defines.Form.FORMID_CLOTHESWEDDINGWREATH)
-            {
-               a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
-               a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
-            }
-            return;
-         case 0x02:
-            if(a_entryObject.formId == skyui.defines.Form.FORMID_DLC1CLOTHESVAMPIRELORDARMOR)
-            {
-               a_entryObject.subType = skyui.defines.Armor.EQUIP_BODY;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Body");
-            }
-            return;
-         default:
-            if(a_entryObject.baseId == skyui.defines.Form.BASEID_CC025ADVDSGSRING)
-            {
-               a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
-               a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
-               a_entryObject.subType = skyui.defines.Armor.EQUIP_RING;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ring");
-            }
-            return;
-      }
-   }
-   function processBookType(a_entryObject)
-   {
-      a_entryObject.subType = skyui.defines.Item.OTHER;
-      a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Book");
-      a_entryObject.isRead = (a_entryObject.flags & skyui.defines.Item.BOOKFLAG_READ) != 0;
-      if(a_entryObject.bookType == skyui.defines.Item.BOOKTYPE_NOTE)
-      {
-         a_entryObject.subType = skyui.defines.Item.BOOK_NOTE;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Note");
-      }
-      if(a_entryObject.keywords == undefined)
-      {
-         return undefined;
-      }
-      if(a_entryObject.keywords.VendorItemRecipe != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.BOOK_RECIPE;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Recipe");
-      }
-      else if(a_entryObject.keywords.VendorItemSpellTome != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.BOOK_SPELLTOME;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Spell Tome");
-      }
-   }
-   function processAmmoType(a_entryObject)
-   {
-      if((a_entryObject.flags & skyui.defines.Weapon.AMMOFLAG_NONBOLT) != 0)
-      {
-         a_entryObject.subType = skyui.defines.Weapon.AMMO_ARROW;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Arrow");
-      }
-      else
-      {
-         a_entryObject.subType = skyui.defines.Weapon.AMMO_BOLT;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Bolt");
-      }
-   }
-   function processAmmoBaseId(a_entryObject)
-   {
-      switch(a_entryObject.formId >>> 24)
-      {
-         case 0x00:
-            switch(a_entryObject.baseId)
-            {
-               case skyui.defines.Form.FORMID_DAEDRICARROW:
-                  a_entryObject.material = skyui.defines.Material.DAEDRIC;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Daedric");
-                  break;
-               case skyui.defines.Form.FORMID_EBONYARROW:
-                  a_entryObject.material = skyui.defines.Material.EBONY;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ebony");
-                  break;
-               case skyui.defines.Form.FORMID_GLASSARROW:
-                  a_entryObject.material = skyui.defines.Material.GLASS;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Glass");
-                  break;
-               case skyui.defines.Form.FORMID_ELVENARROW:
-                  a_entryObject.material = skyui.defines.Material.ELVEN;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
-                  break;
-               case skyui.defines.Form.FORMID_DWARVENARROW:
-               case skyui.defines.Form.FORMID_DWARVENSPHEREARROW:
-               case skyui.defines.Form.FORMID_DWARVENSPHEREBOLT01:
-               case skyui.defines.Form.FORMID_DWARVENSPHEREBOLT02:
-                  a_entryObject.material = skyui.defines.Material.DWARVEN;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
-                  break;
-               case skyui.defines.Form.FORMID_ORCISHARROW:
-                  a_entryObject.material = skyui.defines.Material.ORCISH;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Orcish");
-                  break;
-               case skyui.defines.Form.FORMID_NORDHEROARROW:
-                  a_entryObject.material = skyui.defines.Material.NORDIC;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Nordic");
-                  break;
-               case skyui.defines.Form.FORMID_FALMERARROW:
-                  a_entryObject.material = skyui.defines.Material.FALMER;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
-                  break;
-               case skyui.defines.Form.FORMID_STEELARROW:
-               case skyui.defines.Form.FORMID_MQ101STEELARROW:
-               case skyui.defines.Form.FORMID_DRAUGRARROW:
-               case skyui.defines.Form.FORMID_DUNGEIRMUNDSIGDISARROWSILLUSION:
-                  a_entryObject.material = skyui.defines.Material.STEEL;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
-                  break;
-               case skyui.defines.Form.FORMID_IRONARROW:
-               case skyui.defines.Form.FORMID_CWARROW:
-               case skyui.defines.Form.FORMID_CWARROWSHORT:
-               case skyui.defines.Form.FORMID_TRAPDART:
-               case skyui.defines.Form.FORMID_DUNARCHERPRATICEARROW:
-               case skyui.defines.Form.FORMID_FOLLOWERIRONARROW:
-                  a_entryObject.material = skyui.defines.Material.IRON;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
-            }
-            return;
-         case 0x02:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_DLC1ELVENARROWBLESSED:
-               case skyui.defines.Form.FORMID_DLC1ELVENARROWBLOOD:
-                  a_entryObject.material = skyui.defines.Material.ELVEN;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
-                  break;
-               case skyui.defines.Form.FORMID_TESTDLC1BOLT:
-                  a_entryObject.material = skyui.defines.Material.IRON;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
-            }
-            return;
-         case 0x04:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_DLC2DWARVENBALLISTABOLT:
-                  a_entryObject.material = skyui.defines.Material.DWARVEN;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2RIEKLINGSPEARTHROWN:
-                  a_entryObject.material = skyui.defines.Material.WOOD;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Wood");
-            }
-            return;
-         default:
-            return;
-      }
-   }
-   function processKeyType(a_entryObject)
-   {
-      a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Key");
-      if(a_entryObject.infoValue <= 0)
-      {
-         a_entryObject.infoValue = null;
-      }
-      if(a_entryObject.infoValue <= 0)
-      {
-         a_entryObject.infoValue = null;
-      }
-   }
-   function processPotionType(a_entryObject)
-   {
-      a_entryObject.subType = skyui.defines.Item.POTION_POTION;
-      a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Potion");
-      if((a_entryObject.flags & skyui.defines.Item.ALCHFLAG_FOOD) != 0)
-      {
-         a_entryObject.subType = skyui.defines.Item.POTION_FOOD;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Food");
-         if(a_entryObject.useSound.formId != undefined && a_entryObject.useSound.formId == skyui.defines.Form.FORMID_ITMPotionUse)
-         {
-            a_entryObject.subType = skyui.defines.Item.POTION_DRINK;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Drink");
-         }
-      }
-      else if((a_entryObject.flags & skyui.defines.Item.ALCHFLAG_POISON) != 0)
-      {
-         a_entryObject.subType = skyui.defines.Item.POTION_POISON;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Poison");
-      }
-      else
-      {
-         switch(a_entryObject.actorValue)
-         {
-            case skyui.defines.Actor.AV_HEALTH:
-               a_entryObject.subType = skyui.defines.Item.POTION_HEALTH;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
-               break;
-            case skyui.defines.Actor.AV_MAGICKA:
-               a_entryObject.subType = skyui.defines.Item.POTION_MAGICKA;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
-               break;
-            case skyui.defines.Actor.AV_STAMINA:
-               a_entryObject.subType = skyui.defines.Item.POTION_STAMINA;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
-               break;
-            case skyui.defines.Actor.AV_HEALRATE:
-               a_entryObject.subType = skyui.defines.Item.POTION_HEALRATE;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
-               break;
-            case skyui.defines.Actor.AV_MAGICKARATE:
-               a_entryObject.subType = skyui.defines.Item.POTION_MAGICKARATE;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
-               break;
-            case skyui.defines.Actor.AV_STAMINARATE:
-               a_entryObject.subType = skyui.defines.Item.POTION_STAMINARATE;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
-               break;
-            case skyui.defines.Actor.AV_HEALRATEMULT:
-               a_entryObject.subType = skyui.defines.Item.POTION_HEALRATEMULT;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
-               break;
-            case skyui.defines.Actor.AV_MAGICKARATEMULT:
-               a_entryObject.subType = skyui.defines.Item.POTION_MAGICKARATEMULT;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
-               break;
-            case skyui.defines.Actor.AV_STAMINARATEMULT:
-               a_entryObject.subType = skyui.defines.Item.POTION_STAMINARATEMULT;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
-               break;
-            case skyui.defines.Actor.AV_FIRERESIST:
-               a_entryObject.subType = skyui.defines.Item.POTION_FIRERESIST;
-               break;
-            case skyui.defines.Actor.AV_ELECTRICRESIST:
-               a_entryObject.subType = skyui.defines.Item.POTION_ELECTRICRESIST;
-               break;
-            case skyui.defines.Actor.AV_FROSTRESIST:
-               a_entryObject.subType = skyui.defines.Item.POTION_FROSTRESIST;
-            default:
-               return;
-         }
-      }
-   }
-   function processSoulGemType(a_entryObject)
-   {
-      a_entryObject.subType = skyui.defines.Item.OTHER;
-      a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Soul Gem");
-      if(a_entryObject.gemSize != undefined && a_entryObject.gemSize != skyui.defines.Item.SOULGEM_NONE)
-      {
-         a_entryObject.subType = a_entryObject.gemSize;
-      }
-   }
-   function processSoulGemStatus(a_entryObject)
-   {
-      if(a_entryObject.gemSize == undefined || a_entryObject.soulSize == undefined || a_entryObject.soulSize == skyui.defines.Item.SOULGEM_NONE)
-      {
-         a_entryObject.status = skyui.defines.Item.SOULGEMSTATUS_EMPTY;
-      }
-      else if(a_entryObject.soulSize >= a_entryObject.gemSize)
-      {
-         a_entryObject.status = skyui.defines.Item.SOULGEMSTATUS_FULL;
-      }
-      else
-      {
-         a_entryObject.status = skyui.defines.Item.SOULGEMSTATUS_PARTIAL;
-      }
-      if(a_entryObject.soulSize != undefined)
-      {
-         switch(a_entryObject.soulSize)
-         {
-            case skyui.defines.Item.SOULGEM_NONE:
-               a_entryObject.soulSizeDisplay = null;
-               break;
-            case skyui.defines.Item.SOULGEM_PETTY:
-               a_entryObject.soulSizeDisplay = "$Petty";
-               break;
-            case skyui.defines.Item.SOULGEM_LESSER:
-               a_entryObject.soulSizeDisplay = "$Lesser";
-               break;
-            case skyui.defines.Item.SOULGEM_COMMON:
-               a_entryObject.soulSizeDisplay = "$Common";
-               break;
-            case skyui.defines.Item.SOULGEM_GREATER:
-               a_entryObject.soulSizeDisplay = "$Greater";
-               break;
-            case skyui.defines.Item.SOULGEM_GRAND:
-            case skyui.defines.Item.SOULGEM_AZURA:
-               a_entryObject.soulSizeDisplay = "$Grand";
-            default:
-               return;
-         }
-      }
-   }
-   function processSoulGemBaseId(a_entryObject)
-   {
-      switch(a_entryObject.baseId)
-      {
-         case skyui.defines.Form.FORMID_DA01SOULGEMBLACKSTAR:
-         case skyui.defines.Form.FORMID_DA01SOULGEMAZURASSTAR:
-            a_entryObject.subType = skyui.defines.Item.SOULGEM_AZURA;
-            return;
-         case skyui.defines.Form.BASEID_CC025SOULTOMATO1:
-         case skyui.defines.Form.BASEID_CC025SOULTOMATO2:
-            a_entryObject.subType = skyui.defines.Item.SOULGEM_SOULTOMATO;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$SoulTomato");
-            return;
-         default:
-            return;
-      }
-   }
-   function processMiscType(a_entryObject)
-   {
-      a_entryObject.subType = skyui.defines.Item.OTHER;
-      a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Misc");
-      if(a_entryObject.keywords == undefined)
-      {
-         return undefined;
-      }
-      if(a_entryObject.keywords.BYOHAdoptionClothesKeyword != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_CHILDRENSCLOTHES;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Clothing");
-      }
-      else if(a_entryObject.keywords.BYOHAdoptionToyKeyword != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_TOY;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Toy");
-      }
-      else if(a_entryObject.keywords.BYOHHouseCraftingCategoryWeaponRacks != undefined || a_entryObject.keywords.BYOHHouseCraftingCategoryShelf != undefined || a_entryObject.keywords.BYOHHouseCraftingCategoryFurniture != undefined || a_entryObject.keywords.BYOHHouseCraftingCategoryExterior != undefined || a_entryObject.keywords.BYOHHouseCraftingCategoryContainers != undefined || a_entryObject.keywords.BYOHHouseCraftingCategoryBuilding != undefined || a_entryObject.keywords.BYOHHouseCraftingCategorySmithing != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_HOUSEPART;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$House Part");
-      }
-      else if(a_entryObject.keywords.VendorItemDaedricArtifact != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_ARTIFACT;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Artifact");
-      }
-      else if(a_entryObject.keywords.VendorItemGem != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_GEM;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
-      }
-      else if(a_entryObject.keywords.VendorItemAnimalHide != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_HIDE;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Hide");
-      }
-      else if(a_entryObject.keywords.VendorItemTool != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_TOOL;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Tool");
-      }
-      else if(a_entryObject.keywords.VendorItemAnimalPart != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
-      }
-      else if(a_entryObject.keywords.VendorItemOreIngot != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_INGOT;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingot");
-      }
-      else if(a_entryObject.keywords.VendorItemFireword != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_FIREWOOD;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Firewood");
-      }
-      else if(a_entryObject.keywords.VendorItemClutter != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_CLUTTER;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Clutter");
-      }
+    public function CraftingDataSetter()
+    {
+        super();
+    }
 
-   }
-   function processMiscBaseId(a_entryObject)
-   {
-      switch(a_entryObject.formId >>> 24)
-      {
-         case 0x00:
-            switch(a_entryObject.baseId)
-            {
-               case skyui.defines.Form.FORMID_GEMAMETHYSTFLAWLESS:
-               case skyui.defines.Form.FORMID_GEM1:
-               case skyui.defines.Form.FORMID_GEM2:
-               case skyui.defines.Form.FORMID_GEM3:
-               case skyui.defines.Form.FORMID_GEM4:
-                  a_entryObject.subType = skyui.defines.Item.MISC_GEM;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
-                  break;
-               case skyui.defines.Form.FORMID_RUBYDRAGONCLAW:
-               case skyui.defines.Form.FORMID_IVORYDRAGONCLAW:
-               case skyui.defines.Form.FORMID_GLASSCLAW:
-               case skyui.defines.Form.FORMID_EBONYCLAW:
-               case skyui.defines.Form.FORMID_EMERALDDRAGONCLAW:
-               case skyui.defines.Form.FORMID_DIAMONDCLAW:
-               case skyui.defines.Form.FORMID_IRONCLAW:
-               case skyui.defines.Form.FORMID_CORALDRAGONCLAW:
-               case skyui.defines.Form.FORMID_E3GOLDENCLAW:
-               case skyui.defines.Form.FORMID_SAPPHIREDRAGONCLAW:
-               case skyui.defines.Form.FORMID_MS13GOLDENCLAW:
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Claw");
-                  a_entryObject.subType = skyui.defines.Item.MISC_DRAGONCLAW;
-                  break;
-               case skyui.defines.Form.FORMID_REMAINS1:
-               case skyui.defines.Form.FORMID_REMAINS2:
-               case skyui.defines.Form.FORMID_REMAINS3:
-               case skyui.defines.Form.FORMID_REMAINS4:
-               case skyui.defines.Form.FORMID_REMAINS5:
-                  a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
-                  break;
-               case skyui.defines.Form.FORMID_LOCKPICK:
-                  a_entryObject.subType = skyui.defines.Item.MISC_LOCKPICK;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Lockpick");
-                  break;
-               case skyui.defines.Form.FORMID_GOLD001:
-                  a_entryObject.subType = skyui.defines.Item.MISC_GOLD;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gold");
-                  break;
-               case skyui.defines.Form.FORMID_LEATHER01:
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Leather");
-                  a_entryObject.subType = skyui.defines.Item.MISC_LEATHER;
-                  break;
-               case skyui.defines.Form.FORMID_LEATHERSTRIPS:
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Strips");
-                  a_entryObject.subType = skyui.defines.Item.MISC_LEATHERSTRIPS;
-                  break;
-               case skyui.defines.Form.FORMID_CHITIN1:
-                  a_entryObject.subType = skyui.defines.Item.MISC_NETCHLEATHER;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$NetchLeather");
-                  break;
-               case skyui.defines.Form.FORMID_BROKENWEAPON1:
-               case skyui.defines.Form.FORMID_BROKENWEAPON2:
-               case skyui.defines.Form.FORMID_BROKENWEAPON3:
-               case skyui.defines.Form.FORMID_BROKENWEAPON4:
-               case skyui.defines.Form.FORMID_BROKENWEAPON5:
-               case skyui.defines.Form.FORMID_BROKENWEAPON6:
-               case skyui.defines.Form.FORMID_BROKENWEAPON7:
-               case skyui.defines.Form.FORMID_BROKENWEAPON8:
-               case skyui.defines.Form.FORMID_BROKENWEAPON9:
-               case skyui.defines.Form.FORMID_BROKENWEAPON10:
-               case skyui.defines.Form.FORMID_BROKENWEAPON11:
-               case skyui.defines.Form.FORMID_BROKENWEAPON12:
-               case skyui.defines.Form.FORMID_BROKENWEAPON13:
-               case skyui.defines.Form.FORMID_BROKENWEAPON14:
-               case skyui.defines.Form.FORMID_BROKENWEAPON15:
-               case skyui.defines.Form.FORMID_BROKENWEAPON16:
-               case skyui.defines.Form.FORMID_BROKENWEAPON17:
-               case skyui.defines.Form.FORMID_BROKENWEAPON18:
-               case skyui.defines.Form.FORMID_BROKENWEAPON19:
-               case skyui.defines.Form.FORMID_BROKENWEAPON20:
-               case skyui.defines.Form.FORMID_BROKENWEAPON21:
-               case skyui.defines.Form.FORMID_BROKENWEAPON22:
-               case skyui.defines.Form.FORMID_BROKENWEAPON23:
-               case skyui.defines.Form.FORMID_BROKENWEAPON24:
-               case skyui.defines.Form.FORMID_BROKENWEAPON25:
-               case skyui.defines.Form.FORMID_BROKENWEAPON26:
-               case skyui.defines.Form.FORMID_BROKENWEAPON27:
-               case skyui.defines.Form.FORMID_BROKENWEAPON28:
-               case skyui.defines.Form.FORMID_BROKENWEAPON29:
-               case skyui.defines.Form.FORMID_BROKENWEAPON30:
-               case skyui.defines.Form.FORMID_BROKENWEAPON31:
-                  a_entryObject.subType = skyui.defines.Item.MISC_BROKENWEAPON;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BrokenWeapon");
-                  break;
-               case skyui.defines.Form.FORMID_DWARVENSCRAP1:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP2:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP3:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP4:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP5:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP6:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP7:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP8:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP9:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP10:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP11:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP12:
-                  a_entryObject.subType = skyui.defines.Item.MISC_DWARVENSCRAP;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$DwarvenScrap");
-                  break;
-               case skyui.defines.Form.FORMID_INSTRUMENT1:
-               case skyui.defines.Form.FORMID_INSTRUMENT2:
-               case skyui.defines.Form.FORMID_INSTRUMENT3:
-               case skyui.defines.Form.FORMID_INSTRUMENT4:
-               case skyui.defines.Form.FORMID_INSTRUMENT5:
-               case skyui.defines.Form.FORMID_INSTRUMENT6:
-               case skyui.defines.Form.FORMID_INSTRUMENT7:
-               case skyui.defines.Form.FORMID_INSTRUMENT8:
-               case skyui.defines.Form.FORMID_INSTRUMENT9:
-                  a_entryObject.subType = skyui.defines.Item.MISC_INSTRUMENT;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Instrument");
-                  break;
-               case skyui.defines.Form.FORMID_BUGJAR1:
-               case skyui.defines.Form.FORMID_BUGJAR2:
-               case skyui.defines.Form.FORMID_BUGJAR3:
-               case skyui.defines.Form.FORMID_BUGJAR4:
-               case skyui.defines.Form.FORMID_BUGJAR5:
-                  a_entryObject.subType = skyui.defines.Item.MISC_BUGJAR;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BugJar");
-                  break;
-               case skyui.defines.Form.FORMID_MISCMAP1:
-               case skyui.defines.Form.FORMID_MISCMAP2:
-                  a_entryObject.subType = skyui.defines.Item.MISC_MAP;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
-                  break;
-               case skyui.defines.Form.FORMID_MISCAZURASSTAR:
-                  a_entryObject.subType = skyui.defines.Item.MISC_ARTIFACT;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Artifact");
-                  break;
-               case skyui.defines.Form.FORMID_MISCARTIFACT1:
-               case skyui.defines.Form.FORMID_MISCARTIFACT2:
-                  a_entryObject.subType = skyui.defines.Item.MISC_ARTIFACT;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Artifact");
-                  a_entryObject.iconLabel = "default_potion";
-                  break;
-               case skyui.defines.Form.FORMID_MISCPOTION:
-                  a_entryObject.subType = skyui.defines.Item.MISC_POTION;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Potion");
-                  break;
-               case skyui.defines.Form.FORMID_MISCPOISON:
-                  a_entryObject.subType = skyui.defines.Item.MISC_POISON;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Poison");
-                  break;
-               case skyui.defines.Form.FORMID_MISCSCROLL1:
-               case skyui.defines.Form.FORMID_MISCSCROLL2:
-               case skyui.defines.Form.FORMID_MISCSCROLL3:
-                  a_entryObject.subType = skyui.defines.Item.MISC_SCROLL;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Scroll");
-                  break;
-               case skyui.defines.Form.FORMID_MISCBOOK1:
-               case skyui.defines.Form.FORMID_MISCBOOK2:
-               case skyui.defines.Form.FORMID_MISCBOOK3:
-               case skyui.defines.Form.FORMID_MISCBOOK4:
-                  a_entryObject.subType = skyui.defines.Item.MISC_BOOK;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Book");
-                  break;
-               case skyui.defines.Form.FORMID_MISCRING1:
-               case skyui.defines.Form.FORMID_MISCRING2:
-               case skyui.defines.Form.FORMID_MISCRING3:
-               case skyui.defines.Form.FORMID_MISCRING4:
-               case skyui.defines.Form.FORMID_MISCRING5:
-                  a_entryObject.subType = skyui.defines.Item.MISC_RING;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ring");
-                  break;
-               case skyui.defines.Form.FORMID_ORE1:
-               case skyui.defines.Form.FORMID_ORE2:
-               case skyui.defines.Form.FORMID_ORE3:
-               case skyui.defines.Form.FORMID_ORE4:
-               case skyui.defines.Form.FORMID_ORE5:
-               case skyui.defines.Form.FORMID_ORE6:
-               case skyui.defines.Form.FORMID_ORE7:
-               case skyui.defines.Form.FORMID_ORE8:
-               case skyui.defines.Form.FORMID_ORE9:
-               case skyui.defines.Form.FORMID_ORE10:
-                  a_entryObject.subType = skyui.defines.Item.MISC_ORE;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
-            }
+    // @override IListProcessor
+    public function processList(a_list: BasicList)
+    {
+        var entryList = a_list.entryList;
+        
+        for (var i = 0; i < entryList.length; i++) {
+            var e = entryList[i];
+            if (e.skyui_itemDataProcessed || e.filterFlag == 0)
+                continue;
+                
+            e.skyui_itemDataProcessed = true;
+            
+            // Fix wrong property names
+            this.fixSKSEExtendedObject(e);
+            
+            this.processEntry(e);
+        }
+    }
+    
+    
+  /* PUBLIC FUNCTIONS */
+
+    // @override ItemcardDataExtender
+    public function processEntry(a_entryObject: Object)
+    {
+        a_entryObject.baseId = a_entryObject.formId & 0x00FFFFFF;
+        a_entryObject.eslId = a_entryObject.formId & 0xFFF;
+
+        a_entryObject.isEquipped = (a_entryObject.equipState > 0);
+
+        a_entryObject.infoValue = (a_entryObject.value > 0) ? (Math.round(a_entryObject.value * 100) / 100) : null;
+        a_entryObject.infoWeight =(a_entryObject.weight > 0) ? (Math.round(a_entryObject.weight * 100) / 100) : null;
+        
+        a_entryObject.infoValueWeight = (a_entryObject.weight > 0 && a_entryObject.value > 0) ? Math.round(a_entryObject.value / a_entryObject.weight * 100) / 100 : null;
+
+        switch (a_entryObject.formType) {
+            case skyui.defines.Form.TYPE_SCROLLITEM:
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Scroll");
+                
+                a_entryObject.duration = (a_entryObject.duration > 0) ? (Math.round(a_entryObject.duration * 100) / 100) : null;
+                a_entryObject.magnitude = (a_entryObject.magnitude > 0) ? (Math.round(a_entryObject.magnitude * 100) / 100) : null;
+
+                break;
+
+            case skyui.defines.Form.TYPE_ARMOR:
+                a_entryObject.infoArmor = (a_entryObject.armor > 0) ? (Math.round(a_entryObject.armor * 100) / 100) : null;
+                
+                this.processArmorClass(a_entryObject);
+                this.processArmorPartMask(a_entryObject);
+                this.processMaterialKeywords(a_entryObject);
+                this.processArmorOther(a_entryObject);
+                this.processArmorBaseId(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_BOOK:
+                this.processBookType(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_INGREDIENT:
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingredient");
+                break;
+
+            case skyui.defines.Form.TYPE_LIGHT:
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Torch");
+                break;
+
+            case skyui.defines.Form.TYPE_MISC:
+                this.processMiscType(a_entryObject);
+                this.processMiscBaseId(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_WEAPON:
+                a_entryObject.infoDamage = (a_entryObject.damage > 0) ? (Math.round(a_entryObject.damage * 100) / 100) : null;
+                
+                this.processWeaponType(a_entryObject);
+                this.processMaterialKeywords(a_entryObject);
+                this.processWeaponBaseId(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_AMMO:
+                a_entryObject.infoDamage = (a_entryObject.damage > 0) ? (Math.round(a_entryObject.damage * 100) / 100) : null;
+                
+                this.processAmmoType(a_entryObject);
+                this.processMaterialKeywords(a_entryObject);
+                this.processAmmoBaseId(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_KEY:
+                this.processKeyType(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_POTION:
+                a_entryObject.duration = (a_entryObject.duration > 0) ? (Math.round(a_entryObject.duration * 100) / 100) : null;
+                a_entryObject.magnitude = (a_entryObject.magnitude > 0) ? (Math.round(a_entryObject.magnitude * 100) / 100) : null;
+            
+                this.processPotionType(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_SOULGEM:
+                this.processSoulGemType(a_entryObject);
+                this.processSoulGemStatus(a_entryObject);
+                this.processSoulGemBaseId(a_entryObject);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+
+  /* PRIVATE FUNCTIONS */
+
+    private function processArmorClass(a_entryObject: Object)
+    {
+        if (a_entryObject.weightClass == skyui.defines.Armor.WEIGHT_NONE)
+            a_entryObject.weightClass = null;
+            
+        a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Other");
+
+        switch (a_entryObject.weightClass) {
+            case skyui.defines.Armor.WEIGHT_LIGHT:
+                a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Light");
+                break;
+
+            case skyui.defines.Armor.WEIGHT_HEAVY:
+                a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Heavy");
+                break;
+
+            default:
+                if (a_entryObject.keywords == undefined)
+                    break;
+
+                if (a_entryObject.keywords["VendorItemClothing"] != undefined) {
+                    a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_CLOTHING;
+                    a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Clothing");
+                } else if (a_entryObject.keywords["VendorItemJewelry"] != undefined) {
+                    a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
+                    a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
+                }
+                break;
+        }
+    }
+
+    private function processMaterialKeywords(a_entryObject: Object)
+    {
+        a_entryObject.material = null;
+        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Other");
+
+        if (a_entryObject.keywords == undefined)
             return;
-         case 0x01:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_UPDATEHORSETACK1:
-               case skyui.defines.Form.FORMID_UPDATEHORSETACK2:
-                  a_entryObject.subType = skyui.defines.Item.MISC_HORSETACK;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$HorseTack");
-            }
+
+        if (a_entryObject.keywords["ArmorMaterialDaedric"] != undefined || a_entryObject.keywords["WeapMaterialDaedric"] != undefined || a_entryObject.keywords["ccBGSSSE025_ArmorMaterialDark"] != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialDark"] != undefined || a_entryObject.keywords["ccBGSSSE025_ArmorMaterialGolden"] != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialGolden"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.DAEDRIC;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Daedric");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialDragonplate"] != undefined  || a_entryObject.keywords["ArmorMaterialDragonscale"] != undefined || a_entryObject.keywords["DLC1WeapMaterialDragonbone"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.DRAGON;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dragon");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialDwarven"] != undefined || a_entryObject.keywords["WeapMaterialDwarven"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.DWARVEN;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialEbony"] != undefined || a_entryObject.keywords["WeapMaterialEbony"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.EBONY;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ebony");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialElven"] != undefined || a_entryObject.keywords["WeapMaterialElven"] != undefined || a_entryObject.keywords["ArmorMaterialElvenGilded"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.ELVEN;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialGlass"] != undefined || a_entryObject.keywords["WeapMaterialGlass"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.GLASS;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Glass");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialHide"] != undefined  || a_entryObject.keywords["ArmorMaterialScaled"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.HIDE;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Hide");
+        
+        } else if(a_entryObject.keywords["ArmorMaterialStormcloak"] != undefined || a_entryObject.keywords["ArmorMaterialBearStormcloak"] != undefined)
+        {
+            a_entryObject.material = skyui.defines.Material.STORMCLOAK;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Stormcloak");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialImperialHeavy"] != undefined || a_entryObject.keywords["ArmorMaterialImperialLight"] != undefined || a_entryObject.keywords["WeapMaterialImperial"] != undefined || a_entryObject.keywords["ArmorMaterialImperialStudded"] != undefined || a_entryObject.keywords["ArmorMaterialStudded"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.IMPERIAL;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Imperial");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialIron"] != undefined || a_entryObject.keywords["WeapMaterialIron"] != undefined || a_entryObject.keywords["ArmorMaterialIronBanded"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.IRON;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialLeather"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.LEATHER;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Leather");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialOrcish"] != undefined || a_entryObject.keywords["WeapMaterialOrcish"] != undefined || a_entryObject.keywords["ccBGSSSE055_ArmorMaterialOrcishLight"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.ORCISH;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Orcish");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialSteel"] != undefined || a_entryObject.keywords["WeapMaterialSteel"] != undefined || a_entryObject.keywords["ArmorMaterialSteelPlate"] != undefined || a_entryObject.keywords["WeapMaterialDraugr"] != undefined || a_entryObject.keywords["WeapMaterialDraugrHoned"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.STEEL;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
+        
+        } else if (a_entryObject.keywords["WeapMaterialSilver"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.SILVER;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Silver");
+        
+        } else if(a_entryObject.keywords["ArmorMaterialFalmer"] != undefined || a_entryObject.keywords["DLC1ArmorMaterialFalmerHardened"] != undefined || a_entryObject.keywords["DLC1ArmorMaterielFalmerHeavy"] != undefined || a_entryObject.keywords["DLC1ArmorMaterielFalmerHeavyOriginal"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.FALMER;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
+        
+        } else if (a_entryObject.keywords["DLC2ArmorMaterialBonemoldHeavy"] != undefined || a_entryObject.keywords["DLC2ArmorMaterialBonemoldLight"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.BONEMOLD;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Bonemold");
+
+        } else if (a_entryObject.keywords["DLC2ArmorMaterialChitinHeavy"] != undefined || a_entryObject.keywords["DLC2ArmorMaterialChitinLight"] != undefined || a_entryObject.keywords["DLC2ArmorMaterialMoragTong"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.CHITIN;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Chitin");
+        
+        } else if (a_entryObject.keywords["DLC2ArmorMaterialNordicHeavy"] != undefined || a_entryObject.keywords["DLC2ArmorMaterialNordicLight"] != undefined || a_entryObject.keywords["DLC2WeaponMaterialNordic"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.NORDIC;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Nordic");
+        
+        } else if (a_entryObject.keywords["DLC2ArmorMaterialStalhrimHeavy"] != undefined || a_entryObject.keywords["DLC2ArmorMaterialStalhrimLight"] != undefined || a_entryObject.keywords["DLC2WeaponMaterialStalhrim"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.STALHRIM;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Stalhrim");
+        
+        } else if (a_entryObject.keywords["WeapMaterialFalmer"] != undefined || a_entryObject.keywords["WeapMaterialFalmerHoned"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.FALMER;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
+        
+        } else if(a_entryObject.keywords["ccASVSSE001_ArmorOrdinator"] != undefined || a_entryObject.keywords["ccASVSSE001_ArmorOrdinatorIndoril"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.ORDINATOR;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ordinator");
+        
+        } else if(a_entryObject.keywords["ccBGSSSE025_ArmorMaterialAmber"] != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialAmber"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.AMBER;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Amber");
+        
+        } else if(a_entryObject.keywords["ccBGSSSE025_ArmorMaterialMadness"] != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialMadness"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.MADNESS;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Madness");
+        
+        } else if (a_entryObject.keywords["WeapMaterialWood"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.WOOD;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Wood");
+        }
+    }
+
+    private function processWeaponType(a_entryObject: Object)
+    {
+        a_entryObject.subType = null;
+        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Weapon");
+
+        switch (a_entryObject.weaponType) {
+            case skyui.defines.Weapon.ANIM_HANDTOHANDMELEE:
+            case skyui.defines.Weapon.ANIM_H2H:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_MELEE;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Melee");
+                break;
+
+            case skyui.defines.Weapon.ANIM_ONEHANDSWORD:
+            case skyui.defines.Weapon.ANIM_1HS:
+                if (a_entryObject.keywords != undefined && a_entryObject.keywords["ccBGSSSE001_FishingPoleKW"] != undefined)
+                {
+                    a_entryObject.subType = skyui.defines.Weapon.TYPE_FISHINGROD;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$FishingRod");
+                    return;
+                }
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_SWORD;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Sword");
+                break;
+
+            case skyui.defines.Weapon.ANIM_ONEHANDDAGGER:
+            case skyui.defines.Weapon.ANIM_1HD:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_DAGGER;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Dagger");
+                break;
+
+            case skyui.defines.Weapon.ANIM_ONEHANDAXE:
+            case skyui.defines.Weapon.ANIM_1HA:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_WARAXE;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$War Axe");
+                break;
+
+            case skyui.defines.Weapon.ANIM_ONEHANDMACE:
+            case skyui.defines.Weapon.ANIM_1HM:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_MACE;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Mace");
+                break;
+
+            case skyui.defines.Weapon.ANIM_TWOHANDSWORD:
+            case skyui.defines.Weapon.ANIM_2HS:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_GREATSWORD;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Greatsword");
+                break;
+
+            case skyui.defines.Weapon.ANIM_TWOHANDAXE:
+            case skyui.defines.Weapon.ANIM_2HA:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_BATTLEAXE;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Battleaxe");
+
+                if (a_entryObject.keywords != undefined && a_entryObject.keywords["WeapTypeWarhammer"] != undefined) {
+                    a_entryObject.subType = skyui.defines.Weapon.TYPE_WARHAMMER;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Warhammer");
+                }
+                break;
+
+            case skyui.defines.Weapon.ANIM_BOW:
+            case skyui.defines.Weapon.ANIM_BOW2:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_BOW;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Bow");
+                break;
+
+            case skyui.defines.Weapon.ANIM_STAFF:
+            case skyui.defines.Weapon.ANIM_STAFF2:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_STAFF;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Staff");
+                break;
+
+            case skyui.defines.Weapon.ANIM_CROSSBOW:
+            case skyui.defines.Weapon.ANIM_CBOW:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_CROSSBOW;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Crossbow");
+                break;
+            
+            default:
+                break;
+        }
+    }
+
+    private function processWeaponBaseId(a_entryObject: Object)
+    {
+        switch(a_entryObject.formId >>> 24) {
+            case 0x00:
+                switch (a_entryObject.baseId) {
+                    case skyui.defines.Form.FORMID_WEAPPICKAXE:
+                    case skyui.defines.Form.FORMID_SSDROCKSPLINTERPICKAXE:
+                    case skyui.defines.Form.FORMID_DUNVOLUNRUUDPICKAXE:
+                        a_entryObject.subType = skyui.defines.Weapon.TYPE_PICKAXE;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Pickaxe");
+                        break;
+                    case skyui.defines.Form.FORMID_AXE01:
+                    case skyui.defines.Form.FORMID_DUNHALTEDSTREAMPOACHERSAXE:
+                        a_entryObject.subType = skyui.defines.Weapon.TYPE_WOODAXE;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Wood Axe");
+                        break;
+                    case skyui.defines.Form.FORMID_LONGBOW:
+                    case skyui.defines.Form.FORMID_HUNTINGBOW:
+                    case skyui.defines.Form.FORMID_DRAVINSBOW:
+                        a_entryObject.material = skyui.defines.Material.WOOD;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Wood");
+                        break;
+                    case skyui.defines.Form.FORMID_FORSWORNAXE:
+                    case skyui.defines.Form.FORMID_FORSWORNBOW:
+                    case skyui.defines.Form.FORMID_FORSWORNSTAFF:
+                    case skyui.defines.Form.FORMID_FORSWORNSWORD:
+                        break;
+
+                    default:
+                        break;
+                }
+                break;
+
+            case 0x04:
+                switch (a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_DLC2PICKAXE1:
+                    case skyui.defines.Form.FORMID_DLC2PICKAXE2:
+                    case skyui.defines.Form.FORMID_DLC2PICKAXE3:
+                        a_entryObject.subType = skyui.defines.Weapon.TYPE_PICKAXE;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Pickaxe");
+                        a_entryObject.material = skyui.defines.Material.STEEL;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
+                        break;
+
+                    default:
+                        break;
+                }
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    private function processArmorPartMask(a_entryObject: Object)
+    {
+        if (a_entryObject.partMask == undefined)
             return;
-         case 0x02:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_DLC1GEM1:
-               case skyui.defines.Form.FORMID_DLC1GEM2:
-               case skyui.defines.Form.FORMID_DLC1GEM3:
-               case skyui.defines.Form.FORMID_DLC1GEM4:
-               case skyui.defines.Form.FORMID_DLC1GEM5:
-                  a_entryObject.subType = skyui.defines.Item.MISC_GEM;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
-                  break;
-               case skyui.defines.Form.FORMID_DLC1REMAINS1:
-               case skyui.defines.Form.FORMID_DLC1REMAINS2:
-               case skyui.defines.Form.FORMID_DLC1REMAINS3:
-               case skyui.defines.Form.FORMID_DLC1REMAINS4:
-               case skyui.defines.Form.FORMID_DLC1REMAINS5:
-               case skyui.defines.Form.FORMID_DLC1REMAINS6:
-               case skyui.defines.Form.FORMID_DLC1REMAINS7:
-                  a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
-                  break;
-               case skyui.defines.Form.FORMID_DLC1CHITIN1:
-                  a_entryObject.subType = skyui.defines.Item.MISC_NETCHLEATHER;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$NetchLeather");
+
+        // Sets subType as the most important bitmask index.
+        for (var i = 0; i < skyui.defines.Armor.PARTMASK_PRECEDENCE.length; i++) {
+            if (a_entryObject.partMask & skyui.defines.Armor.PARTMASK_PRECEDENCE[i]) {
+                a_entryObject.mainPartMask = skyui.defines.Armor.PARTMASK_PRECEDENCE[i];
+                break;
             }
+        }
+
+        if (a_entryObject.mainPartMask == undefined)
             return;
-         case 0x03:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_HFHOUSEPART1:
-               case skyui.defines.Form.FORMID_HFHOUSEPART2:
-               case skyui.defines.Form.FORMID_HFHOUSEPART3:
-               case skyui.defines.Form.FORMID_HFHOUSEPART4:
-               case skyui.defines.Form.FORMID_HFHOUSEPART5:
-               case skyui.defines.Form.FORMID_HFHOUSEPART6:
-               case skyui.defines.Form.FORMID_HFHOUSEPART7:
-               case skyui.defines.Form.FORMID_HFHOUSEPART8:
-               case skyui.defines.Form.FORMID_HFHOUSEPART9:
-               case skyui.defines.Form.FORMID_HFHOUSEPART10:
-                  a_entryObject.subType = skyui.defines.Item.MISC_HOUSEPART;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BuildingMaterial");
-            }
+
+        switch (a_entryObject.mainPartMask) {
+            case skyui.defines.Armor.PARTMASK_HEAD:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_HEAD;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Head");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_HAIR:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_HAIR;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Head");
+                break;
+                
+            case skyui.defines.Armor.PARTMASK_LONGHAIR:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_LONGHAIR;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Head");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_BODY:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_BODY;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Body");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_HANDS:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_HANDS;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Hands");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_FOREARMS:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_FOREARMS;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Forearms");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_AMULET:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_AMULET;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Amulet");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_RING:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_RING;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ring");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_FEET:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_FEET;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Feet");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_CALVES:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_CALVES;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Calves");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_SHIELD:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_SHIELD;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Shield");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_CIRCLET:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_CIRCLET;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Circlet");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_EARS:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_EARS;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ears");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_TAIL:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_TAIL;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Tail");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_CLOAK:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_CLOAK;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ClothingCloak");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_BACKPACK:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_BACKPACK;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Backpack");
+                break;
+
+            default:
+                a_entryObject.subType = a_entryObject.mainPartMask;
+                break;
+        }
+    }
+
+    private function processArmorOther(a_entryObject)
+    {
+        if (a_entryObject.weightClass != null)
             return;
-         case 0x04:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_DLC2DRAGONCLAW1:
-               case skyui.defines.Form.FORMID_DLC2DRAGONCLAW2:
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Claw");
-                  a_entryObject.subType = skyui.defines.Item.MISC_DRAGONCLAW;
-                  break;
-               case skyui.defines.Form.FORMID_DLC2GEM1:
-               case skyui.defines.Form.FORMID_DLC2GEM2:
-               case skyui.defines.Form.FORMID_DLC2GEM3:
-               case skyui.defines.Form.FORMID_DLC2GEM4:
-               case skyui.defines.Form.FORMID_DLC2GEM5:
-                  a_entryObject.subType = skyui.defines.Item.MISC_GEM;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2CHITIN1:
-               case skyui.defines.Form.FORMID_DLC2NETCHLEATHER:
-                  a_entryObject.subType = skyui.defines.Item.MISC_NETCHLEATHER;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$NetchLeather");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2TROLLSKULL:
-                  a_entryObject.subType = skyui.defines.Item.MISC_TROLLSKULL;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2SCROLLSPIDERMISC1:
-               case skyui.defines.Form.FORMID_DLC2SCROLLSPIDERMISC2:
-                  a_entryObject.subType = skyui.defines.Item.MISC_SCROLLSPIDER;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ScrollSpider");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2MISCMAP:
-                  a_entryObject.subType = skyui.defines.Item.MISC_MAP;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2INGREDIENT:
-                  a_entryObject.subType = skyui.defines.Item.MISC_INGREDIENT;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingredient");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2ORE1:
-               case skyui.defines.Form.FORMID_DLC2ORE2:
-               case skyui.defines.Form.FORMID_DLC2ORE3:
-                  a_entryObject.subType = skyui.defines.Item.MISC_ORE;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
-            }
+
+        switch (a_entryObject.mainPartMask) {
+            case skyui.defines.Armor.PARTMASK_HEAD:
+            case skyui.defines.Armor.PARTMASK_HAIR:
+            case skyui.defines.Armor.PARTMASK_LONGHAIR:
+            case skyui.defines.Armor.PARTMASK_BODY:
+            case skyui.defines.Armor.PARTMASK_HANDS:
+            case skyui.defines.Armor.PARTMASK_FOREARMS:
+            case skyui.defines.Armor.PARTMASK_FEET:
+            case skyui.defines.Armor.PARTMASK_CALVES:
+            case skyui.defines.Armor.PARTMASK_SHIELD:
+            case skyui.defines.Armor.PARTMASK_TAIL:
+            case skyui.defines.Armor.PARTMASK_CLOAK:
+            case skyui.defines.Armor.PARTMASK_BACKPACK:
+                a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_CLOTHING;
+                a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Clothing");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_AMULET:
+            case skyui.defines.Armor.PARTMASK_RING:
+            case skyui.defines.Armor.PARTMASK_CIRCLET:
+            case skyui.defines.Armor.PARTMASK_EARS:
+                a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
+                a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    private function processArmorBaseId(a_entryObject)
+    {
+        switch(a_entryObject.formId >>> 24) {
+            case 0x00:
+                if (a_entryObject.baseId == skyui.defines.Form.FORMID_CLOTHESWEDDINGWREATH) {
+                    a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
+                    a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
+                }
+                break;
+
+            case 0x02:
+                if (a_entryObject.formId == skyui.defines.Form.FORMID_DLC1CLOTHESVAMPIRELORDARMOR) {
+                    a_entryObject.subType = skyui.defines.Armor.EQUIP_BODY;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Body");
+                }
+                break;
+
+            default:
+                if (a_entryObject.baseId == skyui.defines.Form.BASEID_CC025ADVDSGSRING) {
+                    a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
+                    a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
+                    a_entryObject.subType = skyui.defines.Armor.EQUIP_RING;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ring");
+                }
+                break;
+        }
+    }
+
+    private function processBookType(a_entryObject: Object)
+    {
+        a_entryObject.subType = skyui.defines.Item.OTHER;
+        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Book");
+
+        a_entryObject.isRead = ((a_entryObject.flags & skyui.defines.Item.BOOKFLAG_READ) != 0);
+        
+        if (a_entryObject.bookType == skyui.defines.Item.BOOKTYPE_NOTE) {
+            a_entryObject.subType = skyui.defines.Item.BOOK_NOTE;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Note");
+        }
+
+        if (a_entryObject.keywords == undefined)
             return;
-         case 0xFE:
-            switch(a_entryObject.eslId)
-            {
-               case skyui.defines.Form.ESLID_CC019STAFFREMAINS:
-               case skyui.defines.Form.ESLID_CC036PETWOLFREMAINS:
-                  a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
-                  break;
-               case skyui.defines.Form.ESLID_CCKRTALTARGOLD:
-                  a_entryObject.subType = skyui.defines.Item.MISC_GOLD;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gold");
-                  break;
-               case skyui.defines.Form.ESLID_CCVSV002PETGEAR:
-               case skyui.defines.Form.ESLID_CCVSV002PETAMULET:
-                  a_entryObject.subType = skyui.defines.Item.MISC_PETGEAR;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$PetGear");
+
+        if (a_entryObject.keywords["VendorItemRecipe"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.BOOK_RECIPE;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Recipe");
+
+        } else if (a_entryObject.keywords["VendorItemSpellTome"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.BOOK_SPELLTOME;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Spell Tome");
+        }
+    }
+
+    private function processAmmoType(a_entryObject: Object)
+    {
+        if ((a_entryObject.flags & skyui.defines.Weapon.AMMOFLAG_NONBOLT) != 0) {
+            a_entryObject.subType = skyui.defines.Weapon.AMMO_ARROW;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Arrow");
+
+        } else {
+            a_entryObject.subType = skyui.defines.Weapon.AMMO_BOLT;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Bolt");
+        }
+    }
+
+    private function processAmmoBaseId(a_entryObject: Object)
+    {
+        switch(a_entryObject.formId >>> 24) {
+            case 0x00:
+                switch (a_entryObject.baseId) {
+                    case skyui.defines.Form.FORMID_DAEDRICARROW:
+                        a_entryObject.material = skyui.defines.Material.DAEDRIC;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Daedric");
+                        break;
+
+                    case skyui.defines.Form.FORMID_EBONYARROW:
+                        a_entryObject.material = skyui.defines.Material.EBONY;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ebony");
+                        break;
+
+                    case skyui.defines.Form.FORMID_GLASSARROW:
+                        a_entryObject.material = skyui.defines.Material.GLASS;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Glass");
+                        break;
+
+                    case skyui.defines.Form.FORMID_ELVENARROW:
+                        a_entryObject.material = skyui.defines.Material.ELVEN;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DWARVENARROW:
+                    case skyui.defines.Form.FORMID_DWARVENSPHEREARROW:
+                    case skyui.defines.Form.FORMID_DWARVENSPHEREBOLT01:
+                    case skyui.defines.Form.FORMID_DWARVENSPHEREBOLT02:
+                        a_entryObject.material = skyui.defines.Material.DWARVEN;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
+                        break;
+
+                    case skyui.defines.Form.FORMID_ORCISHARROW:
+                        a_entryObject.material = skyui.defines.Material.ORCISH;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Orcish");
+                        break;
+
+                    case skyui.defines.Form.FORMID_NORDHEROARROW:
+                        a_entryObject.material = skyui.defines.Material.NORDIC;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Nordic");
+                        break;
+
+                    case skyui.defines.Form.FORMID_FALMERARROW:
+                        a_entryObject.material = skyui.defines.Material.FALMER;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
+                        break;
+
+                    case skyui.defines.Form.FORMID_STEELARROW:
+                    case skyui.defines.Form.FORMID_MQ101STEELARROW:
+                    case skyui.defines.Form.FORMID_DRAUGRARROW:
+                    case skyui.defines.Form.FORMID_DUNGEIRMUNDSIGDISARROWSILLUSION:
+                        a_entryObject.material = skyui.defines.Material.STEEL;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
+                        break;
+
+                    case skyui.defines.Form.FORMID_IRONARROW:
+                    case skyui.defines.Form.FORMID_CWARROW:
+                    case skyui.defines.Form.FORMID_CWARROWSHORT:
+                    case skyui.defines.Form.FORMID_TRAPDART:
+                    case skyui.defines.Form.FORMID_DUNARCHERPRATICEARROW:
+                    case skyui.defines.Form.FORMID_FOLLOWERIRONARROW:
+                        a_entryObject.material = skyui.defines.Material.IRON;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
+                        break;
+
+                    default:
+                        break;
+                }
+                break;
+
+            case 0x02:
+                switch(a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_DLC1ELVENARROWBLESSED:
+                    case skyui.defines.Form.FORMID_DLC1ELVENARROWBLOOD:
+                        a_entryObject.material = skyui.defines.Material.ELVEN;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
+                        break;
+
+                    case skyui.defines.Form.FORMID_TESTDLC1BOLT:
+                        a_entryObject.material = skyui.defines.Material.IRON;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
+
+                    default:
+                        break;
+
+                }
+                break;
+
+            case 0x04:
+                switch(a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_DLC2DWARVENBALLISTABOLT:
+                        a_entryObject.material = skyui.defines.Material.DWARVEN;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2RIEKLINGSPEARTHROWN:
+                        a_entryObject.material = skyui.defines.Material.WOOD;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Wood");
+                        break;
+                    
+                    default:
+                        break;
+                }
+
+            default:
+                break;
+        }
+    }
+
+    private function processKeyType(a_entryObject: Object)
+    {
+        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Key");
+
+        if (a_entryObject.infoValue <= 0)
+            a_entryObject.infoValue = null;
+    }
+
+    private function processPotionType(a_entryObject: Object)
+    {
+        a_entryObject.subType = skyui.defines.Item.POTION_POTION;
+        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Potion");
+
+        if ((a_entryObject.flags & skyui.defines.Item.ALCHFLAG_FOOD) != 0) {
+            a_entryObject.subType = skyui.defines.Item.POTION_FOOD;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Food");
+
+            // SKSE >= 1.6.6
+            if (a_entryObject.useSound.formId != undefined && a_entryObject.useSound.formId == skyui.defines.Form.FORMID_ITMPotionUse) {
+                a_entryObject.subType = skyui.defines.Item.POTION_DRINK;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Drink");
             }
+            
+        } else if ((a_entryObject.flags & skyui.defines.Item.ALCHFLAG_POISON) != 0) {
+            a_entryObject.subType = skyui.defines.Item.POTION_POISON;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Poison");
+
+        } else {
+            switch (a_entryObject.actorValue) {
+                case skyui.defines.Actor.AV_HEALTH:
+                    a_entryObject.subType = skyui.defines.Item.POTION_HEALTH;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
+                    break;
+
+                case skyui.defines.Actor.AV_MAGICKA:
+                    a_entryObject.subType = skyui.defines.Item.POTION_MAGICKA;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
+                    break;
+
+                case skyui.defines.Actor.AV_STAMINA:
+                    a_entryObject.subType = skyui.defines.Item.POTION_STAMINA;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
+                    break;
+
+                case skyui.defines.Actor.AV_HEALRATE:
+                    a_entryObject.subType = skyui.defines.Item.POTION_HEALRATE;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
+                    break;
+
+                case skyui.defines.Actor.AV_MAGICKARATE:
+                    a_entryObject.subType = skyui.defines.Item.POTION_MAGICKARATE;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
+                    break;
+
+                case skyui.defines.Actor.AV_STAMINARATE:
+                    a_entryObject.subType = skyui.defines.Item.POTION_STAMINARATE;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
+                    break;
+
+                case skyui.defines.Actor.AV_HEALRATEMULT:
+                    a_entryObject.subType = skyui.defines.Item.POTION_HEALRATEMULT;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
+                    break;
+
+                case skyui.defines.Actor.AV_MAGICKARATEMULT:
+                    a_entryObject.subType = skyui.defines.Item.POTION_MAGICKARATEMULT;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
+                    break;
+
+                case skyui.defines.Actor.AV_STAMINARATEMULT:
+                    a_entryObject.subType = skyui.defines.Item.POTION_STAMINARATEMULT;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
+                    break;
+
+                case skyui.defines.Actor.AV_FIRERESIST:
+                    a_entryObject.subType = skyui.defines.Item.POTION_FIRERESIST;
+                    break;
+
+                case skyui.defines.Actor.AV_ELECTRICRESIST:
+                    a_entryObject.subType = skyui.defines.Item.POTION_ELECTRICRESIST;
+                    break;
+
+                case skyui.defines.Actor.AV_FROSTRESIST:
+                    a_entryObject.subType = skyui.defines.Item.POTION_FROSTRESIST;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    }
+
+    private function processSoulGemType(a_entryObject: Object)
+    {
+        a_entryObject.subType = skyui.defines.Item.OTHER;
+        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Soul Gem");
+
+        // Ignores soulgems that have a size of None
+        if (a_entryObject.gemSize != undefined && a_entryObject.gemSize != skyui.defines.Item.SOULGEM_NONE)
+            a_entryObject.subType = a_entryObject.gemSize;
+    }
+
+    private function processSoulGemStatus(a_entryObject: Object)
+    {
+        if (a_entryObject.gemSize == undefined || a_entryObject.soulSize == undefined || a_entryObject.soulSize == skyui.defines.Item.SOULGEM_NONE)
+            a_entryObject.status = skyui.defines.Item.SOULGEMSTATUS_EMPTY;
+        else if (a_entryObject.soulSize >= a_entryObject.gemSize)
+            a_entryObject.status = skyui.defines.Item.SOULGEMSTATUS_FULL;
+        else
+            a_entryObject.status = skyui.defines.Item.SOULGEMSTATUS_PARTIAL;
+        
+        if (a_entryObject.soulSize != undefined) {
+            switch (a_entryObject.soulSize) {
+                case skyui.defines.Item.SOULGEM_NONE:
+                    a_entryObject.soulSizeDisplay = null;
+                    break;
+                case skyui.defines.Item.SOULGEM_PETTY:
+                    a_entryObject.soulSizeDisplay = "$Petty";
+                    break;
+                case skyui.defines.Item.SOULGEM_LESSER:
+                    a_entryObject.soulSizeDisplay = "$Lesser";
+                    break;
+                case skyui.defines.Item.SOULGEM_COMMON:
+                    a_entryObject.soulSizeDisplay = "$Common";
+                    break;
+                case skyui.defines.Item.SOULGEM_GREATER:
+                    a_entryObject.soulSizeDisplay = "$Greater";
+                    break;
+                case skyui.defines.Item.SOULGEM_GRAND:
+                case skyui.defines.Item.SOULGEM_AZURA:
+                    a_entryObject.soulSizeDisplay = "$Grand";
+                default:
+                    break;
+            }
+        }
+    }
+
+    private function processSoulGemBaseId(a_entryObject: Object)
+    {
+        switch (a_entryObject.baseId) {
+            case skyui.defines.Form.FORMID_DA01SOULGEMBLACKSTAR:
+            case skyui.defines.Form.FORMID_DA01SOULGEMAZURASSTAR:
+                a_entryObject.subType = skyui.defines.Item.SOULGEM_AZURA;
+                break;
+
+            case skyui.defines.Form.BASEID_CC025SOULTOMATO1:
+            case skyui.defines.Form.BASEID_CC025SOULTOMATO2:
+                a_entryObject.subType = skyui.defines.Item.SOULGEM_SOULTOMATO;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$SoulTomato");
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    private function processMiscType(a_entryObject: Object)
+    {
+        a_entryObject.subType = skyui.defines.Item.OTHER;
+        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Misc");
+
+        if (a_entryObject.keywords == undefined)
             return;
-         default:
-            switch(a_entryObject.baseId)
-            {
-               case skyui.defines.Form.BASEID_CCALMSIVIGEM1:
-               case skyui.defines.Form.BASEID_CCALMSIVIGEM2:
-               case skyui.defines.Form.BASEID_CCALMSIVIGEM3:
-               case skyui.defines.Form.BASEID_CCALMSIVIGEM4:
-                  a_entryObject.subType = skyui.defines.Item.MISC_GEM;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
-                  break;
-               case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL1:
-               case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL2:
-               case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL3:
-               case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL4:
-               case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL5:
-               case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL6:
-                  a_entryObject.subType = skyui.defines.Item.MISC_AYLEIDCRYSTAL;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$AyleidCrystal");
-                  break;
-               case skyui.defines.Form.BASEID_CC001DWESCRAP:
-                  a_entryObject.subType = skyui.defines.Item.MISC_DWARVENSCRAP;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$DwarvenScrap");
-                  break;
-               case skyui.defines.Form.BASEID_CC025BUGJAR1:
-               case skyui.defines.Form.BASEID_CC025BUGJAR2:
-               case skyui.defines.Form.BASEID_CC025BUGJAR3:
-                  a_entryObject.subType = skyui.defines.Item.MISC_BUGJAR;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BugJar");
-                  break;
-               case skyui.defines.Form.BASEID_CC031MISCMAP:
-                  a_entryObject.subType = skyui.defines.Item.MISC_MAP;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
-                  break;
-               case skyui.defines.Form.BASEID_CCALMSIVIPOTION:
-                  a_entryObject.subType = skyui.defines.Item.MISC_POTION;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Potion");
-                  break;
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT1:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT2:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT3:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT4:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT5:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT6:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT7:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT8:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT9:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT10:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT11:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT12:
-                  a_entryObject.subType = skyui.defines.Item.MISC_INGREDIENT;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingredient");
-                  break;
-               case skyui.defines.Form.BASEID_CC025ORE1:
-               case skyui.defines.Form.BASEID_CC025ORE2:
-                  a_entryObject.subType = skyui.defines.Item.MISC_ORE;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
-            }
+
+        if (a_entryObject.keywords["BYOHAdoptionClothesKeyword"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_CHILDRENSCLOTHES;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Clothing");
+
+        } else if (a_entryObject.keywords["BYOHAdoptionToyKeyword"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_TOY;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Toy");
+
+        } else if (a_entryObject.keywords["BYOHHouseCraftingCategoryWeaponRacks"] != undefined || a_entryObject.keywords["BYOHHouseCraftingCategoryShelf"] != undefined ||  a_entryObject.keywords["BYOHHouseCraftingCategoryFurniture"] != undefined || a_entryObject.keywords["BYOHHouseCraftingCategoryExterior"] != undefined ||  a_entryObject.keywords["BYOHHouseCraftingCategoryContainers"] != undefined || a_entryObject.keywords["BYOHHouseCraftingCategoryBuilding"] != undefined ||  a_entryObject.keywords["BYOHHouseCraftingCategorySmithing"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_HOUSEPART;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$House Part");
+
+        } else if (a_entryObject.keywords["VendorItemDaedricArtifact"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_ARTIFACT;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Artifact");
+
+        } else if (a_entryObject.keywords["VendorItemGem"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_GEM;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
+
+        } else if (a_entryObject.keywords["VendorItemAnimalHide"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_HIDE;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Hide");
+
+        } else if (a_entryObject.keywords["VendorItemTool"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_TOOL;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Tool");
+
+        } else if (a_entryObject.keywords["VendorItemAnimalPart"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
+
+        } else if (a_entryObject.keywords["VendorItemOreIngot"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_INGOT;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingot");
+
+        } else if (a_entryObject.keywords["VendorItemFireword"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_FIREWOOD;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Firewood");
+
+        } else if(a_entryObject.keywords.VendorItemClutter != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_CLUTTER;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Clutter");
+        }
+    }
+
+    private function processMiscBaseId(a_entryObject: Object)
+    {
+        switch(a_entryObject.formId >>> 24) {
+            case 0x00:
+                switch (a_entryObject.baseId) {
+                    case skyui.defines.Form.FORMID_GEMAMETHYSTFLAWLESS:
+                    case skyui.defines.Form.FORMID_GEM1:
+                    case skyui.defines.Form.FORMID_GEM2:
+                    case skyui.defines.Form.FORMID_GEM3:
+                    case skyui.defines.Form.FORMID_GEM4:
+                        a_entryObject.subType = skyui.defines.Item.MISC_GEM;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
+                        break;
+
+                    case skyui.defines.Form.FORMID_RUBYDRAGONCLAW:
+                    case skyui.defines.Form.FORMID_IVORYDRAGONCLAW:
+                    case skyui.defines.Form.FORMID_GLASSCLAW:
+                    case skyui.defines.Form.FORMID_EBONYCLAW:
+                    case skyui.defines.Form.FORMID_EMERALDDRAGONCLAW:
+                    case skyui.defines.Form.FORMID_DIAMONDCLAW:
+                    case skyui.defines.Form.FORMID_IRONCLAW:
+                    case skyui.defines.Form.FORMID_CORALDRAGONCLAW:
+                    case skyui.defines.Form.FORMID_E3GOLDENCLAW:
+                    case skyui.defines.Form.FORMID_SAPPHIREDRAGONCLAW:
+                    case skyui.defines.Form.FORMID_MS13GOLDENCLAW:
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Claw");
+                        a_entryObject.subType = skyui.defines.Item.MISC_DRAGONCLAW;
+                        break;
+
+                    case skyui.defines.Form.FORMID_REMAINS1:
+                    case skyui.defines.Form.FORMID_REMAINS2:
+                    case skyui.defines.Form.FORMID_REMAINS3:
+                    case skyui.defines.Form.FORMID_REMAINS4:
+                    case skyui.defines.Form.FORMID_REMAINS5:
+                        a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
+                        break;
+
+                    case skyui.defines.Form.FORMID_LOCKPICK:
+                        a_entryObject.subType = skyui.defines.Item.MISC_LOCKPICK;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Lockpick");
+                        break;
+
+                    case skyui.defines.Form.FORMID_GOLD001:
+                        a_entryObject.subType = skyui.defines.Item.MISC_GOLD;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gold");
+                        break;
+
+                    case skyui.defines.Form.FORMID_LEATHER01:
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Leather");
+                        a_entryObject.subType = skyui.defines.Item.MISC_LEATHER;
+                        break;
+
+                    case skyui.defines.Form.FORMID_LEATHERSTRIPS:
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Strips");
+                        a_entryObject.subType = skyui.defines.Item.MISC_LEATHERSTRIPS;
+                        break;
+
+                    case skyui.defines.Form.FORMID_CHITIN1:
+                        a_entryObject.subType = skyui.defines.Item.MISC_NETCHLEATHER;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$NetchLeather");
+                        break;
+
+                    case skyui.defines.Form.FORMID_BROKENWEAPON1:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON2:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON3:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON4:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON5:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON6:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON7:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON8:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON9:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON10:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON11:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON12:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON13:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON14:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON15:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON16:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON17:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON18:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON19:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON20:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON21:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON22:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON23:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON24:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON25:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON26:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON27:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON28:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON29:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON30:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON31:
+                        a_entryObject.subType = skyui.defines.Item.MISC_BROKENWEAPON;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BrokenWeapon");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP1:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP2:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP3:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP4:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP5:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP6:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP7:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP8:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP9:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP10:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP11:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP12:
+                        a_entryObject.subType = skyui.defines.Item.MISC_DWARVENSCRAP;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$DwarvenScrap");
+                        break;
+
+                    case skyui.defines.Form.FORMID_INSTRUMENT1:
+                    case skyui.defines.Form.FORMID_INSTRUMENT2:
+                    case skyui.defines.Form.FORMID_INSTRUMENT3:
+                    case skyui.defines.Form.FORMID_INSTRUMENT4:
+                    case skyui.defines.Form.FORMID_INSTRUMENT5:
+                    case skyui.defines.Form.FORMID_INSTRUMENT6:
+                    case skyui.defines.Form.FORMID_INSTRUMENT7:
+                    case skyui.defines.Form.FORMID_INSTRUMENT8:
+                    case skyui.defines.Form.FORMID_INSTRUMENT9:
+                        a_entryObject.subType = skyui.defines.Item.MISC_INSTRUMENT;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Instrument");
+                        break;
+
+                    case skyui.defines.Form.FORMID_BUGJAR1:
+                    case skyui.defines.Form.FORMID_BUGJAR2:
+                    case skyui.defines.Form.FORMID_BUGJAR3:
+                    case skyui.defines.Form.FORMID_BUGJAR4:
+                    case skyui.defines.Form.FORMID_BUGJAR5:
+                        a_entryObject.subType = skyui.defines.Item.MISC_BUGJAR;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BugJar");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCMAP1:
+                    case skyui.defines.Form.FORMID_MISCMAP2:
+                        a_entryObject.subType = skyui.defines.Item.MISC_MAP;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCAZURASSTAR:
+                        a_entryObject.subType = skyui.defines.Item.MISC_ARTIFACT;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Artifact");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCARTIFACT1:
+                    case skyui.defines.Form.FORMID_MISCARTIFACT2:
+                        a_entryObject.subType = skyui.defines.Item.MISC_ARTIFACT;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Artifact");
+                        a_entryObject.iconLabel = "default_potion";
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCPOTION:
+                        a_entryObject.subType = skyui.defines.Item.MISC_POTION;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Potion");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCPOISON:
+                        a_entryObject.subType = skyui.defines.Item.MISC_POISON;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Poison");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCSCROLL1:
+                    case skyui.defines.Form.FORMID_MISCSCROLL2:
+                    case skyui.defines.Form.FORMID_MISCSCROLL3:
+                        a_entryObject.subType = skyui.defines.Item.MISC_SCROLL;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Scroll");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCBOOK1:
+                    case skyui.defines.Form.FORMID_MISCBOOK2:
+                    case skyui.defines.Form.FORMID_MISCBOOK3:
+                    case skyui.defines.Form.FORMID_MISCBOOK4:
+                        a_entryObject.subType = skyui.defines.Item.MISC_BOOK;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Book");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCRING1:
+                    case skyui.defines.Form.FORMID_MISCRING2:
+                    case skyui.defines.Form.FORMID_MISCRING3:
+                    case skyui.defines.Form.FORMID_MISCRING4:
+                    case skyui.defines.Form.FORMID_MISCRING5:
+                        a_entryObject.subType = skyui.defines.Item.MISC_RING;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ring");
+                        break;
+
+                    case skyui.defines.Form.FORMID_ORE1:
+                    case skyui.defines.Form.FORMID_ORE2:
+                    case skyui.defines.Form.FORMID_ORE3:
+                    case skyui.defines.Form.FORMID_ORE4:
+                    case skyui.defines.Form.FORMID_ORE5:
+                    case skyui.defines.Form.FORMID_ORE6:
+                    case skyui.defines.Form.FORMID_ORE7:
+                    case skyui.defines.Form.FORMID_ORE8:
+                    case skyui.defines.Form.FORMID_ORE9:
+                    case skyui.defines.Form.FORMID_ORE10:
+                        a_entryObject.subType = skyui.defines.Item.MISC_ORE;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
+                        break
+
+                    default:
+                        break;
+                }
+                break;
+
+            case 0x01:
+                switch (a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_UPDATEHORSETACK1:
+                    case skyui.defines.Form.FORMID_UPDATEHORSETACK2:
+                        a_entryObject.subType = skyui.defines.Item.MISC_HORSETACK;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$HorseTack");
+                        break;
+
+                    default:
+                        break;
+                }
+                break;
+
+            case 0x02:
+                switch (a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_DLC1GEM1:
+                    case skyui.defines.Form.FORMID_DLC1GEM2:
+                    case skyui.defines.Form.FORMID_DLC1GEM3:
+                    case skyui.defines.Form.FORMID_DLC1GEM4:
+                    case skyui.defines.Form.FORMID_DLC1GEM5:
+                        a_entryObject.subType = skyui.defines.Item.MISC_GEM;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC1REMAINS1:
+                    case skyui.defines.Form.FORMID_DLC1REMAINS2:
+                    case skyui.defines.Form.FORMID_DLC1REMAINS3:
+                    case skyui.defines.Form.FORMID_DLC1REMAINS4:
+                    case skyui.defines.Form.FORMID_DLC1REMAINS5:
+                    case skyui.defines.Form.FORMID_DLC1REMAINS6:
+                    case skyui.defines.Form.FORMID_DLC1REMAINS7:
+                        a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC1CHITIN1:
+                        a_entryObject.subType = skyui.defines.Item.MISC_NETCHLEATHER;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$NetchLeather");
+                        break
+
+                    default:
+                        break;
+                }
+                break;
+
+            case 0x03:
+                switch (a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_HFHOUSEPART1:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART2:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART3:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART4:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART5:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART6:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART7:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART8:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART9:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART10:
+                        a_entryObject.subType = skyui.defines.Item.MISC_HOUSEPART;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BuildingMaterial");
+                        break;
+                    
+                    default:
+                        break;
+                }
+                break;
+
+            case 0x04:
+                switch (a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_DLC2DRAGONCLAW1:
+                    case skyui.defines.Form.FORMID_DLC2DRAGONCLAW2:
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Claw");
+                        a_entryObject.subType = skyui.defines.Item.MISC_DRAGONCLAW;
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2GEM1:
+                    case skyui.defines.Form.FORMID_DLC2GEM2:
+                    case skyui.defines.Form.FORMID_DLC2GEM3:
+                    case skyui.defines.Form.FORMID_DLC2GEM4:
+                    case skyui.defines.Form.FORMID_DLC2GEM5:
+                        a_entryObject.subType = skyui.defines.Item.MISC_GEM;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2CHITIN1:
+                    case skyui.defines.Form.FORMID_DLC2NETCHLEATHER:
+                        a_entryObject.subType = skyui.defines.Item.MISC_NETCHLEATHER;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$NetchLeather");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2TROLLSKULL:
+                        a_entryObject.subType = skyui.defines.Item.MISC_TROLLSKULL;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2SCROLLSPIDERMISC1:
+                    case skyui.defines.Form.FORMID_DLC2SCROLLSPIDERMISC2:
+                        a_entryObject.subType = skyui.defines.Item.MISC_SCROLLSPIDER;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ScrollSpider");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2MISCMAP:
+                        a_entryObject.subType = skyui.defines.Item.MISC_MAP;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2INGREDIENT:
+                        a_entryObject.subType = skyui.defines.Item.MISC_INGREDIENT;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingredient");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2ORE1:
+                    case skyui.defines.Form.FORMID_DLC2ORE2:
+                    case skyui.defines.Form.FORMID_DLC2ORE3:
+                        a_entryObject.subType = skyui.defines.Item.MISC_ORE;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
+                        break;
+
+                    default:
+                        break;
+                }
+                break;
+
+            case 0xFE:
+                switch (a_entryObject.eslId) {
+                    case skyui.defines.Form.ESLID_CC019STAFFREMAINS:
+                    case skyui.defines.Form.ESLID_CC036PETWOLFREMAINS:
+                        a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
+                        break;
+
+                    case skyui.defines.Form.ESLID_CCKRTALTARGOLD:
+                        a_entryObject.subType = skyui.defines.Item.MISC_GOLD;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gold");
+                        break;
+
+                    case skyui.defines.Form.ESLID_CCVSV002PETGEAR:
+                    case skyui.defines.Form.ESLID_CCVSV002PETAMULET:
+                        a_entryObject.subType = skyui.defines.Item.MISC_PETGEAR;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$PetGear");
+                        break;
+
+                    default:
+                        break;
+                }
+                break;
+
+            default:
+                switch (a_entryObject.baseId)
+                {
+                    case skyui.defines.Form.BASEID_CCALMSIVIGEM1:
+                    case skyui.defines.Form.BASEID_CCALMSIVIGEM2:
+                    case skyui.defines.Form.BASEID_CCALMSIVIGEM3:
+                    case skyui.defines.Form.BASEID_CCALMSIVIGEM4:
+                        a_entryObject.subType = skyui.defines.Item.MISC_GEM;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL1:
+                    case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL2:
+                    case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL3:
+                    case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL4:
+                    case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL5:
+                    case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL6:
+                        a_entryObject.subType = skyui.defines.Item.MISC_AYLEIDCRYSTAL;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$AyleidCrystal");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CC001DWESCRAP:
+                        a_entryObject.subType = skyui.defines.Item.MISC_DWARVENSCRAP;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$DwarvenScrap");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CC025BUGJAR1:
+                    case skyui.defines.Form.BASEID_CC025BUGJAR2:
+                    case skyui.defines.Form.BASEID_CC025BUGJAR3:
+                        a_entryObject.subType = skyui.defines.Item.MISC_BUGJAR;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BugJar");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CC031MISCMAP:
+                        a_entryObject.subType = skyui.defines.Item.MISC_MAP;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CCALMSIVIPOTION:
+                        a_entryObject.subType = skyui.defines.Item.MISC_POTION;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Potion");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT1:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT2:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT3:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT4:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT5:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT6:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT7:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT8:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT9:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT10:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT11:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT12:
+                        a_entryObject.subType = skyui.defines.Item.MISC_INGREDIENT;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingredient");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CC025ORE1:
+                    case skyui.defines.Form.BASEID_CC025ORE2:
+                        a_entryObject.subType = skyui.defines.Item.MISC_ORE;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
+                        break;
+
+                    default:
+                        break;
+                }
+                break;
+        }
+    }
+
+    private function fixSKSEExtendedObject(a_extendedObject: Object)
+    {
+        if (a_extendedObject.formType == undefined)
             return;
-      }
-   }
-   function fixSKSEExtendedObject(a_extendedObject)
-   {
-      if(a_extendedObject.formType == undefined)
-      {
-         return undefined;
-      }
-      var _loc2_;
-      switch(a_extendedObject.formType)
-      {
-         case skyui.defines.Form.TYPE_SPELL:
-         case skyui.defines.Form.TYPE_SCROLLITEM:
-         case skyui.defines.Form.TYPE_INGREDIENT:
-         case skyui.defines.Form.TYPE_POTION:
-         case skyui.defines.Form.TYPE_EFFECTSETTING:
-            if(a_extendedObject.school == undefined && a_extendedObject.subType != undefined)
-            {
-               a_extendedObject.school = a_extendedObject.subType;
-               delete a_extendedObject.subType;
-            }
-            if(a_extendedObject.resistance == undefined && a_extendedObject.magicType != undefined)
-            {
-               a_extendedObject.resistance = a_extendedObject.magicType;
-               delete a_extendedObject.magicType;
-            }
-            break;
-         case skyui.defines.Form.TYPE_WEAPON:
-            if(a_extendedObject.weaponType == undefined && a_extendedObject.subType != undefined)
-            {
-               a_extendedObject.weaponType = a_extendedObject.subType;
-               delete a_extendedObject.subType;
-            }
-            break;
-         case skyui.defines.Form.TYPE_BOOK:
-            if(a_extendedObject.flags == undefined && a_extendedObject.bookType != undefined)
-            {
-               _loc2_ = a_extendedObject.bookType;
-               a_extendedObject.bookType = (_loc2_ & 0xFF00) >>> 8;
-               a_extendedObject.flags = _loc2_ & 0xFF;
-            }
-         default:
-            return;
-      }
-   }
+
+        switch(a_extendedObject.formType) {
+            case skyui.defines.Form.TYPE_SPELL:
+            case skyui.defines.Form.TYPE_SCROLLITEM:
+            case skyui.defines.Form.TYPE_INGREDIENT:
+            case skyui.defines.Form.TYPE_POTION:
+            case skyui.defines.Form.TYPE_EFFECTSETTING:
+
+                // school is sent as subType
+                if (a_extendedObject.school == undefined && a_extendedObject.subType != undefined) {
+                    a_extendedObject.school = a_extendedObject.subType;
+                    delete(a_extendedObject.subType);
+                }
+
+                // resistance is sent as magicType
+                if (a_extendedObject.resistance == undefined && a_extendedObject.magicType != undefined) {
+                    a_extendedObject.resistance = a_extendedObject.magicType;
+                    delete(a_extendedObject.magicType);
+                }
+
+                // primaryValue is sent as actorValue
+                /* // Ignore
+                if (a_extendedObject.primaryValue == undefined && a_extendedObject.actorValue != undefined) {
+                    a_extendedObject.primaryValue = a_extendedObject.actorValue;
+                    delete(a_extendedObject.actorValue);
+                }
+                */
+                break;
+
+            case skyui.defines.Form.TYPE_WEAPON:
+                // weaponType is sent as subType
+                if (a_extendedObject.weaponType == undefined && a_extendedObject.subType != undefined) {
+                    a_extendedObject.weaponType = a_extendedObject.subType;
+                    delete(a_extendedObject.subType);
+                }
+                break;
+
+            case skyui.defines.Form.TYPE_BOOK:
+                // (SKSE < 1.6.6) flags and bookType (and some padding) are sent as one UInt32 bookType
+                if (a_extendedObject.flags == undefined && a_extendedObject.bookType != undefined) {
+                    var oldBookType: Number = a_extendedObject.bookType;
+                    a_extendedObject.bookType	= (oldBookType & 0xFF00) >>> 8;
+                    a_extendedObject.flags		= (oldBookType & 0x00FF);
+                }
+                break;
+
+            default:
+                break;
+        }
+    }
 }

--- a/source/actionscript/ItemMenus/BarterDataSetter.as
+++ b/source/actionscript/ItemMenus/BarterDataSetter.as
@@ -1,29 +1,43 @@
 class BarterDataSetter extends InventoryDataSetter
 {
-   var _barterBuyMult;
-   var _barterSellMult;
-   function BarterDataSetter(a_barterBuyMult, a_barterSellMult)
-   {
-      super();
-      this._barterBuyMult = a_barterBuyMult != undefined ? a_barterBuyMult : 1;
-      this._barterSellMult = a_barterSellMult != undefined ? a_barterSellMult : 1;
-   }
-   function processEntry(a_entryObject, a_itemInfo)
-   {
-      if(a_entryObject.filterFlag < 1024)
-      {
-         a_itemInfo.value *= this._barterSellMult;
-      }
-      else
-      {
-         a_itemInfo.value = Math.max(a_itemInfo.value * this._barterBuyMult,1);
-      }
-      a_itemInfo.value = Math.floor(a_itemInfo.value + 0.5);
-      super.processEntry(a_entryObject,a_itemInfo);
-   }
-   function updateBarterMultipliers(a_barterBuyMult, a_barterSellMult)
-   {
-      this._barterBuyMult = a_barterBuyMult != undefined ? a_barterBuyMult : 1;
-      this._barterSellMult = a_barterSellMult != undefined ? a_barterSellMult : 1;
-   }
+/* PRIVATE VARIABLES */
+    
+    private var _barterBuyMult: Number;
+    private var _barterSellMult: Number;
+    
+    
+/* INITIALIZATION */
+    
+    public function BarterDataSetter(a_barterBuyMult: Number, a_barterSellMult: Number)
+    {
+        super();
+
+        this._barterBuyMult = (a_barterBuyMult == undefined) ? 1.0 : a_barterBuyMult;
+        this._barterSellMult = (a_barterSellMult == undefined) ? 1.0 : a_barterSellMult;
+    }
+    
+    
+/* PUBLIC FUNCTIONS */
+    
+    // @override InventoryDataSetter
+    public function processEntry(a_entryObject: Object, a_itemInfo: Object)
+    {
+        // Apply multipliers to itemInfo value, then process the entry
+        if (a_entryObject.filterFlag < 1024) {
+            a_itemInfo.value *= this._barterSellMult;
+        } else {
+            a_itemInfo.value = Math.max((a_itemInfo.value * this._barterBuyMult), 1);
+        }
+        a_itemInfo.value = Math.floor(a_itemInfo.value + 0.5);
+
+        super.processEntry(a_entryObject, a_itemInfo);
+    }
+
+    public function updateBarterMultipliers(a_barterBuyMult: Number, a_barterSellMult: Number)
+    {
+        // Not used (yet/ever)
+        // see BarterMenu.doTransaction
+        this._barterBuyMult = (a_barterBuyMult == undefined) ? 1.0 : a_barterBuyMult;
+        this._barterSellMult = (a_barterSellMult == undefined) ? 1.0 : a_barterSellMult;
+    }
 }

--- a/source/actionscript/ItemMenus/BarterMenu.as
+++ b/source/actionscript/ItemMenus/BarterMenu.as
@@ -1,170 +1,213 @@
 class BarterMenu extends ItemMenu
 {
-   var _cancelControls;
-   var _categoryListIconArt;
-   var _platform;
-   var _searchControls;
-   var _sortColumnControls;
-   var _sortOrderControls;
-   var _switchControls;
-   var _tabBarIconArt;
-   var bottomBar;
-   var inventoryLists;
-   var itemCard;
-   var navPanel;
-   var _buyMult = 1;
-   var _sellMult = 1;
-   var _confirmAmount = 0;
-   var _playerGold = 0;
-   var _vendorGold = 0;
-   var bEnableTabs = true;
-   function BarterMenu()
-   {
-      super();
-      this._categoryListIconArt = ["inv_all","inv_weapons","inv_armor","inv_potions","inv_scrolls","inv_food","inv_ingredients","inv_books","inv_keys","inv_misc"];
-      this._tabBarIconArt = ["buy","sell"];
-   }
-   function InitExtensions()
-   {
-      super.InitExtensions();
-      gfx.io.GameDelegate.addCallBack("SetBarterMultipliers",this,"SetBarterMultipliers");
-      this.itemCard.addEventListener("messageConfirm",this,"onTransactionConfirm");
-      this.itemCard.addEventListener("sliderChange",this,"onQuantitySliderChange");
-      this.inventoryLists.tabBarIconArt = this._tabBarIconArt;
-      var _loc3_ = this.inventoryLists.categoryList;
-      _loc3_.iconArt = this._categoryListIconArt;
-   }
-   function setConfig(a_config)
-   {
-      super.setConfig(a_config);
-      var _loc3_ = this.inventoryLists.itemList;
-      _loc3_.addDataProcessor(new BarterDataSetter(this._buyMult,this._sellMult));
-      _loc3_.addDataProcessor(new InventoryIconSetter(a_config.Appearance));
-      _loc3_.addDataProcessor(new skyui.props.PropertyDataExtender(a_config.Appearance,a_config.Properties,"itemProperties","itemIcons","itemCompoundProperties"));
-      var _loc5_ = skyui.components.list.ListLayoutManager.createLayout(a_config.ListLayout,"ItemListLayout");
-      _loc3_.layout = _loc5_;
-      if(this.inventoryLists.categoryList.selectedEntry)
-      {
-         _loc5_.changeFilterFlag(this.inventoryLists.categoryList.selectedEntry.flag);
-      }
-   }
-   function onExitButtonPress()
-   {
-      gfx.io.GameDelegate.call("CloseMenu",[]);
-   }
-   function SetBarterMultipliers(a_buyMult, a_sellMult)
-   {
-      this._buyMult = a_buyMult;
-      this._sellMult = a_sellMult;
-   }
-   function ShowRawDealWarning(a_warning)
-   {
-      this.itemCard.ShowConfirmMessage(a_warning);
-   }
-   function UpdateItemCardInfo(a_updateObj)
-   {
-      if(this.isViewingVendorItems())
-      {
-         a_updateObj.value *= this._buyMult;
-         a_updateObj.value = Math.max(a_updateObj.value,1);
-      }
-      else
-      {
-         a_updateObj.value *= this._sellMult;
-      }
-      a_updateObj.value = Math.floor(a_updateObj.value + 0.5);
-      this.itemCard.itemInfo = a_updateObj;
-      this.bottomBar.updateBarterPerItemInfo(a_updateObj);
-   }
-   function UpdatePlayerInfo(a_playerGold, a_vendorGold, a_vendorName, a_playerUpdateObj)
-   {
-      this._vendorGold = a_vendorGold;
-      this._playerGold = a_playerGold;
-      this.bottomBar.updateBarterInfo(a_playerUpdateObj,this.itemCard.itemInfo,a_playerGold,a_vendorGold,a_vendorName);
-   }
-   function onShowItemsList(event)
-   {
-      this.inventoryLists.showItemsList();
-   }
-   function onItemHighlightChange(event)
-   {
-      if(event.index != -1)
-      {
-         this.updateBottomBar(true);
-      }
-      super.onItemHighlightChange(event);
-   }
-   function onHideItemsList(event)
-   {
-      super.onHideItemsList(event);
-      this.bottomBar.updateBarterPerItemInfo({type:skyui.defines.Inventory.ICT_NONE});
-      this.updateBottomBar(false);
-   }
-   function onQuantitySliderChange(event)
-   {
-      var _loc2_ = this.itemCard.itemInfo.value * event.value;
-      if(this.isViewingVendorItems())
-      {
-         _loc2_ *= -1;
-      }
-      this.bottomBar.updateBarterPriceInfo(this._playerGold,this._vendorGold,this.itemCard.itemInfo,_loc2_);
-   }
-   function onQuantityMenuSelect(event)
-   {
-      var _loc2_ = event.amount * this.itemCard.itemInfo.value;
-      if(_loc2_ > this._vendorGold && !this.isViewingVendorItems())
-      {
-         this._confirmAmount = event.amount;
-         gfx.io.GameDelegate.call("GetRawDealWarningString",[_loc2_],this,"ShowRawDealWarning");
-         this.bottomBar.updateBarterPriceInfo(this._playerGold,this._vendorGold,this.itemCard.itemInfo,_loc2_);
-         return undefined;
-      }
-      this.doTransaction(event.amount);
-   }
-   function onItemCardSubMenuAction(event)
-   {
-      super.onItemCardSubMenuAction(event);
-      if(event.menu == "quantity")
-      {
-         if(event.opening)
-         {
-            this.onQuantitySliderChange({value:this.itemCard.itemInfo.count});
-            return undefined;
-         }
-         this.bottomBar.updateBarterPriceInfo(this._playerGold,this._vendorGold);
-      }
-   }
-   function onTransactionConfirm()
-   {
-      this.doTransaction(this._confirmAmount);
-      this._confirmAmount = 0;
-   }
-   function doTransaction(a_amount)
-   {
-      gfx.io.GameDelegate.call("ItemSelect",[a_amount,this.itemCard.itemInfo.value,this.isViewingVendorItems()]);
-   }
-   function isViewingVendorItems()
-   {
-      return this.inventoryLists.categoryList.activeSegment == 0;
-   }
-   function updateBottomBar(a_bSelected)
-   {
-      this.navPanel.clearButtons();
-      if(a_bSelected)
-      {
-         this.navPanel.addButton({text:(!this.isViewingVendorItems() ? "$Sell" : "$Buy"),controls:skyui.defines.Input.Activate});
-      }
-      else
-      {
-         this.navPanel.addButton({text:"$Exit",controls:this._cancelControls});
-         this.navPanel.addButton({text:"$Search",controls:this._searchControls});
-         if(this._platform != 0)
-         {
-            this.navPanel.addButton({text:"$Column",controls:this._sortColumnControls});
-            this.navPanel.addButton({text:"$Order",controls:this._sortOrderControls});
-         }
-         this.navPanel.addButton({text:"$Switch Tab",controls:this._switchControls});
-      }
-      this.navPanel.updateButtons(true);
-   }
+  /* PRIVATE VARIABLES */
+
+    private var _buyMult: Number = 1;
+    private var _sellMult: Number = 1;
+    private var _confirmAmount: Number = 0;
+    private var _playerGold: Number = 0;
+    private var _vendorGold: Number = 0;
+
+    private var _categoryListIconArt: Array;
+    private var _tabBarIconArt: Array;
+    
+    
+  /* PROPERTIES */
+    
+    // @override ItemMenu
+    public var bEnableTabs: Boolean = true;
+
+
+  /* INITIALIZATION */
+
+    public function BarterMenu()
+    {
+        super();
+
+        this._categoryListIconArt = ["inv_all", "inv_weapons", "inv_armor", "inv_potions", "inv_scrolls", "inv_food", "inv_ingredients", "inv_books", "inv_keys", "inv_misc"];
+        this._tabBarIconArt = ["buy", "sell"];
+    }
+    
+    
+  /* PUBLIC FUNCTIONS */
+
+    public function InitExtensions()
+    {
+        super.InitExtensions();
+        gfx.io.GameDelegate.addCallBack("SetBarterMultipliers", this, "SetBarterMultipliers");
+        
+        this.itemCard.addEventListener("messageConfirm",this,"onTransactionConfirm");
+        this.itemCard.addEventListener("sliderChange",this,"onQuantitySliderChange");
+        
+        this.inventoryLists.tabBarIconArt = this._tabBarIconArt;
+        
+        // Initialize menu-specific list components
+        var categoryList: CategoryList = this.inventoryLists.categoryList;
+        categoryList.iconArt = this._categoryListIconArt;
+    }
+
+    // @override ItemMenu
+    public function setConfig(a_config: Object)
+    {
+        super.setConfig(a_config);
+
+        var itemList: TabularList = this.inventoryLists.itemList;		
+        itemList.addDataProcessor(new BarterDataSetter(this._buyMult, this._sellMult));
+        itemList.addDataProcessor(new InventoryIconSetter(a_config["Appearance"]));
+        itemList.addDataProcessor(new skyui.props.PropertyDataExtender(a_config["Appearance"], a_config["Properties"], "itemProperties", "itemIcons", "itemCompoundProperties"));
+        
+        var layout: ListLayout = skyui.components.list.ListLayoutManager.createLayout(a_config["ListLayout"], "ItemListLayout");
+        itemList.layout = layout;
+
+        // Not 100% happy with doing this here, but has to do for now.
+        if (this.inventoryLists.categoryList.selectedEntry)
+            layout.changeFilterFlag(this.inventoryLists.categoryList.selectedEntry.flag);
+    }
+
+    private function onExitButtonPress()
+    {
+        gfx.io.GameDelegate.call("CloseMenu",[]);
+    }
+
+    // @API
+    public function SetBarterMultipliers(a_buyMult: Number, a_sellMult: Number)
+    {
+        this._buyMult = a_buyMult;
+        this._sellMult = a_sellMult;
+    }
+
+    // @API
+    public function ShowRawDealWarning(a_warning: String)
+    {
+        this.itemCard.ShowConfirmMessage(a_warning);
+    }
+    
+    // @override ItemMenu
+    public function UpdateItemCardInfo(a_updateObj: Object)
+    {
+        if (this.isViewingVendorItems()) {
+            a_updateObj.value *= this._buyMult;
+            a_updateObj.value = Math.max(a_updateObj.value, 1);
+        } else {
+            a_updateObj.value *= this._sellMult;
+        }
+        a_updateObj.value = Math.floor(a_updateObj.value + 0.5);
+        this.itemCard.itemInfo = a_updateObj;
+        this.bottomBar.updateBarterPerItemInfo(a_updateObj);
+    }
+
+    // @override ItemMenu
+    public function UpdatePlayerInfo(a_playerGold: Number, a_vendorGold: Number, a_vendorName: String, a_playerUpdateObj: Object)
+    {
+        this._vendorGold = a_vendorGold;
+        this._playerGold = a_playerGold;
+        this.bottomBar.updateBarterInfo(a_playerUpdateObj, this.itemCard.itemInfo, a_playerGold, a_vendorGold, a_vendorName);
+    }
+    
+    
+  /* PRIVATE FUNCTIONS */
+
+    // @override ItemMenu
+    private function onShowItemsList(event: Object)
+    {
+        this.inventoryLists.showItemsList();
+
+        //super.onShowItemsList(event);
+    }
+
+    // @override ItemMenu
+    private function onItemHighlightChange(event: Object)
+    {
+        if (event.index != -1)
+            this.updateBottomBar(true);
+
+        super.onItemHighlightChange(event);
+    }
+
+    // @override ItemMenu
+    private function onHideItemsList(event: Object)
+    {
+        super.onHideItemsList(event);
+
+        this.bottomBar.updateBarterPerItemInfo({type: skyui.defines.Inventory.ICT_NONE});
+        
+        this.updateBottomBar(false);
+    }
+    
+    private function onQuantitySliderChange(event: Object)
+    {
+        var price = this.itemCard.itemInfo.value * event.value;
+        if (this.isViewingVendorItems()) {
+            price *= -1;
+        }
+        this.bottomBar.updateBarterPriceInfo(this._playerGold, this._vendorGold, this.itemCard.itemInfo, price);
+    }
+    
+    // @override ItemMenu
+    private function onQuantityMenuSelect(event: Object)
+    {
+        var price = event.amount * this.itemCard.itemInfo.value;
+        if (price > this._vendorGold && !this.isViewingVendorItems()) {
+            this._confirmAmount = event.amount;
+
+            gfx.io.GameDelegate.call("GetRawDealWarningString", [price], this, "ShowRawDealWarning");
+
+            this.bottomBar.updateBarterPriceInfo(this._playerGold, this._vendorGold, this.itemCard.itemInfo, price);
+            return;
+        }
+        this.doTransaction(event.amount);
+    }
+
+    // @override ItemMenu
+    private function onItemCardSubMenuAction(event: Object)
+    {
+        super.onItemCardSubMenuAction(event);
+        if (event.menu == "quantity") {
+            if (event.opening) {
+                this.onQuantitySliderChange({value: this.itemCard.itemInfo.count});
+                return;
+            }
+            this.bottomBar.updateBarterPriceInfo(this._playerGold, this._vendorGold);
+        }
+    }
+    
+    private function onTransactionConfirm()
+    {
+        this.doTransaction(this._confirmAmount);
+        this._confirmAmount = 0;
+    }
+    
+    private function doTransaction(a_amount: Number)
+    {
+        gfx.io.GameDelegate.call("ItemSelect",[a_amount, this.itemCard.itemInfo.value, this.isViewingVendorItems()]);
+        // Update barter multipliers
+        // Update itemList => dataProcessor => BarterDataSetter updateBarterMultipliers
+        // Update itemCardInfo gfx.io.GameDelegate.call("RequestItemCardInfo",[], this, "UpdateItemCardInfo");
+    }
+    
+    private function isViewingVendorItems()
+    {
+        return this.inventoryLists.categoryList.activeSegment == 0;
+    }
+    
+    // @override ItemMenu
+    private function updateBottomBar(a_bSelected: Boolean)
+    {
+        this.navPanel.clearButtons();
+        
+        if (a_bSelected) {
+            this.navPanel.addButton({text: (this.isViewingVendorItems() ? "$Buy" : "$Sell"), controls: skyui.defines.Input.Activate});
+        } else {
+            this.navPanel.addButton({text: "$Exit", controls: this._cancelControls});
+            this.navPanel.addButton({text: "$Search", controls: this._searchControls});
+            if (this._platform != 0) {
+                this.navPanel.addButton({text: "$Column", controls: this._sortColumnControls});
+                this.navPanel.addButton({text: "$Order", controls: this._sortOrderControls});
+            }
+            this.navPanel.addButton({text: "$Switch Tab", controls: this._switchControls});
+        }
+        
+        this.navPanel.updateButtons(true);
+    }
+
 }

--- a/source/actionscript/ItemMenus/BottomBar.as
+++ b/source/actionscript/ItemMenus/BottomBar.as
@@ -1,372 +1,354 @@
 class BottomBar extends MovieClip
-{
-   var _healthMeter;
-   var _lastItemType;
-   var _levelMeter;
-   var _magickaMeter;
-   var _playerInfoObj;
-   var _staminaMeter;
-   var buttonPanel;
-   var playerInfoCard;
-   function BottomBar()
-   {
-      super();
-      this._lastItemType = skyui.defines.Inventory.ICT_NONE;
-      this._healthMeter = new Components.Meter(this.playerInfoCard.HealthRect.MeterInstance.Meter_mc);
-      this._magickaMeter = new Components.Meter(this.playerInfoCard.MagickaRect.MeterInstance.Meter_mc);
-      this._staminaMeter = new Components.Meter(this.playerInfoCard.StaminaRect.MeterInstance.Meter_mc);
-      this._levelMeter = new Components.Meter(this.playerInfoCard.LevelMeterInstance.Meter_mc);
-   }
-   function positionElements(a_leftOffset, a_rightOffset)
-   {
-      this.buttonPanel._x = a_leftOffset;
-      this.buttonPanel.updateButtons(true);
-      this.playerInfoCard._x = a_rightOffset - this.playerInfoCard._width;
-   }
-   function showPlayerInfo()
-   {
-      this.playerInfoCard._alpha = 100;
-   }
-   function hidePlayerInfo()
-   {
-      this.playerInfoCard._alpha = 0;
-   }
-   function UpdatePlayerInfo(a_playerUpdateObj, a_itemUpdateObj)
-   {
-      this._playerInfoObj = a_playerUpdateObj;
-      this.updatePerItemInfo(a_itemUpdateObj);
-   }
-   function updatePerItemInfo(a_itemUpdateObj)
-   {
-      var _loc2_ = this.playerInfoCard;
-      var _loc4_ = a_itemUpdateObj.type;
-      var _loc11_ = true;
-      if(_loc4_ == undefined)
-      {
-         _loc4_ = this._lastItemType;
-         if(a_itemUpdateObj == undefined)
-         {
-            a_itemUpdateObj = {type:this._lastItemType};
-         }
-      }
-      else
-      {
-         this._lastItemType = _loc4_;
-      }
-      var _loc7_;
-      var _loc10_;
-      var _loc6_;
-      var _loc9_;
-      var _loc5_;
-      var _loc8_;
-      var _loc14_;
-      var _loc13_;
-      var _loc12_;
-      if(this._playerInfoObj != undefined && a_itemUpdateObj != undefined)
-      {
-         switch(_loc4_)
-         {
-            case skyui.defines.Inventory.ICT_ARMOR:
-               _loc2_.gotoAndStop("Armor");
-               _loc7_ = Math.floor(this._playerInfoObj.armor).toString();
-               if(a_itemUpdateObj.armorChange != undefined)
-               {
-                  _loc10_ = Math.round(a_itemUpdateObj.armorChange);
-                  if(_loc10_ > 0)
-                  {
-                     _loc7_ = _loc7_ + " <font color=\'#189515\'>(+" + _loc10_.toString() + ")</font>";
-                  }
-                  else if(_loc10_ < 0)
-                  {
-                     _loc7_ = _loc7_ + " <font color=\'#FF0000\'>(" + _loc10_.toString() + ")</font>";
-                  }
-               }
-               _loc2_.ArmorRatingValue.textAutoSize = "shrink";
-               _loc2_.ArmorRatingValue.html = true;
-               _loc2_.ArmorRatingValue.SetText(_loc7_,true);
-               _loc6_ = this._playerInfoObj.warmth != undefined ? Math.floor(this._playerInfoObj.warmth).toString() : "0";
-               if(a_itemUpdateObj.warmthChange != undefined)
-               {
-                  _loc9_ = Math.round(a_itemUpdateObj.warmthChange);
-                  if(_loc9_ > 0)
-                  {
-                     _loc6_ = _loc6_ + " <font color=\'#189515\'>(+" + _loc9_.toString() + ")</font>";
-                  }
-                  else if(_loc9_ < 0)
-                  {
-                     _loc6_ = _loc6_ + " <font color=\'#FF0000\'>(" + _loc9_.toString() + ")</font>";
-                  }
-               }
-               _loc2_.WarmthRatingLabel._visible = this._playerInfoObj.warmth != undefined;
-               _loc2_.WarmthRatingValue._visible = this._playerInfoObj.warmth != undefined;
-               _loc2_.WarmthRatingValue.textAutoSize = "shrink";
-               _loc2_.WarmthRatingValue.html = true;
-               _loc2_.WarmthRatingValue.SetText(_loc6_,true);
-               break;
-            case skyui.defines.Inventory.ICT_WEAPON:
-               _loc2_.gotoAndStop("Weapon");
-               _loc5_ = Math.floor(this._playerInfoObj.damage).toString();
-               if(a_itemUpdateObj.damageChange != undefined)
-               {
-                  _loc8_ = Math.round(a_itemUpdateObj.damageChange);
-                  if(_loc8_ > 0)
-                  {
-                     _loc5_ = _loc5_ + " <font color=\'#189515\'>(+" + _loc8_.toString() + ")</font>";
-                  }
-                  else if(_loc8_ < 0)
-                  {
-                     _loc5_ = _loc5_ + " <font color=\'#FF0000\'>(" + _loc8_.toString() + ")</font>";
-                  }
-               }
-               _loc2_.DamageValue.textAutoSize = "shrink";
-               _loc2_.DamageValue.html = true;
-               _loc2_.DamageValue.SetText(_loc5_,true);
-               break;
-            case skyui.defines.Inventory.ICT_POTION:
-            case skyui.defines.Inventory.ICT_FOOD:
-               _loc14_ = 0;
-               _loc13_ = 1;
-               _loc12_ = 2;
-               if(a_itemUpdateObj.potionType == _loc13_)
-               {
-                  _loc2_.gotoAndStop("MagickaPotion");
-                  break;
-               }
-               if(a_itemUpdateObj.potionType == _loc12_)
-               {
-                  _loc2_.gotoAndStop("StaminaPotion");
-                  break;
-               }
-               if(a_itemUpdateObj.potionType == _loc14_)
-               {
-                  _loc2_.gotoAndStop("HealthPotion");
-               }
-               break;
-            case skyui.defines.Inventory.ICT_SPELL_DEFAULT:
-            case skyui.defines.Inventory.ICT_ACTIVE_EFFECT:
-               _loc2_.gotoAndStop("Magic");
-               _loc11_ = false;
-               break;
-            case skyui.defines.Inventory.ICT_SPELL:
-               _loc2_.gotoAndStop("MagicSkill");
-               if(a_itemUpdateObj.magicSchoolName != undefined)
-               {
-                  this.updateSkillBar(a_itemUpdateObj.magicSchoolName,a_itemUpdateObj.magicSchoolLevel,a_itemUpdateObj.magicSchoolPct);
-               }
-               _loc11_ = false;
-               break;
-            case skyui.defines.Inventory.ICT_SHOUT:
-               _loc2_.gotoAndStop("Shout");
-               _loc2_.DragonSoulTextInstance.SetText(this._playerInfoObj.dragonSoulText);
-               _loc11_ = false;
-               break;
-            case skyui.defines.Inventory.ICT_BOOK:
-            case skyui.defines.Inventory.ICT_INGREDIENT:
-            case skyui.defines.Inventory.ICT_MISC:
-            case skyui.defines.Inventory.ICT_KEY:
-            default:
-               _loc2_.gotoAndStop("Default");
-         }
-         if(_loc11_)
-         {
-            _loc2_.CarryWeightValue.textAutoSize = "shrink";
-            _loc2_.CarryWeightValue.SetText(Math.ceil(this._playerInfoObj.encumbrance) + "/" + Math.floor(this._playerInfoObj.maxEncumbrance));
-            _loc2_.PlayerGoldValue.textAutoSize = "shrink";
-            _loc2_.PlayerGoldValue.SetText(this._playerInfoObj.gold.toString());
-            _loc2_.PlayerGoldLabel._x = _loc2_.PlayerGoldValue._x + _loc2_.PlayerGoldValue.getLineMetrics(0).x - _loc2_.PlayerGoldLabel._width;
-            _loc2_.CarryWeightValue._x = _loc2_.PlayerGoldLabel._x + _loc2_.PlayerGoldLabel.getLineMetrics(0).x - _loc2_.CarryWeightValue._width - 5;
-            _loc2_.CarryWeightLabel._x = _loc2_.CarryWeightValue._x + _loc2_.CarryWeightValue.getLineMetrics(0).x - _loc2_.CarryWeightLabel._width;
-            if(_loc4_ === skyui.defines.Inventory.ICT_ARMOR)
-            {
-               _loc2_.ArmorRatingValue._x = _loc2_.CarryWeightLabel._x + _loc2_.CarryWeightLabel.getLineMetrics(0).x - _loc2_.ArmorRatingValue._width - 5;
-               _loc2_.ArmorRatingLabel._x = _loc2_.ArmorRatingValue._x + _loc2_.ArmorRatingValue.getLineMetrics(0).x - _loc2_.ArmorRatingLabel._width;
-               _loc2_.WarmthRatingValue._x = _loc2_.ArmorRatingLabel._x + _loc2_.ArmorRatingLabel.getLineMetrics(0).x - _loc2_.WarmthRatingValue._width - 5;
-               _loc2_.WarmthRatingLabel._x = _loc2_.WarmthRatingValue._x + _loc2_.WarmthRatingValue.getLineMetrics(0).x - _loc2_.WarmthRatingLabel._width;
+{   
+  /* PRIVATE VARIABLES */	
+
+    private var _lastItemType: Number;
+    
+    private var _healthMeter: Meter;
+    private var _magickaMeter: Meter;
+    private var _staminaMeter: Meter;
+    private var _levelMeter: Meter;
+
+    private var _playerInfoObj: Object;
+    
+    
+  /* STAGE ELEMENTS */
+
+    public var playerInfoCard: MovieClip;
+    
+    
+  /* PROPERTIES */
+
+    public var buttonPanel: ButtonPanel;
+    
+    
+  /* INITIALIZATION */
+
+    public function BottomBar()
+    {
+        super();
+        this._lastItemType = skyui.defines.Inventory.ICT_NONE;
+        this._healthMeter = new Components.Meter(this.playerInfoCard.HealthRect.MeterInstance.Meter_mc);
+        this._magickaMeter = new Components.Meter(this.playerInfoCard.MagickaRect.MeterInstance.Meter_mc);
+        this._staminaMeter = new Components.Meter(this.playerInfoCard.StaminaRect.MeterInstance.Meter_mc);
+        this._levelMeter = new Components.Meter(this.playerInfoCard.LevelMeterInstance.Meter_mc);
+    }
+    
+    
+  /* PUBLIC FUNCTIONS */
+
+    public function positionElements(a_leftOffset: Number, a_rightOffset: Number)
+    {
+        this.buttonPanel._x = a_leftOffset;
+        this.buttonPanel.updateButtons(true);
+        this.playerInfoCard._x = a_rightOffset - this.playerInfoCard._width;
+    }
+
+    public function showPlayerInfo()
+    {
+        this.playerInfoCard._alpha = 100;
+    }
+
+    public function hidePlayerInfo()
+    {
+        this.playerInfoCard._alpha = 0;
+    }
+
+    // @API
+    public function UpdatePlayerInfo(a_playerUpdateObj: Object, a_itemUpdateObj: Object)
+    {
+        this._playerInfoObj = a_playerUpdateObj;
+        this.updatePerItemInfo(a_itemUpdateObj);
+    }
+
+    public function updatePerItemInfo(a_itemUpdateObj: Object)
+    {
+        var infoCard = this.playerInfoCard;
+        var itemType: Number = a_itemUpdateObj.type;
+        var bHasWeightandValue = true;
+        
+        if (itemType == undefined) {
+            itemType = this._lastItemType;
+            if (a_itemUpdateObj == undefined)
+                a_itemUpdateObj = {type: this._lastItemType};
+        } else {
+            this._lastItemType = itemType;
+        }
+        if (this._playerInfoObj != undefined && a_itemUpdateObj != undefined) {
+            switch(itemType) {
+                case skyui.defines.Inventory.ICT_ARMOR:
+                    infoCard.gotoAndStop("Armor");
+                    var strArmor: String = Math.floor(this._playerInfoObj.armor).toString();
+                    if (a_itemUpdateObj.armorChange != undefined) {
+                        var iArmorDelta = Math.round(a_itemUpdateObj.armorChange);
+                        if (iArmorDelta > 0) 
+                            strArmor = strArmor + " <font color=\'#189515\'>(+" + iArmorDelta.toString() + ")</font>";
+                        else if (iArmorDelta < 0) 
+                            strArmor = strArmor + " <font color=\'#FF0000\'>(" + iArmorDelta.toString() + ")</font>";
+                    }
+                    infoCard.ArmorRatingValue.textAutoSize = "shrink";
+                    infoCard.ArmorRatingValue.html = true;
+                    infoCard.ArmorRatingValue.SetText(strArmor, true);
+                    
+                    var strWarmth  = this._playerInfoObj.warmth != undefined ? Math.floor(this._playerInfoObj.warmth).toString() : "0";
+                    if (a_itemUpdateObj.warmthChange != undefined)
+                    {
+                        var iWarmthDelta = Math.round(a_itemUpdateObj.warmthChange);
+                        if (iWarmthDelta > 0)
+                            strWarmth = strWarmth + " <font color=\'#189515\'>(+" + iWarmthDelta.toString() + ")</font>";
+                        else if (iWarmthDelta < 0)
+                            strWarmth = strWarmth + " <font color=\'#FF0000\'>(" + iWarmthDelta.toString() + ")</font>";
+                    }
+                    infoCard.WarmthRatingLabel._visible = this._playerInfoObj.warmth != undefined;
+                    infoCard.WarmthRatingValue._visible = this._playerInfoObj.warmth != undefined;
+                    infoCard.WarmthRatingValue.textAutoSize = "shrink";
+                    infoCard.WarmthRatingValue.html = true;
+                    infoCard.WarmthRatingValue.SetText(strWarmth, true);
+                    break;
+                    
+                case skyui.defines.Inventory.ICT_WEAPON:
+                    infoCard.gotoAndStop("Weapon");
+                    var strDamage: String = Math.floor(this._playerInfoObj.damage).toString();
+                    if (a_itemUpdateObj.damageChange != undefined) {
+                        var iDamageDelta = Math.round(a_itemUpdateObj.damageChange);
+                        if (iDamageDelta > 0) 
+                            strDamage = strDamage + " <font color=\'#189515\'>(+" + iDamageDelta.toString() + ")</font>";
+                        else if (iDamageDelta < 0) 
+                            strDamage = strDamage + " <font color=\'#FF0000\'>(" + iDamageDelta.toString() + ")</font>";
+                    }
+                    infoCard.DamageValue.textAutoSize = "shrink";
+                    infoCard.DamageValue.html = true;
+                    infoCard.DamageValue.SetText(strDamage, true);
+                    break;
+                    
+                case skyui.defines.Inventory.ICT_POTION:
+                case skyui.defines.Inventory.ICT_FOOD:
+                    var EF_HEALTH: Number = 0;
+                    var EF_MAGICKA: Number = 1;
+                    var EF_STAMINA: Number = 2;
+                    if (a_itemUpdateObj.potionType == EF_MAGICKA) 
+                        infoCard.gotoAndStop("MagickaPotion");
+                    else if (a_itemUpdateObj.potionType == EF_STAMINA) 
+                        infoCard.gotoAndStop("StaminaPotion");
+                    else if (a_itemUpdateObj.potionType == EF_HEALTH) 
+                        infoCard.gotoAndStop("HealthPotion");
+                    break;
+                    
+                case skyui.defines.Inventory.ICT_SPELL_DEFAULT:
+                case skyui.defines.Inventory.ICT_ACTIVE_EFFECT:
+                    infoCard.gotoAndStop("Magic");
+                    bHasWeightandValue = false;
+                    break;
+                    
+                case skyui.defines.Inventory.ICT_SPELL:
+                    infoCard.gotoAndStop("MagicSkill");
+                    if (a_itemUpdateObj.magicSchoolName != undefined) 
+                        this.updateSkillBar(a_itemUpdateObj.magicSchoolName, a_itemUpdateObj.magicSchoolLevel, a_itemUpdateObj.magicSchoolPct);
+                    bHasWeightandValue = false;
+                    break;
+                    
+                case skyui.defines.Inventory.ICT_SHOUT:
+                    infoCard.gotoAndStop("Shout");
+                    infoCard.DragonSoulTextInstance.SetText(this._playerInfoObj.dragonSoulText);
+                    bHasWeightandValue = false;
+                    break;
+                    
+                case skyui.defines.Inventory.ICT_BOOK:
+                case skyui.defines.Inventory.ICT_INGREDIENT:
+                case skyui.defines.Inventory.ICT_MISC:
+                case skyui.defines.Inventory.ICT_KEY:
+                default:
+                    infoCard.gotoAndStop("Default");
             }
-            else if(_loc4_ === skyui.defines.Inventory.ICT_WEAPON)
-            {
-               _loc2_.DamageValue._x = _loc2_.CarryWeightLabel._x + _loc2_.CarryWeightLabel.getLineMetrics(0).x - _loc2_.DamageValue._width - 5;
-               _loc2_.DamageLabel._x = _loc2_.DamageValue._x + _loc2_.DamageValue.getLineMetrics(0).x - _loc2_.DamageLabel._width;
+            
+            if (bHasWeightandValue) {
+                infoCard.CarryWeightValue.textAutoSize = "shrink";
+                infoCard.CarryWeightValue.SetText(Math.ceil(this._playerInfoObj.encumbrance) + "/" + Math.floor(this._playerInfoObj.maxEncumbrance));
+                infoCard.PlayerGoldValue.textAutoSize = "shrink";
+                infoCard.PlayerGoldValue.SetText(this._playerInfoObj.gold.toString());
+                infoCard.PlayerGoldLabel._x = infoCard.PlayerGoldValue._x + infoCard.PlayerGoldValue.getLineMetrics(0).x - infoCard.PlayerGoldLabel._width;
+                infoCard.CarryWeightValue._x = infoCard.PlayerGoldLabel._x + infoCard.PlayerGoldLabel.getLineMetrics(0).x - infoCard.CarryWeightValue._width - 5;
+                infoCard.CarryWeightLabel._x = infoCard.CarryWeightValue._x + infoCard.CarryWeightValue.getLineMetrics(0).x - infoCard.CarryWeightLabel._width;
+                if (itemType === skyui.defines.Inventory.ICT_ARMOR) {
+                    infoCard.ArmorRatingValue._x = infoCard.CarryWeightLabel._x + infoCard.CarryWeightLabel.getLineMetrics(0).x - infoCard.ArmorRatingValue._width - 5;
+                    infoCard.ArmorRatingLabel._x = infoCard.ArmorRatingValue._x + infoCard.ArmorRatingValue.getLineMetrics(0).x - infoCard.ArmorRatingLabel._width;
+                    infoCard.WarmthRatingValue._x = infoCard.ArmorRatingLabel._x + infoCard.ArmorRatingLabel.getLineMetrics(0).x - infoCard.WarmthRatingValue._width - 5;
+                    infoCard.WarmthRatingLabel._x = infoCard.WarmthRatingValue._x + infoCard.WarmthRatingValue.getLineMetrics(0).x - infoCard.WarmthRatingLabel._width;
+                } else if (itemType === skyui.defines.Inventory.ICT_WEAPON) {
+                    infoCard.DamageValue._x = infoCard.CarryWeightLabel._x + infoCard.CarryWeightLabel.getLineMetrics(0).x - infoCard.DamageValue._width - 5;
+                    infoCard.DamageLabel._x = infoCard.DamageValue._x + infoCard.DamageValue.getLineMetrics(0).x - infoCard.DamageLabel._width;
+                }
             }
-         }
-         this.updateStatMeter(_loc2_.HealthRect,this._healthMeter,this._playerInfoObj.health,this._playerInfoObj.maxHealth,this._playerInfoObj.healthColor);
-         this.updateStatMeter(_loc2_.MagickaRect,this._magickaMeter,this._playerInfoObj.magicka,this._playerInfoObj.maxMagicka,this._playerInfoObj.magickaColor);
-         this.updateStatMeter(_loc2_.StaminaRect,this._staminaMeter,this._playerInfoObj.stamina,this._playerInfoObj.maxStamina,this._playerInfoObj.staminaColor);
-      }
-   }
-   function UpdateCraftingInfo(a_skillName, a_levelStart, a_levelPercent)
-   {
-      this.playerInfoCard.gotoAndStop("Crafting");
-      this.updateSkillBar(a_skillName,a_levelStart,a_levelPercent);
-   }
-   function updateBarterInfo(a_playerUpdateObj, a_itemUpdateObj, a_playerGold, a_vendorGold, a_vendorName)
-   {
-      this._playerInfoObj = a_playerUpdateObj;
-      var _loc2_ = this.playerInfoCard;
-      _loc2_.gotoAndStop("Barter");
-      _loc2_.CarryWeightValue.textAutoSize = "shrink";
-      _loc2_.CarryWeightValue.SetText(Math.ceil(this._playerInfoObj.encumbrance) + "/" + Math.floor(this._playerInfoObj.maxEncumbrance));
-      _loc2_.VendorGoldLabel.textAutoSize = "shrink";
-      if(a_vendorName != undefined)
-      {
-         _loc2_.VendorGoldLabel.SetText("$Gold");
-         _loc2_.VendorGoldLabel.SetText(a_vendorName + " " + _loc2_.VendorGoldLabel.text);
-      }
-      this.updateBarterPriceInfo(a_playerGold,a_vendorGold,a_itemUpdateObj);
-   }
-   function updateBarterPriceInfo(a_playerGold, a_vendorGold, a_itemUpdateObj, a_goldDelta)
-   {
-      var _loc2_ = this.playerInfoCard;
-      _loc2_.PlayerGoldValue.textAutoSize = "shrink";
-      if(a_goldDelta == undefined)
-      {
-         _loc2_.PlayerGoldValue.SetText(a_playerGold.toString(),true);
-      }
-      else if(a_goldDelta >= 0)
-      {
-         _loc2_.PlayerGoldValue.SetText(a_playerGold.toString() + " <font color=\'#189515\'>(+" + a_goldDelta.toString() + ")</font>",true);
-      }
-      else
-      {
-         _loc2_.PlayerGoldValue.SetText(a_playerGold.toString() + " <font color=\'#FF0000\'>(" + a_goldDelta.toString() + ")</font>",true);
-      }
-      _loc2_.VendorGoldValue.textAutoSize = "shrink";
-      _loc2_.VendorGoldValue.SetText(a_vendorGold.toString());
-      _loc2_.VendorGoldLabel._x = _loc2_.VendorGoldValue._x + _loc2_.VendorGoldValue.getLineMetrics(0).x - _loc2_.VendorGoldLabel._width;
-      _loc2_.PlayerGoldValue._x = _loc2_.VendorGoldLabel._x + _loc2_.VendorGoldLabel.getLineMetrics(0).x - _loc2_.PlayerGoldValue._width - 10;
-      _loc2_.PlayerGoldLabel._x = _loc2_.PlayerGoldValue._x + _loc2_.PlayerGoldValue.getLineMetrics(0).x - _loc2_.PlayerGoldLabel._width;
-      _loc2_.CarryWeightValue._x = _loc2_.PlayerGoldLabel._x + _loc2_.PlayerGoldLabel.getLineMetrics(0).x - _loc2_.CarryWeightValue._width - 5;
-      _loc2_.CarryWeightLabel._x = _loc2_.CarryWeightValue._x + _loc2_.CarryWeightValue.getLineMetrics(0).x - _loc2_.CarryWeightLabel._width;
-      this.updateBarterPerItemInfo(a_itemUpdateObj);
-   }
-   function updateBarterPerItemInfo(a_itemUpdateObj)
-   {
-      var _loc2_ = this.playerInfoCard;
-      var _loc10_ = a_itemUpdateObj.type;
-      if(_loc10_ == undefined)
-      {
-         _loc10_ = this._lastItemType;
-         if(a_itemUpdateObj == undefined)
-         {
-            a_itemUpdateObj = {type:this._lastItemType};
-         }
-      }
-      else
-      {
-         this._lastItemType = _loc10_;
-      }
-      var _loc6_;
-      var _loc9_;
-      var _loc5_;
-      var _loc8_;
-      var _loc4_;
-      var _loc7_;
-      if(a_itemUpdateObj != undefined)
-      {
-         _loc10_ = a_itemUpdateObj.type;
-         switch(_loc10_)
-         {
-            case skyui.defines.Inventory.ICT_ARMOR:
-               _loc2_.gotoAndStop("Barter_Armor");
-               _loc6_ = Math.floor(this._playerInfoObj.armor).toString();
-               if(a_itemUpdateObj.armorChange != undefined)
-               {
-                  _loc9_ = Math.round(a_itemUpdateObj.armorChange);
-                  if(_loc9_ > 0)
-                  {
-                     _loc6_ = _loc6_ + " <font color=\'#189515\'>(+" + _loc9_.toString() + ")</font>";
-                  }
-                  else if(_loc9_ < 0)
-                  {
-                     _loc6_ = _loc6_ + " <font color=\'#FF0000\'>(" + _loc9_.toString() + ")</font>";
-                  }
-               }
-               _loc2_.ArmorRatingValue.textAutoSize = "shrink";
-               _loc2_.ArmorRatingValue.html = true;
-               _loc2_.ArmorRatingValue.SetText(_loc6_,true);
-               _loc2_.ArmorRatingValue._x = _loc2_.CarryWeightLabel._x + _loc2_.CarryWeightLabel.getLineMetrics(0).x - _loc2_.ArmorRatingValue._width - 5;
-               _loc2_.ArmorRatingLabel._x = _loc2_.ArmorRatingValue._x + _loc2_.ArmorRatingValue.getLineMetrics(0).x - _loc2_.ArmorRatingLabel._width;
-               _loc5_ = Math.floor(this._playerInfoObj.warmth).toString();
-               if(a_itemUpdateObj.warmthChange != undefined)
-               {
-                  _loc8_ = Math.round(a_itemUpdateObj.warmthChange);
-                  if(_loc8_ > 0)
-                  {
-                     _loc5_ = _loc5_ + " <font color=\'#189515\'>(+" + _loc8_.toString() + ")</font>";
-                  }
-                  else if(_loc8_ < 0)
-                  {
-                     _loc5_ = _loc5_ + " <font color=\'#FF0000\'>(" + _loc8_.toString() + ")</font>";
-                  }
-               }
-               _loc2_.WarmthRatingLabel._visible = this._playerInfoObj.warmth != undefined;
-               _loc2_.WarmthRatingValue._visible = this._playerInfoObj.warmth != undefined;
-               _loc2_.WarmthRatingValue.textAutoSize = "shrink";
-               _loc2_.WarmthRatingValue.html = true;
-               _loc2_.WarmthRatingValue.SetText(_loc5_,true);
-               _loc2_.WarmthRatingValue._x = _loc2_.ArmorRatingLabel._x + _loc2_.ArmorRatingLabel.getLineMetrics(0).x - _loc2_.WarmthRatingValue._width - 5;
-               _loc2_.WarmthRatingLabel._x = _loc2_.WarmthRatingValue._x + _loc2_.WarmthRatingValue.getLineMetrics(0).x - _loc2_.WarmthRatingLabel._width;
-               return;
-            case skyui.defines.Inventory.ICT_WEAPON:
-               _loc2_.gotoAndStop("Barter_Weapon");
-               _loc4_ = Math.floor(this._playerInfoObj.damage).toString();
-               if(a_itemUpdateObj.damageChange != undefined)
-               {
-                  _loc7_ = Math.round(a_itemUpdateObj.damageChange);
-                  if(_loc7_ > 0)
-                  {
-                     _loc4_ = _loc4_ + " <font color=\'#189515\'>(+" + _loc7_.toString() + ")</font>";
-                  }
-                  else if(_loc7_ < 0)
-                  {
-                     _loc4_ = _loc4_ + " <font color=\'#FF0000\'>(" + _loc7_.toString() + ")</font>";
-                  }
-               }
-               _loc2_.DamageValue.textAutoSize = "shrink";
-               _loc2_.DamageValue.html = true;
-               _loc2_.DamageValue.SetText(_loc4_,true);
-               _loc2_.DamageValue._x = _loc2_.CarryWeightLabel._x + _loc2_.CarryWeightLabel.getLineMetrics(0).x - _loc2_.DamageValue._width - 5;
-               _loc2_.DamageLabel._x = _loc2_.DamageValue._x + _loc2_.DamageValue.getLineMetrics(0).x - _loc2_.DamageLabel._width;
-               return;
-            default:
-               _loc2_.gotoAndStop("Barter");
-               return;
-         }
-      }
-   }
-   function setGiftInfo(a_favorPoints)
-   {
-      this.playerInfoCard.gotoAndStop("Gift");
-   }
-   function setPlatform(a_platform, a_bPS3Switch)
-   {
-      this.buttonPanel.setPlatform(a_platform,a_bPS3Switch);
-   }
-   function updateStatMeter(a_meterRect, a_meterObj, a_currValue, a_maxValue, a_colorStr)
-   {
-      if(a_colorStr == undefined)
-      {
-         a_colorStr = "#FFFFFF";
-      }
-      if(a_meterRect._alpha > 0)
-      {
-         if(a_meterRect.MeterText != undefined)
-         {
-            a_meterRect.MeterText.textAutoSize = "shrink";
-            a_meterRect.MeterText.html = true;
-            a_meterRect.MeterText.SetText("<font color=\'" + a_colorStr + "\'>" + Math.floor(a_currValue) + "/" + Math.floor(a_maxValue) + "</font>",true);
-         }
-         a_meterRect.MeterInstance.gotoAndStop("Pause");
-         a_meterObj.SetPercent(a_currValue / a_maxValue * 100);
-      }
-   }
-   function updateSkillBar(a_skillName, a_levelStart, a_levelPercent)
-   {
-      var _loc2_ = this.playerInfoCard;
-      _loc2_.SkillLevelLabel.SetText(a_skillName);
-      _loc2_.SkillLevelCurrent.SetText(a_levelStart);
-      _loc2_.SkillLevelNext.SetText(a_levelStart + 1);
-      _loc2_.LevelMeterInstance.gotoAndStop("Pause");
-      this._levelMeter.SetPercent(a_levelPercent);
-   }
+            this.updateStatMeter(infoCard.HealthRect, this._healthMeter, this._playerInfoObj.health, this._playerInfoObj.maxHealth, this._playerInfoObj.healthColor);
+            this.updateStatMeter(infoCard.MagickaRect, this._magickaMeter, this._playerInfoObj.magicka, this._playerInfoObj.maxMagicka, this._playerInfoObj.magickaColor);
+            this.updateStatMeter(infoCard.StaminaRect, this._staminaMeter, this._playerInfoObj.stamina, this._playerInfoObj.maxStamina, this._playerInfoObj.staminaColor);
+        }
+    }
+
+    // @API
+    public function UpdateCraftingInfo(a_skillName: String, a_levelStart: Number, a_levelPercent: Number)
+    {
+        this.playerInfoCard.gotoAndStop("Crafting");
+        this.updateSkillBar(a_skillName, a_levelStart, a_levelPercent);
+    }
+
+    public function updateBarterInfo(a_playerUpdateObj: Object, a_itemUpdateObj: Object, a_playerGold: Number, a_vendorGold: Number, a_vendorName: String)
+    {
+        this._playerInfoObj = a_playerUpdateObj;
+
+        var infoCard = this.playerInfoCard;
+
+        infoCard.gotoAndStop("Barter");
+
+        infoCard.CarryWeightValue.textAutoSize = "shrink";
+        infoCard.CarryWeightValue.SetText(Math.ceil(this._playerInfoObj.encumbrance) + "/" + Math.floor(this._playerInfoObj.maxEncumbrance));
+
+        infoCard.VendorGoldLabel.textAutoSize = "shrink";
+        if (a_vendorName != undefined) {
+            infoCard.VendorGoldLabel.SetText("$Gold");
+            infoCard.VendorGoldLabel.SetText(a_vendorName + " " + infoCard.VendorGoldLabel.text);
+        }
+
+        this.updateBarterPriceInfo(a_playerGold, a_vendorGold, a_itemUpdateObj);
+    }
+
+    public function updateBarterPriceInfo(a_playerGold: Number, a_vendorGold: Number, a_itemUpdateObj: Object, a_goldDelta: Number)
+    {
+        var infoCard = this.playerInfoCard;
+
+        infoCard.PlayerGoldValue.textAutoSize = "shrink";
+        if (a_goldDelta == undefined) {
+            infoCard.PlayerGoldValue.SetText(a_playerGold.toString(), true);
+        } else if (a_goldDelta >= 0) {
+            infoCard.PlayerGoldValue.SetText(a_playerGold.toString() + " <font color=\'#189515\'>(+" + a_goldDelta.toString() + ")</font>", true);
+        } else {
+            infoCard.PlayerGoldValue.SetText(a_playerGold.toString() + " <font color=\'#FF0000\'>(" + a_goldDelta.toString() + ")</font>", true);
+        }
+
+        infoCard.VendorGoldValue.textAutoSize = "shrink";
+        infoCard.VendorGoldValue.SetText(a_vendorGold.toString());
+
+        infoCard.VendorGoldLabel._x = infoCard.VendorGoldValue._x + infoCard.VendorGoldValue.getLineMetrics(0).x - infoCard.VendorGoldLabel._width;
+        infoCard.PlayerGoldValue._x = infoCard.VendorGoldLabel._x + infoCard.VendorGoldLabel.getLineMetrics(0).x - infoCard.PlayerGoldValue._width - 10;
+        infoCard.PlayerGoldLabel._x = infoCard.PlayerGoldValue._x + infoCard.PlayerGoldValue.getLineMetrics(0).x - infoCard.PlayerGoldLabel._width;
+        infoCard.CarryWeightValue._x = infoCard.PlayerGoldLabel._x + infoCard.PlayerGoldLabel.getLineMetrics(0).x - infoCard.CarryWeightValue._width - 5;
+        infoCard.CarryWeightLabel._x = infoCard.CarryWeightValue._x + infoCard.CarryWeightValue.getLineMetrics(0).x - infoCard.CarryWeightLabel._width;
+
+        this.updateBarterPerItemInfo(a_itemUpdateObj);
+    }
+
+    public function updateBarterPerItemInfo(a_itemUpdateObj: Object)
+    {
+        var infoCard = this.playerInfoCard;
+        var itemType: Number = a_itemUpdateObj.type;
+
+        if (itemType == undefined) {
+            itemType = this._lastItemType;
+            if (a_itemUpdateObj == undefined)
+                a_itemUpdateObj = {type: this._lastItemType};
+        } else {
+            this._lastItemType = itemType;
+        }
+
+        if (a_itemUpdateObj != undefined) {
+            var itemType: Number = a_itemUpdateObj.type;
+            
+            switch(itemType) {
+                case skyui.defines.Inventory.ICT_ARMOR:
+                    infoCard.gotoAndStop("Barter_Armor");
+                    var strArmor: String = Math.floor(_playerInfoObj.armor).toString();
+                    if (a_itemUpdateObj.armorChange != undefined) {
+                        var iArmorDelta: Number = Math.round(a_itemUpdateObj.armorChange);
+                        if (iArmorDelta > 0) 
+                            strArmor = strArmor + " <font color=\'#189515\'>(+" + iArmorDelta.toString() + ")</font>";
+                        else if (iArmorDelta < 0) 
+                            strArmor = strArmor + " <font color=\'#FF0000\'>(" + iArmorDelta.toString() + ")</font>";
+                    }
+                    infoCard.ArmorRatingValue.textAutoSize = "shrink";
+                    infoCard.ArmorRatingValue.html = true;
+                    infoCard.ArmorRatingValue.SetText(strArmor, true);
+                    infoCard.ArmorRatingValue._x = infoCard.CarryWeightLabel._x + infoCard.CarryWeightLabel.getLineMetrics(0).x - infoCard.ArmorRatingValue._width - 5;
+                    infoCard.ArmorRatingLabel._x = infoCard.ArmorRatingValue._x + infoCard.ArmorRatingValue.getLineMetrics(0).x - infoCard.ArmorRatingLabel._width;
+
+                    var strWarmth  = this._playerInfoObj.warmth != undefined ? Math.floor(this._playerInfoObj.warmth).toString() : "0";
+                    if (a_itemUpdateObj.warmthChange != undefined)
+                    {
+                        var iWarmthDelta = Math.round(a_itemUpdateObj.warmthChange);
+                        if (iWarmthDelta > 0)
+                            strWarmth = strWarmth + " <font color=\'#189515\'>(+" + iWarmthDelta.toString() + ")</font>";
+                        else if (iWarmthDelta < 0)
+                            strWarmth = strWarmth + " <font color=\'#FF0000\'>(" + iWarmthDelta.toString() + ")</font>";
+                    }
+                    infoCard.WarmthRatingLabel._visible = this._playerInfoObj.warmth != undefined;
+                    infoCard.WarmthRatingValue._visible = this._playerInfoObj.warmth != undefined;
+                    infoCard.WarmthRatingValue.textAutoSize = "shrink";
+                    infoCard.WarmthRatingValue.html = true;
+                    infoCard.WarmthRatingValue.SetText(strWarmth, true);
+                    infoCard.WarmthRatingValue._x = infoCard.ArmorRatingLabel._x + infoCard.ArmorRatingLabel.getLineMetrics(0).x - infoCard.WarmthRatingValue._width - 5;
+                    infoCard.WarmthRatingLabel._x = infoCard.WarmthRatingValue._x + infoCard.WarmthRatingValue.getLineMetrics(0).x - infoCard.WarmthRatingLabel._width;
+                    break;
+                    
+                case skyui.defines.Inventory.ICT_WEAPON:
+                    infoCard.gotoAndStop("Barter_Weapon");
+                    var strDamage: String = Math.floor(this._playerInfoObj.damage).toString();
+                    if (a_itemUpdateObj.damageChange != undefined) {
+                        var iDamageDelta: Number = Math.round(a_itemUpdateObj.damageChange);
+                        if (iDamageDelta > 0) 
+                            strDamage = strDamage + " <font color=\'#189515\'>(+" + iDamageDelta.toString() + ")</font>";
+                        else if (iDamageDelta < 0) 
+                            strDamage = strDamage + " <font color=\'#FF0000\'>(" + iDamageDelta.toString() + ")</font>";
+                    }
+                    infoCard.DamageValue.textAutoSize = "shrink";
+                    infoCard.DamageValue.html = true;
+                    infoCard.DamageValue.SetText(strDamage, true);
+                    infoCard.DamageValue._x = infoCard.CarryWeightLabel._x + infoCard.CarryWeightLabel.getLineMetrics(0).x - infoCard.DamageValue._width - 5;
+                    infoCard.DamageLabel._x = infoCard.DamageValue._x + infoCard.DamageValue.getLineMetrics(0).x - infoCard.DamageLabel._width;
+                    break;
+                    
+                default:
+                    infoCard.gotoAndStop("Barter");
+                    break;
+            }
+        }
+    }
+
+    public function setGiftInfo(a_favorPoints: Number)
+    {
+        this.playerInfoCard.gotoAndStop("Gift");
+    }
+
+    public function setPlatform(a_platform: Number, a_bPS3Switch: Boolean)
+    {
+        this.buttonPanel.setPlatform(a_platform, a_bPS3Switch);
+    }
+
+
+  /* PRIVATE FUNCTIONS */
+    
+    private function updateStatMeter(a_meterRect: MovieClip, a_meterObj: Meter, a_currValue: Number, a_maxValue: Number, a_colorStr: String)
+    {
+        if (a_colorStr == undefined) 
+            a_colorStr = "#FFFFFF";
+        if (a_meterRect._alpha > 0) {
+            if (a_meterRect.MeterText != undefined) {
+                a_meterRect.MeterText.textAutoSize = "shrink";
+                a_meterRect.MeterText.html = true;
+                a_meterRect.MeterText.SetText("<font color=\'" + a_colorStr + "\'>" + Math.floor(a_currValue) + "/" + Math.floor(a_maxValue) + "</font>", true);
+            }
+            a_meterRect.MeterInstance.gotoAndStop("Pause");
+            a_meterObj.SetPercent(a_currValue / a_maxValue * 100);
+        }
+    }
+    
+    private function updateSkillBar(a_skillName: String, a_levelStart: Number, a_levelPercent: Number)
+    {
+        var infoCard = this.playerInfoCard;
+        
+        infoCard.SkillLevelLabel.SetText(a_skillName);
+        infoCard.SkillLevelCurrent.SetText(a_levelStart);
+        infoCard.SkillLevelNext.SetText(a_levelStart + 1);
+        infoCard.LevelMeterInstance.gotoAndStop("Pause");
+        this._levelMeter.SetPercent(a_levelPercent);
+    }
+
 }

--- a/source/actionscript/ItemMenus/CategoryList.as
+++ b/source/actionscript/ItemMenus/CategoryList.as
@@ -1,350 +1,379 @@
 class CategoryList extends skyui.components.list.BasicList
 {
-   var selectedEntry;
-   var _activeSegment;
-   var _bFastSwitch;
-   var _bRequestInvalidate;
-   var _bRequestUpdate;
-   var _bSuspended;
-   var _contentWidth;
-   var _entryClipManager;
-   var _entryList;
-   var _segmentLength;
-   var _segmentOffset;
-   var _selectedIndex;
-   var _selectorPos;
-   var _targetSelectorPos;
-   var _totalWidth;
-   var background;
-   var disableInput;
-   var disableSelection;
-   var dispatchEvent;
-   var dividerIndex;
-   var doSetSelectedIndex;
-   var getClipByIndex;
-   var iconSize;
-   var isMouseDrivenNav;
-   var listEnumeration;
-   var listState;
-   var onInvalidate;
-   var selectorCenter;
-   var selectorLeft;
-   var selectorRight;
-   var setClipCount;
-   static var LEFT_SEGMENT = 0;
-   static var RIGHT_SEGMENT = 1;
-   function CategoryList()
-   {
-      super();
-      this._selectorPos = 0;
-      this._targetSelectorPos = 0;
-      this._bFastSwitch = false;
-      this._activeSegment = CategoryList.LEFT_SEGMENT;
-      this.dividerIndex = -1;
-      this._segmentOffset = 0;
-      this._segmentLength = 0;
-      if(this.iconSize == undefined)
-      {
-         this.iconSize = 32;
-      }
-   }
-   function set activeSegment(a_segment)
-   {
-      if(a_segment == this._activeSegment)
-      {
-         return;
-      }
-      this._activeSegment = a_segment;
-      this.calculateSegmentParams();
-      if(a_segment == CategoryList.LEFT_SEGMENT && this._selectedIndex > this.dividerIndex)
-      {
-         this.doSetSelectedIndex(this._selectedIndex - this.dividerIndex - 1,skyui.components.list.BasicList.SELECT_MOUSE);
-      }
-      else if(a_segment == CategoryList.RIGHT_SEGMENT && this._selectedIndex < this.dividerIndex)
-      {
-         this.doSetSelectedIndex(this._selectedIndex + this.dividerIndex + 1,skyui.components.list.BasicList.SELECT_MOUSE);
-      }
-      this.UpdateList();
-   }
-   function get activeSegment()
-   {
-      return this._activeSegment;
-   }
-   function clearList()
-   {
-      this.dividerIndex = -1;
-      this._entryList.splice(0);
-   }
-   function InvalidateData()
-   {
-      if(this._bSuspended)
-      {
-         this._bRequestInvalidate = true;
-         return undefined;
-      }
-      this.listEnumeration.invalidate();
-      this.calculateSegmentParams();
-      if(this._selectedIndex >= this.listEnumeration.size())
-      {
-         this._selectedIndex = this.listEnumeration.size() - 1;
-      }
-      this.UpdateList();
-      if(this.onInvalidate)
-      {
-         this.onInvalidate();
-      }
-   }
-   function UpdateList()
-   {
-      if(this._bSuspended)
-      {
-         this._bRequestUpdate = true;
-         return undefined;
-      }
-      this.setClipCount(this._segmentLength);
-      var _loc5_ = 0;
-      var _loc2_ = 0;
-      var _loc3_;
-      while(_loc2_ < this._segmentLength)
-      {
-         _loc3_ = this.getClipByIndex(_loc2_);
-         _loc3_.setEntry(this.listEnumeration.at(_loc2_ + this._segmentOffset),this.listState);
-         _loc3_.background._width = _loc3_.background._height = this.iconSize;
-         this.listEnumeration.at(_loc2_ + this._segmentOffset).clipIndex = _loc2_;
-         _loc3_.itemIndex = _loc2_ + this._segmentOffset;
-         _loc5_ += this.iconSize;
-         _loc2_ = _loc2_ + 1;
-      }
-      this._contentWidth = _loc5_;
-      this._totalWidth = this.background._width;
-      var _loc6_ = (this._totalWidth - this._contentWidth) / (this._segmentLength + 1);
-      var _loc4_ = this.background._x + _loc6_;
-      _loc2_ = 0;
-      while(_loc2_ < this._segmentLength)
-      {
-         _loc3_ = this.getClipByIndex(_loc2_);
-         _loc3_._x = _loc4_;
-         _loc4_ = _loc4_ + this.iconSize + _loc6_;
-         _loc3_._visible = true;
-         _loc2_ = _loc2_ + 1;
-      }
-      this.updateSelector();
-   }
-   function moveSelectionLeft()
-   {
-      if(this.disableSelection)
-      {
-         return undefined;
-      }
-      var _loc2_ = this._selectedIndex;
-      var _loc3_ = this._selectedIndex;
-      do
-      {
-         if(_loc2_ > this._segmentOffset)
-         {
-            _loc2_ = _loc2_ - 1;
-         }
-         else
-         {
-            this._bFastSwitch = true;
-            _loc2_ = this._segmentOffset + this._segmentLength - 1;
-         }
-      }
-      while(_loc2_ != _loc3_ && this.listEnumeration.at(_loc2_).filterFlag == 0 && !this.listEnumeration.at(_loc2_).bDontHide);
-      
-      this.onItemPress(_loc2_,0);
-   }
-   function moveSelectionRight()
-   {
-      if(this.disableSelection)
-      {
-         return undefined;
-      }
-      var _loc2_ = this._selectedIndex;
-      var _loc3_ = this._selectedIndex;
-      do
-      {
-         if(_loc2_ < this._segmentOffset + this._segmentLength - 1)
-         {
-            _loc2_ = _loc2_ + 1;
-         }
-         else
-         {
-            this._bFastSwitch = true;
-            _loc2_ = this._segmentOffset;
-         }
-      }
-      while(_loc2_ != _loc3_ && this.listEnumeration.at(_loc2_).filterFlag == 0 && !this.listEnumeration.at(_loc2_).bDontHide);
-      
-      this.onItemPress(_loc2_,0);
-   }
-   function handleInput(details, pathToFocus)
-   {
-      if(this.disableInput)
-      {
-         return false;
-      }
-      if(Shared.GlobalFunc.IsKeyPressed(details))
-      {
-         if(details.navEquivalent == gfx.ui.NavigationCode.LEFT)
-         {
-            this.moveSelectionLeft();
-            return true;
-         }
-         if(details.navEquivalent == gfx.ui.NavigationCode.RIGHT)
-         {
-            this.moveSelectionRight();
-            return true;
-         }
-      }
-      return false;
-   }
-   function onEnterFrame()
-   {
-      super.onEnterFrame();
-      if(this._bFastSwitch && this._selectorPos != this._targetSelectorPos)
-      {
-         this._selectorPos = this._targetSelectorPos;
-         this._bFastSwitch = false;
-         this.refreshSelector();
-      }
-      else if(this._selectorPos < this._targetSelectorPos)
-      {
-         this._selectorPos = this._selectorPos + (this._targetSelectorPos - this._selectorPos) * 0.2 + 1;
-         this.refreshSelector();
-         if(this._selectorPos > this._targetSelectorPos)
-         {
+  /* CONSTANTS */
+    
+    public static var LEFT_SEGMENT = 0;
+    public static var RIGHT_SEGMENT = 1;
+    
+    
+  /* STAGE ELEMENTS */
+    
+    public var selectorCenter: MovieClip;
+    public var selectorLeft: MovieClip;
+    public var selectorRight: MovieClip;
+    public var background: MovieClip;
+    
+    
+  /* PRIVATE VARIABLES */
+    
+    private var _xOffset: Number;
+    private var _contentWidth: Number;
+    private var _totalWidth: Number;
+    private var _selectorPos: Number;
+    private var _targetSelectorPos: Number;
+    private var _bFastSwitch: Boolean;
+    private var _segmentOffset: Number;
+    private var _segmentLength: Number;
+
+
+  /* PROPERTIES */
+    
+    // Distance from border to start icon.
+    public var iconIndent: Number;
+    
+    // Size of the icon.
+    public var iconSize: Number;
+    
+    // Array that contains the icon label for category at position i.
+    // The category list uses fixed lengths/icons, so this is assigned statically.
+    public var iconArt: Array;
+    
+    // For segmented lists, this is in the index of the divider that seperates player and container/vendor inventory.
+    public var dividerIndex: Number;
+    
+    // The active segment for divided lists (left or right).
+    private var _activeSegment: Number;
+    
+    public function set activeSegment(a_segment: Number)
+    {
+        if (a_segment == this._activeSegment)
+            return;
+        
+        this._activeSegment = a_segment;
+        
+        this.calculateSegmentParams();
+        
+        if (a_segment == CategoryList.LEFT_SEGMENT && this._selectedIndex > this.dividerIndex)
+            this.doSetSelectedIndex(this._selectedIndex - this.dividerIndex - 1, skyui.components.list.BasicList.SELECT_MOUSE);
+        else if (a_segment == CategoryList.RIGHT_SEGMENT && this._selectedIndex < this.dividerIndex)
+            this.doSetSelectedIndex(this._selectedIndex + this.dividerIndex + 1, skyui.components.list.BasicList.SELECT_MOUSE);
+        
+        this.UpdateList();
+    }
+    
+    public function get activeSegment()
+    {
+        return this._activeSegment;
+    }
+    
+    
+  /* INITIALIZATION */
+    
+    public function CategoryList()
+    {
+        super();
+        
+        this._selectorPos = 0;
+        this._targetSelectorPos = 0;
+        this._bFastSwitch = false;
+
+        this._activeSegment = CategoryList.LEFT_SEGMENT;
+        this.dividerIndex = -1;
+        this._segmentOffset = 0;
+        this._segmentLength = 0;
+        
+        if (this.iconSize == undefined)
+            this.iconSize = 32;
+    }
+    
+    
+  /* PUBLIC FUNCTIONS */
+
+    // Clears the list. For the category list, that's ok since the entryList isn't manipulated directly.
+    // @override BasicList
+    public function clearList()
+    {
+        this.dividerIndex = -1;
+        this._entryList.splice(0);
+    }
+    
+    // @override BasicList
+    public function InvalidateData()
+    {
+        if (this._bSuspended) {
+            this._bRequestInvalidate = true;
+            return;
+        }
+        
+        this.listEnumeration.invalidate();
+
+        this.calculateSegmentParams();
+        
+        if (this._selectedIndex >= this.listEnumeration.size())
+            this._selectedIndex = this.listEnumeration.size() - 1;
+
+        this.UpdateList();
+        
+        if (this.onInvalidate)
+            this.onInvalidate();
+    }
+    
+    // @override BasicList
+    public function UpdateList()
+    {
+        if (this._bSuspended) {
+            this._bRequestUpdate = true;
+            return;
+        }
+        
+        this.setClipCount(this._segmentLength);
+
+        var cw = 0;
+
+        for (var i = 0; i < this._segmentLength; i++) {
+            var entryClip = this.getClipByIndex(i);
+
+            entryClip.setEntry(this.listEnumeration.at(i + this._segmentOffset), this.listState);
+
+            entryClip.background._width = entryClip.background._height = this.iconSize;
+
+            this.listEnumeration.at(i + this._segmentOffset).clipIndex = i;
+            entryClip.itemIndex = i + this._segmentOffset;
+
+            cw = cw + this.iconSize;
+        }
+
+        this._contentWidth = cw;
+        this._totalWidth = this.background._width;
+
+        var spacing = (this._totalWidth - this._contentWidth) / (this._segmentLength + 1);
+
+        var xPos = this.background._x + spacing;
+
+        for (var i = 0; i < this._segmentLength; i++) {
+            var entryClip = this.getClipByIndex(i);
+            entryClip._x = xPos;
+
+            xPos = xPos + this.iconSize + spacing;
+            entryClip._visible = true;
+        }
+        
+        this.updateSelector();
+    }
+    
+    // Moves the selection left to the next element. Wraps around.
+    public function moveSelectionLeft()
+    {
+        if (this.disableSelection)
+            return;
+
+        var curIndex = this._selectedIndex;
+        var startIndex = this._selectedIndex;
+            
+        do {
+            if (curIndex > this._segmentOffset) {
+                curIndex--;
+            } else {
+                this._bFastSwitch = true;
+                curIndex = this._segmentOffset + this._segmentLength - 1;					
+            }
+        } while (curIndex != startIndex && this.listEnumeration.at(curIndex).filterFlag == 0 && !this.listEnumeration.at(curIndex).bDontHide);
+            
+        this.onItemPress(curIndex, 0);
+    }
+
+    // Moves the selection right to the next element. Wraps around.
+    public function moveSelectionRight()
+    {
+        if (this.disableSelection)
+            return;
+            
+        var curIndex = this._selectedIndex;
+        var startIndex = this._selectedIndex;
+            
+        do {
+            if (curIndex < this._segmentOffset + this._segmentLength - 1) {
+                curIndex++;
+            } else {
+                this._bFastSwitch = true;
+                curIndex = this._segmentOffset;
+            }
+        } while (curIndex != startIndex && this.listEnumeration.at(curIndex).filterFlag == 0 && !this.listEnumeration.at(curIndex).bDontHide);
+            
+        this.onItemPress(curIndex, 0);
+    }
+    
+    // @GFx
+    public function handleInput(details: InputDetails, pathToFocus: Array)
+    {
+        if (this.disableInput)
+            return false;
+            
+        if (Shared.GlobalFunc.IsKeyPressed(details)) {
+            if (details.navEquivalent == gfx.ui.NavigationCode.LEFT) {
+                this.moveSelectionLeft();
+                return true;
+            } else if (details.navEquivalent == gfx.ui.NavigationCode.RIGHT) {
+                this.moveSelectionRight();
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    // @override BasicList
+    public function onEnterFrame()
+    {
+        super.onEnterFrame();
+        
+        if (this._bFastSwitch && this._selectorPos != this._targetSelectorPos) {
             this._selectorPos = this._targetSelectorPos;
-         }
-      }
-      else if(this._selectorPos > this._targetSelectorPos)
-      {
-         this._selectorPos = this._selectorPos - (this._selectorPos - this._targetSelectorPos) * 0.2 - 1;
-         this.refreshSelector();
-         if(this._selectorPos < this._targetSelectorPos)
-         {
-            this._selectorPos = this._targetSelectorPos;
-         }
-      }
-   }
-   function onItemPress(a_index, a_keyboardOrMouse)
-   {
-      if(this.disableInput || this.disableSelection || a_index == -1)
-      {
-         return undefined;
-      }
-      this.doSetSelectedIndex(a_index,a_keyboardOrMouse);
-      this.updateSelector();
-      this.dispatchEvent({type:"itemPress",index:this._selectedIndex,entry:this.selectedEntry,keyboardOrMouse:a_keyboardOrMouse});
-   }
-   function onItemPressAux(a_index, a_keyboardOrMouse, a_buttonIndex)
-   {
-      if(this.disableInput || this.disableSelection || a_index == -1 || a_buttonIndex != 1)
-      {
-         return undefined;
-      }
-      this.doSetSelectedIndex(a_index,a_keyboardOrMouse);
-      this.updateSelector();
-      this.dispatchEvent({type:"itemPressAux",index:this._selectedIndex,entry:this.selectedEntry,keyboardOrMouse:a_keyboardOrMouse});
-   }
-   function onItemRollOver(a_index)
-   {
-      if(this.disableInput || this.disableSelection)
-      {
-         return undefined;
-      }
-      this.isMouseDrivenNav = true;
-      if(a_index == this._selectedIndex)
-      {
-         return undefined;
-      }
-      var _loc2_ = this.getClipByIndex(a_index);
-      _loc2_._alpha = 75;
-   }
-   function onItemRollOut(a_index)
-   {
-      if(this.disableInput || this.disableSelection)
-      {
-         return undefined;
-      }
-      this.isMouseDrivenNav = true;
-      if(a_index == this._selectedIndex)
-      {
-         return undefined;
-      }
-      var _loc2_ = this.getClipByIndex(a_index);
-      _loc2_._alpha = 50;
-   }
-   function calculateSegmentParams()
-   {
-      if(this.dividerIndex != undefined && this.dividerIndex != -1)
-      {
-         if(this._activeSegment == CategoryList.LEFT_SEGMENT)
-         {
+            this._bFastSwitch = false;
+            this.refreshSelector();
+            
+        } else if (this._selectorPos < this._targetSelectorPos) {
+            this._selectorPos = this._selectorPos + (this._targetSelectorPos - this._selectorPos) * 0.2 + 1;
+            
+            this.refreshSelector();
+            
+            if (this._selectorPos > this._targetSelectorPos)
+                this._selectorPos = this._targetSelectorPos;
+            
+        } else if (this._selectorPos > this._targetSelectorPos) {
+            this._selectorPos = this._selectorPos - (this._selectorPos - this._targetSelectorPos) * 0.2 - 1;
+            
+            this.refreshSelector();
+            
+            if (this._selectorPos < this._targetSelectorPos)
+                this._selectorPos = this._targetSelectorPos;
+        }
+    }
+    
+    // @override BasicList
+    public function onItemPress(a_index: Number, a_keyboardOrMouse: Number)
+    {
+        if (this.disableInput || this.disableSelection || a_index == -1)
+            return;
+            
+        this.doSetSelectedIndex(a_index, a_keyboardOrMouse);
+        this.updateSelector();
+        this.dispatchEvent({type: "itemPress", index: this._selectedIndex, entry: this.selectedEntry, keyboardOrMouse: a_keyboardOrMouse});
+    }
+    
+    // @override BasicList
+    private function onItemPressAux(a_index: Number, a_keyboardOrMouse: Number, a_buttonIndex: Number)
+    {
+        if (this.disableInput || this.disableSelection || a_index == -1 || a_buttonIndex != 1)
+            return;
+        
+        this.doSetSelectedIndex(a_index, a_keyboardOrMouse);
+        this.updateSelector();
+        this.dispatchEvent({type: "itemPressAux", index: this._selectedIndex, entry: this.selectedEntry, keyboardOrMouse: a_keyboardOrMouse});
+    }
+    
+    // @override BasicList
+    public function onItemRollOver(a_index: Number)
+    {
+        if (this.disableInput || this.disableSelection)
+            return;
+            
+        this.isMouseDrivenNav = true;
+        
+        if (a_index == this._selectedIndex)
+            return;
+            
+        var entryClip = this.getClipByIndex(a_index);
+        entryClip._alpha = 75;
+    }
+
+    // @override BasicList
+    public function onItemRollOut(a_index: Number)
+    {
+        if (this.disableInput || this.disableSelection)
+            return;
+            
+        this.isMouseDrivenNav = true;
+        
+        if (a_index == this._selectedIndex)
+            return;
+            
+        var entryClip = this.getClipByIndex(a_index);
+        entryClip._alpha = 50;
+    }
+
+
+/* PRIVATE FUNCTIONS */
+    
+    private function calculateSegmentParams()
+    {
+        // Divided
+        if (this.dividerIndex != undefined && this.dividerIndex != -1) {
+            if (this._activeSegment == CategoryList.LEFT_SEGMENT) {
+                this._segmentOffset = 0;
+                this._segmentLength = this.dividerIndex;
+            } else {
+                this._segmentOffset = this.dividerIndex + 1;
+                this._segmentLength = this.listEnumeration.size() - this._segmentOffset;
+            }
+        
+        // Default for non-divided lists
+        } else {
             this._segmentOffset = 0;
-            this._segmentLength = this.dividerIndex;
-         }
-         else
-         {
-            this._segmentOffset = this.dividerIndex + 1;
-            this._segmentLength = this.listEnumeration.size() - this._segmentOffset;
-         }
-      }
-      else
-      {
-         this._segmentOffset = 0;
-         this._segmentLength = this.listEnumeration.size();
-      }
-   }
-   function updateSelector()
-   {
-      if(this.selectorCenter == undefined)
-      {
-         return undefined;
-      }
-      if(this._selectedIndex == -1)
-      {
-         this.selectorCenter._visible = false;
-         if(this.selectorLeft != undefined)
-         {
-            this.selectorLeft._visible = false;
-         }
-         if(this.selectorRight != undefined)
-         {
-            this.selectorRight._visible = false;
-         }
-         return undefined;
-      }
-      var _loc2_ = this._entryClipManager.getClip(this._selectedIndex - this._segmentOffset);
-      this._targetSelectorPos = _loc2_._x + (_loc2_.background._width - this.selectorCenter._width) / 2;
-      this.selectorCenter._visible = true;
-      this.selectorCenter._y = _loc2_._y + _loc2_.background._height;
-      if(this.selectorLeft != undefined)
-      {
-         this.selectorLeft._visible = true;
-         this.selectorLeft._x = 0;
-         this.selectorLeft._y = this.selectorCenter._y;
-      }
-      if(this.selectorRight != undefined)
-      {
-         this.selectorRight._visible = true;
-         this.selectorRight._y = this.selectorCenter._y;
-         this.selectorRight._width = this._totalWidth - this.selectorRight._x;
-      }
-   }
-   function refreshSelector()
-   {
-      this.selectorCenter._visible = true;
-      var _loc2_ = this._entryClipManager.getClip(this._selectedIndex - this._segmentOffset);
-      this.selectorCenter._x = this._selectorPos;
-      if(this.selectorLeft != undefined)
-      {
-         this.selectorLeft._width = this.selectorCenter._x;
-      }
-      if(this.selectorRight != undefined)
-      {
-         this.selectorRight._x = this.selectorCenter._x + this.selectorCenter._width;
-         this.selectorRight._width = this._totalWidth - this.selectorRight._x;
-      }
-   }
+            this._segmentLength = this.listEnumeration.size();
+        }
+    }
+    
+    private function updateSelector()
+    {
+        if (this.selectorCenter == undefined) {
+            return;
+        }
+            
+        if (this._selectedIndex == -1) {
+            this.selectorCenter._visible = false;
+
+            if (this.selectorLeft != undefined)
+                this.selectorLeft._visible = false;
+                
+            if (this.selectorRight != undefined)
+                this.selectorRight._visible = false;
+
+            return;
+        }
+
+        var selectedClip = this._entryClipManager.getClip(this._selectedIndex - this._segmentOffset);
+
+        this._targetSelectorPos = selectedClip._x + (selectedClip.background._width - this.selectorCenter._width) / 2;
+        
+        this.selectorCenter._visible = true;
+        this.selectorCenter._y = selectedClip._y + selectedClip.background._height;
+        
+        if (this.selectorLeft != undefined) {
+            this.selectorLeft._visible = true;
+            this.selectorLeft._x = 0;
+            this.selectorLeft._y = this.selectorCenter._y;
+        }
+
+        if (this.selectorRight != undefined) {
+            this.selectorRight._visible = true;
+            this.selectorRight._y = this.selectorCenter._y;
+            this.selectorRight._width = this._totalWidth - this.selectorRight._x;
+        }
+    }
+
+    private function refreshSelector()
+    {
+        this.selectorCenter._visible = true;
+        var selectedClip = this._entryClipManager.getClip(this._selectedIndex - this._segmentOffset);
+
+        this.selectorCenter._x = this._selectorPos;
+
+        if (this.selectorLeft != undefined)
+            this.selectorLeft._width = this.selectorCenter._x;
+
+        if (this.selectorRight != undefined) {
+            this.selectorRight._x = this.selectorCenter._x + this.selectorCenter._width;
+            this.selectorRight._width = this._totalWidth - this.selectorRight._x;
+        }
+    }
 }

--- a/source/actionscript/ItemMenus/CategoryListEntry.as
+++ b/source/actionscript/ItemMenus/CategoryListEntry.as
@@ -1,51 +1,62 @@
 class CategoryListEntry extends skyui.components.list.BasicListEntry
 {
-   var _alpha;
-   var _iconLabel;
-   var _iconSize;
-   var enabled;
-   var icon;
-   function CategoryListEntry()
-   {
-      super();
-   }
-   function initialize(a_index, a_state)
-   {
-      super.initialize();
-      var _loc3_ = new MovieClipLoader();
-      _loc3_.addListener(this);
-      this._iconLabel = CategoryList(a_state.list).iconArt[a_index];
-      this._iconSize = CategoryList(a_state.list).iconSize;
-      _loc3_.loadClip(a_state.iconSource,this.icon);
-   }
-   function setEntry(a_entryObject, a_state)
-   {
-      if(a_entryObject.filterFlag == 0 && !a_entryObject.bDontHide)
-      {
-         this._alpha = 15;
-         this.enabled = false;
-      }
-      else if(a_entryObject == a_state.list.selectedEntry)
-      {
-         this._alpha = 100;
-         this.enabled = true;
-      }
-      else
-      {
-         this._alpha = 50;
-         this.enabled = true;
-      }
-   }
-   function onLoadInit(a_mc)
-   {
-      if(a_mc.background != undefined)
-      {
-         a_mc._xscale = a_mc._yscale = this._iconSize / a_mc.background._width * 100;
-      }
-      else
-      {
-         a_mc._width = a_mc._height = this._iconSize;
-      }
-      a_mc.gotoAndStop(this._iconLabel);
-   }
+  /* PRIVATE VARIABLES */
+
+    private var _iconLabel: String;
+    private var _iconSize: Number;
+    
+    
+  /* STAGE ELMENTS */
+
+    public var icon: MovieClip;
+
+    
+  /* PUBLIC FUNCTIONS */
+
+    public function CategoryListEntry()
+    {
+        super();
+    }
+    
+    public function initialize(a_index: Number, a_state: ListState)
+    {
+        super.initialize();
+
+        var iconLoader = new MovieClipLoader();
+        iconLoader.addListener(this);
+
+        this._iconLabel = CategoryList(a_state.list).iconArt[a_index];
+        this._iconSize = CategoryList(a_state.list).iconSize;
+
+        iconLoader.loadClip(a_state.iconSource, this.icon);
+    }
+    
+    public function setEntry(a_entryObject: Object, a_state: ListState)
+    {
+        if (a_entryObject.filterFlag == 0 && !a_entryObject.bDontHide) {
+            this._alpha = 15;
+            this.enabled = false;
+        } else if (a_entryObject == a_state.list.selectedEntry) {
+            this._alpha = 100;
+            this.enabled = true;
+        } else {
+            this._alpha = 50;
+            this.enabled = true;
+        }
+    }
+
+  /* PRIVATE FUNCTIONS */
+
+    // @implements MovieClipLoader
+    private function onLoadInit(a_mc: MovieClip)
+    {
+        if (a_mc.background != undefined) {
+            // If the icon set has a background, scale the icon until background size would = icon size
+            a_mc._xscale = a_mc._yscale = (this._iconSize / a_mc.background._width) * 100;
+        } else {
+            a_mc._width = a_mc._height = this._iconSize;
+        }
+        
+        a_mc.gotoAndStop(this._iconLabel);
+    }
 }

--- a/source/actionscript/ItemMenus/ContainerMenu.as
+++ b/source/actionscript/ItemMenus/ContainerMenu.as
@@ -205,8 +205,8 @@ class ContainerMenu extends ItemMenu
 
     private function onQuantityMenuSelect(event: Object)
     {
-        if (_equipHand != undefined) {
-            gfx.io.GameDelegate.call("EquipItem",[_equipHand, event.amount]);
+        if (this._equipHand != undefined) {
+            gfx.io.GameDelegate.call("EquipItem",[this._equipHand, event.amount]);
 
             if (!this.checkBook(this.inventoryLists.itemList.selectedEntry))
                 this.checkPoison(this.inventoryLists.itemList.selectedEntry);
@@ -243,7 +243,7 @@ class ContainerMenu extends ItemMenu
                     this.navPanel.addButton({text: "$Take All", controls: skyui.defines.Input.XButton});
             } else {
                 if (this._platform != 0) {
-                    this.navPanel.addButton({text: bNPCMode ? "$Give" : "$Store", controls: skyui.defines.Input.Activate});
+                    this.navPanel.addButton({text: this.bNPCMode ? "$Give" : "$Store", controls: skyui.defines.Input.Activate});
                     this.navPanel.addButton(this.getEquipButtonData(this.itemCard.itemInfo.type, true));
                 } else {
                     if (this._bEquipMode)

--- a/source/actionscript/ItemMenus/ContainerMenu.as
+++ b/source/actionscript/ItemMenus/ContainerMenu.as
@@ -1,312 +1,335 @@
 class ContainerMenu extends ItemMenu
 {
-   var _cancelControls;
-   var _categoryListIconArt;
-   var _equipHand;
-   var _equipModeControls;
-   var _equipModeKey;
-   var _platform;
-   var _quantityMinCount;
-   var _searchControls;
-   var _sortColumnControls;
-   var _sortOrderControls;
-   var _switchControls;
-   var _tabBarIconArt;
-   var bFadedIn;
-   var bottomBar;
-   var checkBook;
-   var confirmSelectedEntry;
-   var getEquipButtonData;
-   var inventoryLists;
-   var itemCard;
-   var itemCardFadeHolder;
-   var navPanel;
-   var shouldProcessItemsListInput;
-   static var NULL_HAND = -1;
-   static var RIGHT_HAND = 0;
-   static var LEFT_HAND = 1;
-   var _bEquipMode = false;
-   var bNPCMode = false;
-   var bEnableTabs = true;
-   function ContainerMenu()
-   {
-      super();
-      this._categoryListIconArt = ["inv_all","inv_weapons","inv_armor","inv_potions","inv_scrolls","inv_food","inv_ingredients","inv_books","inv_keys","inv_misc"];
-      this._tabBarIconArt = ["take","give"];
-   }
-   function InitExtensions()
-   {
-      super.InitExtensions();
-      this.inventoryLists.tabBarIconArt = this._tabBarIconArt;
-      var _loc3_ = this.inventoryLists.categoryList;
-      _loc3_.iconArt = this._categoryListIconArt;
-      gfx.io.GameDelegate.addCallBack("AttemptEquip",this,"AttemptEquip");
-      gfx.io.GameDelegate.addCallBack("XButtonPress",this,"onXButtonPress");
-      this.itemCardFadeHolder.StealTextInstance._visible = false;
-   }
-   function setConfig(a_config)
-   {
-      super.setConfig(a_config);
-      var _loc3_ = this.inventoryLists.itemList;
-      _loc3_.addDataProcessor(new InventoryDataSetter());
-      _loc3_.addDataProcessor(new InventoryIconSetter(a_config.Appearance));
-      _loc3_.addDataProcessor(new skyui.props.PropertyDataExtender(a_config.Appearance,a_config.Properties,"itemProperties","itemIcons","itemCompoundProperties"));
-      var _loc5_ = skyui.components.list.ListLayoutManager.createLayout(a_config.ListLayout,"ItemListLayout");
-      _loc3_.layout = _loc5_;
-      if(this.inventoryLists.categoryList.selectedEntry)
-      {
-         _loc5_.changeFilterFlag(this.inventoryLists.categoryList.selectedEntry.flag);
-      }
-      this._equipModeKey = a_config.Input.controls.pc.equipMode;
-      this._equipModeControls = {keyCode:this._equipModeKey};
-   }
-   function ShowItemsList()
-   {
-   }
-   function handleInput(details, pathToFocus)
-   {
-      super.handleInput(details,pathToFocus);
+  /* CONSTANTS */
+
+    private static var NULL_HAND: Number = -1;
+    private static var RIGHT_HAND: Number = 0;
+    private static var LEFT_HAND: Number = 1;
+
+
+  /* PRIVATE VARIABLES */
+
+    private var _bEquipMode: Boolean = false;
+    private var _equipHand: Number;
+
+    private var _equipModeKey: Number;
+    private var _equipModeControls: Object;
+    
+    private var _categoryListIconArt: Array;
+    private var _tabBarIconArt: Array;
+    
+    
+  /* PROPERTIES */
+    
+    // @API
+    public var bNPCMode: Boolean = false;
+    
+    // @override ItemMenu
+    public var bEnableTabs: Boolean = true;
+
+
+  /* INITIALIZATION */
+
+    public function ContainerMenu()
+    {
+        super();
+        
+        this._categoryListIconArt = ["inv_all", "inv_weapons", "inv_armor", "inv_potions", "inv_scrolls", "inv_food", "inv_ingredients", "inv_books", "inv_keys", "inv_misc"];
+        
+        this._tabBarIconArt = ["take", "give"];
+    }
+
+
+  /* PUBLIC FUNCTIONS */
+
+    public function InitExtensions()
+    {
+        super.InitExtensions();
+        
+        this.inventoryLists.tabBarIconArt = this._tabBarIconArt;
+
+        // Initialize menu-specific list components
+        var categoryList: CategoryList = this.inventoryLists.categoryList;
+        categoryList.iconArt = this._categoryListIconArt;
+
+        gfx.io.GameDelegate.addCallBack("AttemptEquip", this, "AttemptEquip");
+        gfx.io.GameDelegate.addCallBack("XButtonPress", this, "onXButtonPress");
+        this.itemCardFadeHolder.StealTextInstance._visible = false;
+    }
+
+    // @override ItemMenu
+    public function setConfig(a_config: Object)
+    {
+        super.setConfig(a_config);
+        
+        var itemList: TabularList = this.inventoryLists.itemList;		
+        itemList.addDataProcessor(new InventoryDataSetter());
+        itemList.addDataProcessor(new InventoryIconSetter(a_config["Appearance"]));
+        itemList.addDataProcessor(new skyui.props.PropertyDataExtender(a_config["Appearance"], a_config["Properties"], "itemProperties", "itemIcons", "itemCompoundProperties"));
+        
+        var layout: ListLayout = skyui.components.list.ListLayoutManager.createLayout(a_config["ListLayout"], "ItemListLayout");
+        itemList.layout = layout;
+
+        // Not 100% happy with doing this here, but has to do for now.
+        if (this.inventoryLists.categoryList.selectedEntry)
+            layout.changeFilterFlag(this.inventoryLists.categoryList.selectedEntry.flag);
+            
+        this._equipModeKey = a_config["Input"].controls.pc.equipMode;
+        this._equipModeControls = {keyCode: this._equipModeKey};
+    }
+
+    // @API
+    public function ShowItemsList()
+    {
+        // Not necessary anymore. Now handled in onShowItemsList for consistency reasons.
+        //inventoryLists.showItemsList();
+    }
+
+    // @GFx
+    public function handleInput(details: InputDetails, pathToFocus: Array)
+    {
+        super.handleInput(details,pathToFocus);
       
-      if(this._platform == 0 && details.skseKeycode == this._equipModeKey)
-      {
-         this._bEquipMode = details.value != "keyUp";
-         
-         if(this.shouldProcessItemsListInput(false))
-         {
-            this.updateBottomBar(true);
-         }
-      }
-      return true;
-   }
-   function UpdateItemCardInfo(a_updateObj)
-   {
-      super.UpdateItemCardInfo(a_updateObj);
-      this.updateBottomBar(true);
-      if(a_updateObj.pickpocketChance != undefined)
-      {
-         this.itemCardFadeHolder.StealTextInstance._visible = true;
-         this.itemCardFadeHolder.StealTextInstance.PercentTextInstance.html = true;
-         this.itemCardFadeHolder.StealTextInstance.PercentTextInstance.htmlText = "<font face=\'$EverywhereBoldFont\' size=\'24\' color=\'#FFFFFF\'>" + a_updateObj.pickpocketChance + "%</font>" + (!this.isViewingContainer() ? skyui.util.Translator.translate("$ TO PLACE") : skyui.util.Translator.translate("$ TO STEAL"));
-      }
-      else
-      {
-         this.itemCardFadeHolder.StealTextInstance._visible = false;
-      }
-   }
-   function AttemptEquip(a_slot, a_bCheckOverList)
-   {
-      var _loc2_ = a_bCheckOverList != undefined ? a_bCheckOverList : true;
-      if(!this.shouldProcessItemsListInput(_loc2_) || !this.confirmSelectedEntry())
-      {
-         return undefined;
-      }
-      if(this._platform == 0)
-      {
-         if(this._bEquipMode)
-         {
+        if (this._platform == 0 && details.skseKeycode == this._equipModeKey) {
+            this._bEquipMode = details.value != "keyUp";
+            
+            if (this.shouldProcessItemsListInput(false))
+                this.updateBottomBar(true);
+        }
+        return true;
+    }
+
+    // @override ItemMenu
+    public function UpdateItemCardInfo(a_updateObj: Object)
+    {
+        super.UpdateItemCardInfo(a_updateObj);
+
+        this.updateBottomBar(true);
+
+        if (a_updateObj.pickpocketChance != undefined) {
+            this.itemCardFadeHolder.StealTextInstance._visible = true;
+            this.itemCardFadeHolder.StealTextInstance.PercentTextInstance.html = true;
+            this.itemCardFadeHolder.StealTextInstance.PercentTextInstance.htmlText = "<font face=\'$EverywhereBoldFont\' size=\'24\' color=\'#FFFFFF\'>" + a_updateObj.pickpocketChance + "%</font>" + (this.isViewingContainer() ? skyui.util.Translator.translate("$ TO STEAL") : skyui.util.Translator.translate("$ TO PLACE"));
+        } else {
+            this.itemCardFadeHolder.StealTextInstance._visible = false;
+        }
+    }
+
+    // @API
+    public function AttemptEquip(a_slot: Number, a_bCheckOverList: Boolean)
+    {
+        var bCheckOverList = a_bCheckOverList == undefined ? true : a_bCheckOverList;
+        
+        if (!this.shouldProcessItemsListInput(bCheckOverList) || !this.confirmSelectedEntry())
+            return;
+            
+        if (this._platform == 0) {
+            if (this._bEquipMode)
+                this.startItemEquip(a_slot);
+            else
+                this.startItemTransfer();
+        } else {
             this.startItemEquip(a_slot);
-         }
-         else
-         {
+        }
+    }
+
+    // @API
+    public function onXButtonPress()
+    {
+        // If we are zoomed into an item, do nothing
+        if (!this.bFadedIn)
+            return;
+        
+        if (this.isViewingContainer() && !this.bNPCMode)
+            gfx.io.GameDelegate.call("TakeAllItems", []);
+    }
+
+    // @API
+    public function SetPlatform(a_platform: Number, a_bPS3Switch: Boolean)
+    {
+        super.SetPlatform(a_platform, a_bPS3Switch);
+
+        this._bEquipMode = (a_platform != 0);
+    }
+    
+    
+  /* PRIVATE FUNCTIONS */
+
+    private function onItemSelect(event: Object)
+    {
+        if (event.keyboardOrMouse != 0) {
+            if (this._platform == 0 && this._bEquipMode)
+                this.startItemEquip(ContainerMenu.NULL_HAND);
+            else
+                this.startItemTransfer();
+        }
+    }
+
+    private function onItemCardSubMenuAction(event: Object)
+    {
+        super.onItemCardSubMenuAction(event);
+
+        if (event.menu == "quantity")
+            gfx.io.GameDelegate.call("QuantitySliderOpen", [event.opening]);
+    }
+
+    // @override ItemMenu
+    private function onItemHighlightChange(event: Object)
+    {
+        if (event.index != -1)
+            this.updateBottomBar(true);
+
+        super.onItemHighlightChange(event);
+    }
+
+    // @override ItemMenu
+    private function onShowItemsList(event: Object)
+    {
+        this.inventoryLists.showItemsList();
+    }
+
+    // @override ItemMenu
+    private function onHideItemsList(event: Object)
+    {
+        super.onHideItemsList(event);
+
+        this.bottomBar.updatePerItemInfo({type: skyui.defines.Inventory.ICT_NONE});
+
+        this.updateBottomBar(false);
+    }
+
+    private function onMouseRotationFastClick(a_mouseButton: Number)
+    {
+        gfx.io.GameDelegate.call("CheckForMouseEquip", [a_mouseButton], this, "AttemptEquip");
+    }
+
+    private function onQuantityMenuSelect(event: Object)
+    {
+        if (_equipHand != undefined) {
+            gfx.io.GameDelegate.call("EquipItem",[_equipHand, event.amount]);
+
+            if (!this.checkBook(this.inventoryLists.itemList.selectedEntry))
+                this.checkPoison(this.inventoryLists.itemList.selectedEntry);
+
+            this._equipHand = undefined;
+            return;
+        }
+
+        if (this.inventoryLists.itemList.selectedEntry.enabled) {
+            gfx.io.GameDelegate.call("ItemTransfer", [event.amount, this.isViewingContainer()]);
+            return;
+        }
+
+        gfx.io.GameDelegate.call("DisabledItemSelect",[]);
+    }
+    
+    // @override ItemMenu
+    private function updateBottomBar(a_bSelected: Boolean)
+    {
+        this.navPanel.clearButtons();
+        
+        if (a_bSelected && this.inventoryLists.itemList.selectedIndex != -1 && this.inventoryLists.currentState == InventoryLists.SHOW_PANEL) {
+            if (this.isViewingContainer()) {
+                if (this._platform != 0) {
+                    this.navPanel.addButton({text: "$Take", controls: skyui.defines.Input.Activate});
+                    this.navPanel.addButton(this.getEquipButtonData(this.itemCard.itemInfo.type, true));
+                } else {
+                    if (this._bEquipMode)
+                        this.navPanel.addButton(this.getEquipButtonData(this.itemCard.itemInfo.type));
+                    else
+                        this.navPanel.addButton({text: "$Take", controls: skyui.defines.Input.Activate});
+                }
+                if (!this.bNPCMode)
+                    this.navPanel.addButton({text: "$Take All", controls: skyui.defines.Input.XButton});
+            } else {
+                if (this._platform != 0) {
+                    this.navPanel.addButton({text: bNPCMode ? "$Give" : "$Store", controls: skyui.defines.Input.Activate});
+                    this.navPanel.addButton(this.getEquipButtonData(this.itemCard.itemInfo.type, true));
+                } else {
+                    if (this._bEquipMode)
+                        this.navPanel.addButton(this.getEquipButtonData(this.itemCard.itemInfo.type));
+                    else
+                        this.navPanel.addButton({text: this.bNPCMode ? "$Give" : "$Store", controls: skyui.defines.Input.Activate});
+                }
+
+                this.navPanel.addButton({text: this.itemCard.itemInfo.favorite ? "$Unfavorite" : "$Favorite", controls: skyui.defines.Input.YButton});
+            }
+            if (!this._bEquipMode)
+                this.navPanel.addButton({text: "$Equip Mode", controls: this._equipModeControls});
+        } else {
+            this.navPanel.addButton({text: "$Exit", controls: this._cancelControls});
+            this.navPanel.addButton({text: "$Search", controls: this._searchControls});
+            if (this._platform != 0) {
+                this.navPanel.addButton({text: "$Column", controls: this._sortColumnControls});
+                this.navPanel.addButton({text: "$Order", controls: this._sortOrderControls});
+            }
+            this.navPanel.addButton({text: "$Switch Tab", controls: this._switchControls});
+            
+            if (this.isViewingContainer() && !this.bNPCMode)
+                this.navPanel.addButton({text: "$Take All", controls: skyui.defines.Input.XButton});			
+
+        }
+        
+        this.navPanel.updateButtons(true);
+    }
+
+    private function startItemTransfer()
+    {
+        if (this.inventoryLists.itemList.selectedEntry.enabled) {
+            // Don't remove. This is so if an item weighs nothing, it takes the whole stack
+            //  Gold, for example.
+            if (this.itemCard.itemInfo.weight == 0 && this.isViewingContainer()) {
+                this.onQuantityMenuSelect({amount: this.inventoryLists.itemList.selectedEntry.count});
+                return;
+            }
+
+            if (this._quantityMinCount < 1 || (this.inventoryLists.itemList.selectedEntry.count < this._quantityMinCount)) {
+                this.onQuantityMenuSelect({amount:1});
+            } else {
+                this.itemCard.ShowQuantityMenu(this.inventoryLists.itemList.selectedEntry.count);
+            }
+        }
+    }
+
+    private function startItemEquip(a_equipHand: Number)
+    {
+        if (this.isViewingContainer()) {
+            this._equipHand = a_equipHand;
             this.startItemTransfer();
-         }
-      }
-      else
-      {
-         this.startItemEquip(a_slot);
-      }
-   }
-   function onXButtonPress()
-   {
-      if(!this.bFadedIn)
-      {
-         return undefined;
-      }
-      if(this.isViewingContainer() && !this.bNPCMode)
-      {
-         gfx.io.GameDelegate.call("TakeAllItems",[]);
-      }
-   }
-   function SetPlatform(a_platform, a_bPS3Switch)
-   {
-      super.SetPlatform(a_platform,a_bPS3Switch);
-      this._bEquipMode = a_platform != 0;
-   }
-   function onItemSelect(event)
-   {
-      if(event.keyboardOrMouse != 0)
-      {
-         if(this._platform == 0 && this._bEquipMode)
-         {
-            this.startItemEquip(ContainerMenu.NULL_HAND);
-         }
-         else
-         {
-            this.startItemTransfer();
-         }
-      }
-   }
-   function onItemCardSubMenuAction(event)
-   {
-      super.onItemCardSubMenuAction(event);
-      if(event.menu == "quantity")
-      {
-         gfx.io.GameDelegate.call("QuantitySliderOpen",[event.opening]);
-      }
-   }
-   function onItemHighlightChange(event)
-   {
-      if(event.index != -1)
-      {
-         this.updateBottomBar(true);
-      }
-      super.onItemHighlightChange(event);
-   }
-   function onShowItemsList(event)
-   {
-      this.inventoryLists.showItemsList();
-   }
-   function onHideItemsList(event)
-   {
-      super.onHideItemsList(event);
-      this.bottomBar.updatePerItemInfo({type:skyui.defines.Inventory.ICT_NONE});
-      this.updateBottomBar(false);
-   }
-   function onMouseRotationFastClick(a_mouseButton)
-   {
-      gfx.io.GameDelegate.call("CheckForMouseEquip",[a_mouseButton],this,"AttemptEquip");
-   }
-   function onQuantityMenuSelect(event)
-   {
-      if(this._equipHand != undefined)
-      {
-         gfx.io.GameDelegate.call("EquipItem",[this._equipHand,event.amount]);
-         if(!this.checkBook(this.inventoryLists.itemList.selectedEntry))
-         {
+            return;
+        }
+
+        gfx.io.GameDelegate.call("EquipItem", [a_equipHand]);
+        if (!this.checkBook(this.inventoryLists.itemList.selectedEntry))
             this.checkPoison(this.inventoryLists.itemList.selectedEntry);
-         }
-         this._equipHand = undefined;
-         return undefined;
-      }
-      if(this.inventoryLists.itemList.selectedEntry.enabled)
-      {
-         gfx.io.GameDelegate.call("ItemTransfer",[event.amount,this.isViewingContainer()]);
-         return undefined;
-      }
-      gfx.io.GameDelegate.call("DisabledItemSelect",[]);
-   }
-   function updateBottomBar(a_bSelected)
-   {
-      this.navPanel.clearButtons();
-      if(a_bSelected && this.inventoryLists.itemList.selectedIndex != -1 && this.inventoryLists.currentState == InventoryLists.SHOW_PANEL)
-      {
-         if(this.isViewingContainer())
-         {
-            if(this._platform != 0)
-            {
-               this.navPanel.addButton({text:"$Take",controls:skyui.defines.Input.Activate});
-               this.navPanel.addButton(this.getEquipButtonData(this.itemCard.itemInfo.type,true));
-            }
-            else if(this._bEquipMode)
-            {
-               this.navPanel.addButton(this.getEquipButtonData(this.itemCard.itemInfo.type));
-            }
-            else
-            {
-               this.navPanel.addButton({text:"$Take",controls:skyui.defines.Input.Activate});
-            }
-            if(!this.bNPCMode)
-            {
-               this.navPanel.addButton({text:"$Take All",controls:skyui.defines.Input.XButton});
-            }
-         }
-         else
-         {
-            if(this._platform != 0)
-            {
-               this.navPanel.addButton({text:(!this.bNPCMode ? "$Store" : "$Give"),controls:skyui.defines.Input.Activate});
-               this.navPanel.addButton(this.getEquipButtonData(this.itemCard.itemInfo.type,true));
-            }
-            else if(this._bEquipMode)
-            {
-               this.navPanel.addButton(this.getEquipButtonData(this.itemCard.itemInfo.type));
-            }
-            else
-            {
-               this.navPanel.addButton({text:(!this.bNPCMode ? "$Store" : "$Give"),controls:skyui.defines.Input.Activate});
-            }
-            this.navPanel.addButton({text:(!this.itemCard.itemInfo.favorite ? "$Favorite" : "$Unfavorite"),controls:skyui.defines.Input.YButton});
-         }
-         if(!this._bEquipMode)
-         {
-            this.navPanel.addButton({text:"$Equip Mode",controls:this._equipModeControls});
-         }
-      }
-      else
-      {
-         this.navPanel.addButton({text:"$Exit",controls:this._cancelControls});
-         this.navPanel.addButton({text:"$Search",controls:this._searchControls});
-         if(this._platform != 0)
-         {
-            this.navPanel.addButton({text:"$Column",controls:this._sortColumnControls});
-            this.navPanel.addButton({text:"$Order",controls:this._sortOrderControls});
-         }
-         this.navPanel.addButton({text:"$Switch Tab",controls:this._switchControls});
-         if(this.isViewingContainer() && !this.bNPCMode)
-         {
-            this.navPanel.addButton({text:"$Take All",controls:skyui.defines.Input.XButton});
-         }
-      }
-      this.navPanel.updateButtons(true);
-   }
-   function startItemTransfer()
-   {
-      if(this.inventoryLists.itemList.selectedEntry.enabled)
-      {
-         if(this.itemCard.itemInfo.weight == 0 && this.isViewingContainer())
-         {
-            this.onQuantityMenuSelect({amount:this.inventoryLists.itemList.selectedEntry.count});
-            return undefined;
-         }
-         if(this._quantityMinCount < 1 || this.inventoryLists.itemList.selectedEntry.count < this._quantityMinCount)
-         {
-            this.onQuantityMenuSelect({amount:1});
-         }
-         else
-         {
-            this.itemCard.ShowQuantityMenu(this.inventoryLists.itemList.selectedEntry.count);
-         }
-      }
-   }
-   function startItemEquip(a_equipHand)
-   {
-      if(this.isViewingContainer())
-      {
-         this._equipHand = a_equipHand;
-         this.startItemTransfer();
-         return undefined;
-      }
-      gfx.io.GameDelegate.call("EquipItem",[a_equipHand]);
-      if(!this.checkBook(this.inventoryLists.itemList.selectedEntry))
-      {
-         this.checkPoison(this.inventoryLists.itemList.selectedEntry);
-      }
-   }
-   function isViewingContainer()
-   {
-      return this.inventoryLists.categoryList.activeSegment == 0;
-   }
-   function checkPoison(a_entryObject)
-   {
-      if(a_entryObject.type != skyui.defines.Inventory.ICT_POTION || _global.skse == null)
-      {
-         return false;
-      }
-      if(a_entryObject.subType != skyui.defines.Item.POTION_POISON)
-      {
-         return false;
-      }
-      this._bEquipMode = false;
-      return true;
-   }
+    }
+    
+    private function isViewingContainer()
+    {
+        return (this.inventoryLists.categoryList.activeSegment == 0);
+    }
+
+    /*
+        This method is only used in ContainerMenu.
+        If you attempt to use a poison in Container menu
+        a dialog box is presented to ask whether you want to poison the equipped weapon
+        If you release the _equipModeKey while the diaolog is present, the keyUp event
+        for this key is not received by ContainerMenu, so _bEquipMode remains true
+        meaning that the bottom bar buttons are incorrect
+    */
+    private function checkPoison(a_entryObject: Object)
+    {
+        if (a_entryObject.type != skyui.defines.Inventory.ICT_POTION || _global.skse == null)
+            return false;
+
+        if (a_entryObject.subType != skyui.defines.Item.POTION_POISON)
+            return false;
+
+        // force equip mode to false.
+        // Use this until we can detect if a specific keyCode is depressed
+        // _bEquipMode = skse.IsKeyDown(_equipModeKey)
+        this._bEquipMode = false;
+
+        return true;
+    }
 }

--- a/source/actionscript/ItemMenus/GiftMenu.as
+++ b/source/actionscript/ItemMenus/GiftMenu.as
@@ -1,103 +1,133 @@
 class GiftMenu extends ItemMenu
 {
-   var _cancelControls;
-   var _categoryListIconArt;
-   var _platform;
-   var _searchControls;
-   var _sortColumnControls;
-   var _sortOrderControls;
-   var bottomBar;
-   var inventoryLists;
-   var navPanel;
-   var _bGivingGifts = true;
-   function GiftMenu()
-   {
-      super();
-      this._categoryListIconArt = ["inv_all","inv_weapons","inv_armor","inv_potions","inv_scrolls","inv_food","inv_ingredients","inv_books","inv_keys","inv_misc"];
-   }
-   function InitExtensions()
-   {
-      super.InitExtensions();
-      gfx.io.GameDelegate.addCallBack("SetMenuInfo",this,"SetMenuInfo");
-      var _loc3_ = this.inventoryLists.categoryList;
-      _loc3_.iconArt = this._categoryListIconArt;
-   }
-   function setConfig(a_config)
-   {
-      super.setConfig(a_config);
-      var _loc3_ = this.inventoryLists.itemList;
-      _loc3_.addDataProcessor(new InventoryDataSetter());
-      _loc3_.addDataProcessor(new InventoryIconSetter(a_config.Appearance));
-      _loc3_.addDataProcessor(new skyui.props.PropertyDataExtender(a_config.Appearance,a_config.Properties,"itemProperties","itemIcons","itemCompoundProperties"));
-      var _loc5_ = skyui.components.list.ListLayoutManager.createLayout(a_config.ListLayout,"ItemListLayout");
-      _loc3_.layout = _loc5_;
-      if(this.inventoryLists.categoryList.selectedEntry)
-      {
-         _loc5_.changeFilterFlag(this.inventoryLists.categoryList.selectedEntry.flag);
-      }
-   }
-   function ShowItemsList()
-   {
-   }
-   function SetMenuInfo(a_bGivingGifts, a_bUseFavorPoints)
-   {
-      this._bGivingGifts = a_bGivingGifts;
-      if(!a_bUseFavorPoints)
-      {
-         this.bottomBar.hidePlayerInfo();
-      }
-   }
-   function UpdatePlayerInfo(a_favorPoints)
-   {
-      this.bottomBar.setGiftInfo(a_favorPoints);
-   }
-   function onShowItemsList(event)
-   {
-      var _loc2_ = this.inventoryLists.categoryList;
-      _loc2_.selectedIndex = 0;
-      _loc2_.entryList[0].text = "$ALL";
-      _loc2_.InvalidateData();
-      this.inventoryLists.showItemsList();
-   }
-   function onHideItemsList(event)
-   {
-      super.onHideItemsList(event);
-      this.bottomBar.updatePerItemInfo({type:skyui.defines.Inventory.ICT_NONE});
-      this.updateBottomBar(false);
-   }
-   function onItemHighlightChange(event)
-   {
-      super.onItemHighlightChange(event);
-      if(event.index != -1)
-      {
-         this.updateBottomBar(true);
-      }
-   }
-   function onItemCardSubMenuAction(event)
-   {
-      super.onItemCardSubMenuAction(event);
-      if(event.menu == "quantity")
-      {
-         gfx.io.GameDelegate.call("QuantitySliderOpen",[event.opening]);
-      }
-   }
-   function updateBottomBar(a_bSelected)
-   {
-      this.navPanel.clearButtons();
-      if(a_bSelected)
-      {
-         this.navPanel.addButton({text:(!this._bGivingGifts ? "$Take" : "$Give"),controls:skyui.defines.Input.Activate});
-      }
-      else
-      {
-         this.navPanel.addButton({text:"$Exit",controls:this._cancelControls});
-         this.navPanel.addButton({text:"$Search",controls:this._searchControls});
-         if(this._platform != 0)
-         {
-            this.navPanel.addButton({text:"$Column",controls:this._sortColumnControls});
-            this.navPanel.addButton({text:"$Order",controls:this._sortOrderControls});
-         }
-      }
-      this.navPanel.updateButtons(true);
-   }
+  /* PRIVATE VARIABLES */
+
+    private var _bGivingGifts: Boolean = true;
+
+    private var _categoryListIconArt: Array;
+
+
+  /* INITIALIZATION */
+
+    public function GiftMenu()
+    {
+        super();
+
+        this._categoryListIconArt = ["inv_all", "inv_weapons", "inv_armor", "inv_potions", "inv_scrolls", "inv_food", "inv_ingredients", "inv_books", "inv_keys", "inv_misc"];
+    }
+    
+    
+  /* PUBLIC FUNCTIONS */
+
+    public function InitExtensions()
+    {
+        super.InitExtensions();
+        gfx.io.GameDelegate.addCallBack("SetMenuInfo", this, "SetMenuInfo");
+        
+        // Initialize menu-specific list components
+        var categoryList: CategoryList = this.inventoryLists.categoryList;
+        categoryList.iconArt = this._categoryListIconArt;
+    }
+
+    // @override ItemMenu
+    public function setConfig(a_config: Object)
+    {
+        super.setConfig(a_config);
+
+        var itemList: TabularList = this.inventoryLists.itemList;		
+        itemList.addDataProcessor(new InventoryDataSetter());
+        itemList.addDataProcessor(new InventoryIconSetter(a_config["Appearance"]));
+        itemList.addDataProcessor(new skyui.props.PropertyDataExtender(a_config["Appearance"], a_config["Properties"], "itemProperties", "itemIcons", "itemCompoundProperties"));
+        
+        var layout: ListLayout = skyui.components.list.ListLayoutManager.createLayout(a_config["ListLayout"], "ItemListLayout");
+        itemList.layout = layout;
+
+        // Not 100% happy with doing this here, but has to do for now.
+        if (this.inventoryLists.categoryList.selectedEntry)
+            layout.changeFilterFlag(this.inventoryLists.categoryList.selectedEntry.flag);
+    }
+
+    // @API
+    public function ShowItemsList()
+    {
+        // Not necessary anymore. Now handled in onShowItemsList for consistency reasons.
+        //inventoryLists.showItemsList();
+    }
+
+    // @API
+    public function SetMenuInfo(a_bGivingGifts: Boolean, a_bUseFavorPoints: Boolean)
+    {
+        this._bGivingGifts = a_bGivingGifts;
+        
+        if (!a_bUseFavorPoints)
+            this.bottomBar.hidePlayerInfo();
+    }
+
+    // @override ItemMenu
+    public function UpdatePlayerInfo(a_favorPoints: Number)
+    {
+        this.bottomBar.setGiftInfo(a_favorPoints);
+    }
+
+    
+  /* PRIVATE FUNCTIONS */
+
+    // @override ItemMenu
+    private function onShowItemsList(event: Object)
+    {
+        // Force select of first category because RestoreIndices isn't called for GiftMenu
+        // TODO: Do this in the correct place, i.e. InventoryLists.SetCategoriesList();
+        var categoryList: CategoryList = this.inventoryLists.categoryList;
+        categoryList.selectedIndex = 0;
+        categoryList.entryList[0].text = "$ALL";
+        categoryList.InvalidateData();
+
+        this.inventoryLists.showItemsList();
+    }
+
+    // @override ItemMenu
+    private function onHideItemsList(event: Object)
+    {
+        super.onHideItemsList(event);
+
+        this.bottomBar.updatePerItemInfo({type: skyui.defines.Inventory.ICT_NONE});
+        
+        this.updateBottomBar(false);
+    }
+
+    private function onItemHighlightChange(event: Object)
+    {
+        super.onItemHighlightChange(event);
+        
+        if (event.index != -1)
+            this.updateBottomBar(true);	
+    }
+
+    // @override ItemMenu
+    private function onItemCardSubMenuAction(event: Object)
+    {
+        super.onItemCardSubMenuAction(event);
+        if (event.menu == "quantity")
+            gfx.io.GameDelegate.call("QuantitySliderOpen", [event.opening]);
+    }
+    
+    // @override ItemMenu
+    private function updateBottomBar(a_bSelected: Boolean)
+    {
+        this.navPanel.clearButtons();
+        
+        if (a_bSelected) {
+            this.navPanel.addButton({text: (this._bGivingGifts ? "$Give" : "$Take"), controls: skyui.defines.Input.Activate});
+        } else {
+            this.navPanel.addButton({text: "$Exit", controls: this._cancelControls});
+            this.navPanel.addButton({text: "$Search", controls: this._searchControls});
+            if (this._platform != 0) {
+                this.navPanel.addButton({text: "$Column", controls: this._sortColumnControls});
+                this.navPanel.addButton({text: "$Order", controls: this._sortOrderControls});
+            }
+        }
+        
+        this.navPanel.updateButtons(true);
+    }
+
 }

--- a/source/actionscript/ItemMenus/InventoryDataSetter.as
+++ b/source/actionscript/ItemMenus/InventoryDataSetter.as
@@ -99,6 +99,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                 this.processSoulGemStatus(a_entryObject);
                 this.processSoulGemBaseId(a_entryObject);
                 break;
+
+            default:
+                break;
         }
     }
 
@@ -144,7 +147,7 @@ class InventoryDataSetter extends ItemcardDataExtender
         if (a_entryObject.keywords == undefined)
             return;
 
-        if (a_entryObject.keywords["ArmorMaterialDaedric"] != undefined || a_entryObject.keywords["WeapMaterialDaedric"] != undefined  || a_entryObject.keywords["DLC1WeapMaterialDragonbone"] != undefined || a_entryObject.keywords["ccBGSSSE025_ArmorMaterialDark"] != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialDark"] != undefined || a_entryObject.keywords["ccBGSSSE025_ArmorMaterialGolden"] != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialGolden"] != undefined) {
+        if (a_entryObject.keywords["ArmorMaterialDaedric"] != undefined || a_entryObject.keywords["WeapMaterialDaedric"] != undefined || a_entryObject.keywords["ccBGSSSE025_ArmorMaterialDark"] != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialDark"] != undefined || a_entryObject.keywords["ccBGSSSE025_ArmorMaterialGolden"] != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialGolden"] != undefined) {
             a_entryObject.material = skyui.defines.Material.DAEDRIC;
             a_entryObject.materialDisplay = skyui.util.Translator.translate("$Daedric");
         
@@ -156,8 +159,7 @@ class InventoryDataSetter extends ItemcardDataExtender
             a_entryObject.material = skyui.defines.Material.DWARVEN;
             a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
         
-        } else if (a_entryObject.keywords["ArmorMaterialEbony"] != undefined ||
-                a_entryObject.keywords["WeapMaterialEbony"] != undefined) {
+        } else if (a_entryObject.keywords["ArmorMaterialEbony"] != undefined || a_entryObject.keywords["WeapMaterialEbony"] != undefined) {
             a_entryObject.material = skyui.defines.Material.EBONY;
             a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ebony");
         
@@ -165,8 +167,7 @@ class InventoryDataSetter extends ItemcardDataExtender
             a_entryObject.material = skyui.defines.Material.ELVEN;
             a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
         
-        } else if (a_entryObject.keywords["ArmorMaterialGlass"] != undefined ||
-                a_entryObject.keywords["WeapMaterialGlass"] != undefined) {
+        } else if (a_entryObject.keywords["ArmorMaterialGlass"] != undefined || a_entryObject.keywords["WeapMaterialGlass"] != undefined) {
             a_entryObject.material = skyui.defines.Material.GLASS;
             a_entryObject.materialDisplay = skyui.util.Translator.translate("$Glass");
         
@@ -199,7 +200,7 @@ class InventoryDataSetter extends ItemcardDataExtender
             a_entryObject.material = skyui.defines.Material.STEEL;
             a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
         
-        } else if (a_entryObject.keywords["WeapMaterialSilver"] != undefined || a_entryObject.keywords["WeapMaterialSteel"] != undefined) {
+        } else if (a_entryObject.keywords["WeapMaterialSilver"] != undefined) {
             a_entryObject.material = skyui.defines.Material.SILVER;
             a_entryObject.materialDisplay = skyui.util.Translator.translate("$Silver");
         
@@ -227,15 +228,15 @@ class InventoryDataSetter extends ItemcardDataExtender
             a_entryObject.material = skyui.defines.Material.FALMER;
             a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
         
-        } else if(a_entryObject.keywords.ccASVSSE001_ArmorOrdinator != undefined || a_entryObject.keywords["ccASVSSE001_ArmorOrdinatorIndoril"] != undefined) {
+        } else if(a_entryObject.keywords["ccASVSSE001_ArmorOrdinator"] != undefined || a_entryObject.keywords["ccASVSSE001_ArmorOrdinatorIndoril"] != undefined) {
             a_entryObject.material = skyui.defines.Material.ORDINATOR;
             a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ordinator");
         
-        } else if(a_entryObject.keywords.ccBGSSSE025_ArmorMaterialAmber != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialAmber"] != undefined) {
+        } else if(a_entryObject.keywords["ccBGSSSE025_ArmorMaterialAmber"] != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialAmber"] != undefined) {
             a_entryObject.material = skyui.defines.Material.AMBER;
             a_entryObject.materialDisplay = skyui.util.Translator.translate("$Amber");
         
-        } else if(a_entryObject.keywords.ccBGSSSE025_ArmorMaterialMadness != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialMadness"] != undefined) {
+        } else if(a_entryObject.keywords["ccBGSSSE025_ArmorMaterialMadness"] != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialMadness"] != undefined) {
             a_entryObject.material = skyui.defines.Material.MADNESS;
             a_entryObject.materialDisplay = skyui.util.Translator.translate("$Madness");
         
@@ -321,6 +322,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                 a_entryObject.subType = skyui.defines.Weapon.TYPE_CROSSBOW;
                 a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Crossbow");
                 break;
+            
+            default:
+                break;
         }
     }
 
@@ -351,6 +355,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                     case skyui.defines.Form.FORMID_FORSWORNSTAFF:
                     case skyui.defines.Form.FORMID_FORSWORNSWORD:
                         break;
+
+                    default:
+                        break;
                 }
                 break;
 
@@ -364,7 +371,13 @@ class InventoryDataSetter extends ItemcardDataExtender
                         a_entryObject.material = skyui.defines.Material.STEEL;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
                         break;
+
+                    default:
+                        break;
                 }
+                break;
+
+            default:
                 break;
         }
     }
@@ -501,6 +514,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                 a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
                 a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
                 break;
+
+            default:
+                break;
         }
     }
 
@@ -550,6 +566,7 @@ class InventoryDataSetter extends ItemcardDataExtender
         if (a_entryObject.keywords["VendorItemRecipe"] != undefined) {
             a_entryObject.subType = skyui.defines.Item.BOOK_RECIPE;
             a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Recipe");
+
         } else if (a_entryObject.keywords["VendorItemSpellTome"] != undefined) {
             a_entryObject.subType = skyui.defines.Item.BOOK_SPELLTOME;
             a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Spell Tome");
@@ -561,6 +578,7 @@ class InventoryDataSetter extends ItemcardDataExtender
         if ((a_entryObject.flags & skyui.defines.Weapon.AMMOFLAG_NONBOLT) != 0) {
             a_entryObject.subType = skyui.defines.Weapon.AMMO_ARROW;
             a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Arrow");
+
         } else {
             a_entryObject.subType = skyui.defines.Weapon.AMMO_BOLT;
             a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Bolt");
@@ -576,18 +594,22 @@ class InventoryDataSetter extends ItemcardDataExtender
                         a_entryObject.material = skyui.defines.Material.DAEDRIC;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Daedric");
                         break;
+
                     case skyui.defines.Form.FORMID_EBONYARROW:
                         a_entryObject.material = skyui.defines.Material.EBONY;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ebony");
                         break;
+
                     case skyui.defines.Form.FORMID_GLASSARROW:
                         a_entryObject.material = skyui.defines.Material.GLASS;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Glass");
                         break;
+
                     case skyui.defines.Form.FORMID_ELVENARROW:
                         a_entryObject.material = skyui.defines.Material.ELVEN;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
                         break;
+
                     case skyui.defines.Form.FORMID_DWARVENARROW:
                     case skyui.defines.Form.FORMID_DWARVENSPHEREARROW:
                     case skyui.defines.Form.FORMID_DWARVENSPHEREBOLT01:
@@ -595,18 +617,22 @@ class InventoryDataSetter extends ItemcardDataExtender
                         a_entryObject.material = skyui.defines.Material.DWARVEN;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
                         break;
+
                     case skyui.defines.Form.FORMID_ORCISHARROW:
                         a_entryObject.material = skyui.defines.Material.ORCISH;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Orcish");
                         break;
+
                     case skyui.defines.Form.FORMID_NORDHEROARROW:
                         a_entryObject.material = skyui.defines.Material.NORDIC;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Nordic");
                         break;
+
                     case skyui.defines.Form.FORMID_FALMERARROW:
                         a_entryObject.material = skyui.defines.Material.FALMER;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
                         break;
+
                     case skyui.defines.Form.FORMID_STEELARROW:
                     case skyui.defines.Form.FORMID_MQ101STEELARROW:
                     case skyui.defines.Form.FORMID_DRAUGRARROW:
@@ -614,6 +640,7 @@ class InventoryDataSetter extends ItemcardDataExtender
                         a_entryObject.material = skyui.defines.Material.STEEL;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
                         break;
+
                     case skyui.defines.Form.FORMID_IRONARROW:
                     case skyui.defines.Form.FORMID_CWARROW:
                     case skyui.defines.Form.FORMID_CWARROWSHORT:
@@ -622,6 +649,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                     case skyui.defines.Form.FORMID_FOLLOWERIRONARROW:
                         a_entryObject.material = skyui.defines.Material.IRON;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
+                        break;
+
+                    default:
                         break;
                 }
                 break;
@@ -633,9 +663,13 @@ class InventoryDataSetter extends ItemcardDataExtender
                         a_entryObject.material = skyui.defines.Material.ELVEN;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
                         break;
+
                     case skyui.defines.Form.FORMID_TESTDLC1BOLT:
                         a_entryObject.material = skyui.defines.Material.IRON;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
+
+                    default:
+                        break;
 
                 }
                 break;
@@ -646,20 +680,24 @@ class InventoryDataSetter extends ItemcardDataExtender
                         a_entryObject.material = skyui.defines.Material.DWARVEN;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
                         break;
+
                     case skyui.defines.Form.FORMID_DLC2RIEKLINGSPEARTHROWN:
                         a_entryObject.material = skyui.defines.Material.WOOD;
                         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Wood");
                         break;
+                    
+                    default:
+                        break;
                 }
+
+            default:
+                break;
         }
     }
 
     private function processKeyType(a_entryObject: Object)
     {
         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Key");
-
-        if (a_entryObject.infoValue <= 0)
-            a_entryObject.infoValue = null;
 
         if (a_entryObject.infoValue <= 0)
             a_entryObject.infoValue = null;
@@ -683,16 +721,19 @@ class InventoryDataSetter extends ItemcardDataExtender
         } else if ((a_entryObject.flags & skyui.defines.Item.ALCHFLAG_POISON) != 0) {
             a_entryObject.subType = skyui.defines.Item.POTION_POISON;
             a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Poison");
+
         } else {
             switch (a_entryObject.actorValue) {
                 case skyui.defines.Actor.AV_HEALTH:
                     a_entryObject.subType = skyui.defines.Item.POTION_HEALTH;
                     a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
                     break;
+
                 case skyui.defines.Actor.AV_MAGICKA:
                     a_entryObject.subType = skyui.defines.Item.POTION_MAGICKA;
                     a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
                     break;
+
                 case skyui.defines.Actor.AV_STAMINA:
                     a_entryObject.subType = skyui.defines.Item.POTION_STAMINA;
                     a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
@@ -702,10 +743,12 @@ class InventoryDataSetter extends ItemcardDataExtender
                     a_entryObject.subType = skyui.defines.Item.POTION_HEALRATE;
                     a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
                     break;
+
                 case skyui.defines.Actor.AV_MAGICKARATE:
                     a_entryObject.subType = skyui.defines.Item.POTION_MAGICKARATE;
                     a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
                     break;
+
                 case skyui.defines.Actor.AV_STAMINARATE:
                     a_entryObject.subType = skyui.defines.Item.POTION_STAMINARATE;
                     a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
@@ -715,10 +758,12 @@ class InventoryDataSetter extends ItemcardDataExtender
                     a_entryObject.subType = skyui.defines.Item.POTION_HEALRATEMULT;
                     a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
                     break;
+
                 case skyui.defines.Actor.AV_MAGICKARATEMULT:
                     a_entryObject.subType = skyui.defines.Item.POTION_MAGICKARATEMULT;
                     a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
                     break;
+
                 case skyui.defines.Actor.AV_STAMINARATEMULT:
                     a_entryObject.subType = skyui.defines.Item.POTION_STAMINARATEMULT;
                     a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
@@ -734,6 +779,9 @@ class InventoryDataSetter extends ItemcardDataExtender
 
                 case skyui.defines.Actor.AV_FROSTRESIST:
                     a_entryObject.subType = skyui.defines.Item.POTION_FROSTRESIST;
+                    break;
+
+                default:
                     break;
             }
         }
@@ -772,6 +820,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                 a_entryObject.subType = skyui.defines.Item.SOULGEM_SOULTOMATO;
                 a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$SoulTomato");
                 break;
+
+            default:
+                break;
         }
     }
 
@@ -791,11 +842,9 @@ class InventoryDataSetter extends ItemcardDataExtender
             a_entryObject.subType = skyui.defines.Item.MISC_TOY;
             a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Toy");
 
-        
         } else if (a_entryObject.keywords["BYOHHouseCraftingCategoryWeaponRacks"] != undefined || a_entryObject.keywords["BYOHHouseCraftingCategoryShelf"] != undefined ||  a_entryObject.keywords["BYOHHouseCraftingCategoryFurniture"] != undefined || a_entryObject.keywords["BYOHHouseCraftingCategoryExterior"] != undefined ||  a_entryObject.keywords["BYOHHouseCraftingCategoryContainers"] != undefined || a_entryObject.keywords["BYOHHouseCraftingCategoryBuilding"] != undefined ||  a_entryObject.keywords["BYOHHouseCraftingCategorySmithing"] != undefined) {
             a_entryObject.subType = skyui.defines.Item.MISC_HOUSEPART;
             a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$House Part");
-        
 
         } else if (a_entryObject.keywords["VendorItemDaedricArtifact"] != undefined) {
             a_entryObject.subType = skyui.defines.Item.MISC_ARTIFACT;
@@ -821,7 +870,7 @@ class InventoryDataSetter extends ItemcardDataExtender
             a_entryObject.subType = skyui.defines.Item.MISC_INGOT;
             a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingot");
 
-        } else if (a_entryObject.keywords["VendorItemFirewood"] != undefined) {
+        } else if (a_entryObject.keywords["VendorItemFireword"] != undefined) {
             a_entryObject.subType = skyui.defines.Item.MISC_FIREWOOD;
             a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Firewood");
 
@@ -1032,6 +1081,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                         a_entryObject.subType = skyui.defines.Item.MISC_ORE;
                         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
                         break
+
+                    default:
+                        break;
                 }
                 break;
 
@@ -1041,6 +1093,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                     case skyui.defines.Form.FORMID_UPDATEHORSETACK2:
                         a_entryObject.subType = skyui.defines.Item.MISC_HORSETACK;
                         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$HorseTack");
+                        break;
+
+                    default:
                         break;
                 }
                 break;
@@ -1071,6 +1126,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                         a_entryObject.subType = skyui.defines.Item.MISC_NETCHLEATHER;
                         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$NetchLeather");
                         break
+
+                    default:
+                        break;
                 }
                 break;
 
@@ -1088,6 +1146,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                     case skyui.defines.Form.FORMID_HFHOUSEPART10:
                         a_entryObject.subType = skyui.defines.Item.MISC_HOUSEPART;
                         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BuildingMaterial");
+                        break;
+                    
+                    default:
                         break;
                 }
                 break;
@@ -1142,6 +1203,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                         a_entryObject.subType = skyui.defines.Item.MISC_ORE;
                         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
                         break;
+
+                    default:
+                        break;
                 }
                 break;
 
@@ -1162,6 +1226,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                     case skyui.defines.Form.ESLID_CCVSV002PETAMULET:
                         a_entryObject.subType = skyui.defines.Item.MISC_PETGEAR;
                         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$PetGear");
+                        break;
+
+                    default:
                         break;
                 }
                 break;
@@ -1230,6 +1297,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                         a_entryObject.subType = skyui.defines.Item.MISC_ORE;
                         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
                         break;
+
+                    default:
+                        break;
                 }
                 break;
         }
@@ -1260,6 +1330,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                         a_entryObject.subType = skyui.defines.Item.BOOK_ELDERSCROLL;
                         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ElderScroll");
                         break;
+
+                    default:
+                        break;
                 }
                 break;
                 
@@ -1270,6 +1343,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                     case skyui.defines.Form.FORMID_DLC1ELDERSCROLL3:
                         a_entryObject.subType = skyui.defines.Item.BOOK_ELDERSCROLL;
                         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ElderScroll");
+                        break;
+
+                    default:
                         break;
                 }
                 break;
@@ -1332,6 +1408,9 @@ class InventoryDataSetter extends ItemcardDataExtender
                 a_entryObject.subType = skyui.defines.Item.SCROLL_SPIDER;
                 a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ScrollSpider");
                 break;
+
+            default:
+                break;
         }
     }
     function processPotionBaseId(a_entryObject)
@@ -1342,6 +1421,9 @@ class InventoryDataSetter extends ItemcardDataExtender
             case skyui.defines.Form.BASEID_HEARTLANDAYLEIDCRYSTALPOTION2:
                 a_entryObject.subType = skyui.defines.Item.POTION_AYLEIDCRYSTAL;
                 a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$AyleidCrystal");
+                break;
+
+            default:
                 break;
         }
     }

--- a/source/actionscript/ItemMenus/InventoryDataSetter.as
+++ b/source/actionscript/ItemMenus/InventoryDataSetter.as
@@ -1,1304 +1,1348 @@
 class InventoryDataSetter extends ItemcardDataExtender
 {
-   function InventoryDataSetter()
-   {
-      super();
-   }
-   function processEntry(a_entryObject, a_itemInfo)
-   {
-      a_entryObject.baseId = a_entryObject.formId & 0xFFFFFF;
-      a_entryObject.eslId = a_entryObject.formId & 0xFFF;
-      a_entryObject.type = a_itemInfo.type;
-      a_entryObject.isEquipped = a_entryObject.equipState > 0;
-      a_entryObject.isStolen = a_itemInfo.stolen == true;
-      a_entryObject.infoValue = a_itemInfo.value <= 0 ? null : Math.round(a_itemInfo.value * 100) / 100;
-      a_entryObject.infoWeight = a_itemInfo.weight <= 0 ? null : Math.round(a_itemInfo.weight * 100) / 100;
-      a_entryObject.infoValueWeight = !(a_itemInfo.weight > 0 && a_itemInfo.value > 0) ? null : Math.round(a_itemInfo.value / a_itemInfo.weight);
-      switch(a_entryObject.formType)
-      {
-         case skyui.defines.Form.TYPE_SCROLLITEM:
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Scroll");
-            a_entryObject.duration = a_entryObject.duration <= 0 ? null : Math.round(a_entryObject.duration * 100) / 100;
-            a_entryObject.magnitude = a_entryObject.magnitude <= 0 ? null : Math.round(a_entryObject.magnitude * 100) / 100;
-            this.processScrollBaseId(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_ARMOR:
-            a_entryObject.isEnchanted = a_itemInfo.effects != "";
-            a_entryObject.infoArmor = a_itemInfo.armor <= 0 ? null : Math.round(a_itemInfo.armor * 100) / 100;
-            this.processArmorClass(a_entryObject);
-            this.processArmorPartMask(a_entryObject);
-            this.processMaterialKeywords(a_entryObject); 
-            this.processArmorOther(a_entryObject);
-            this.processArmorBaseId(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_BOOK:
-            this.processBookType(a_entryObject);
-            this.processBookBaseId(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_INGREDIENT:
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingredient");
-            break;
-         case skyui.defines.Form.TYPE_LIGHT:
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Torch");
-            break;
-         case skyui.defines.Form.TYPE_MISC:
-            this.processMiscType(a_entryObject);
-            this.processMiscBaseId(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_WEAPON:
-            a_entryObject.isEnchanted = a_itemInfo.effects != "";
-            a_entryObject.isPoisoned = a_itemInfo.poisoned == true;
-            a_entryObject.infoDamage = a_itemInfo.damage <= 0 ? null : Math.round(a_itemInfo.damage * 100) / 100;
-            this.processWeaponType(a_entryObject);
-            this.processMaterialKeywords(a_entryObject);
-            this.processWeaponBaseId(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_AMMO:
-            a_entryObject.isEnchanted = a_itemInfo.effects != "";
-            a_entryObject.infoDamage = a_itemInfo.damage <= 0 ? null : Math.round(a_itemInfo.damage * 100) / 100;
-            this.processAmmoType(a_entryObject);
-            this.processMaterialKeywords(a_entryObject);
-            this.processAmmoBaseId(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_KEY:
-            this.processKeyType(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_POTION:
-            a_entryObject.duration = a_entryObject.duration <= 0 ? null : Math.round(a_entryObject.duration * 100) / 100;
-            a_entryObject.magnitude = a_entryObject.magnitude <= 0 ? null : Math.round(a_entryObject.magnitude * 100) / 100;
-            this.processPotionType(a_entryObject);
-            this.processPotionBaseId(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_SOULGEM:
-            this.processSoulGemType(a_entryObject);
-            this.processSoulGemStatus(a_entryObject);
-            this.processSoulGemBaseId(a_entryObject);
-         default:
-            return;
-      }
-   }
-   function processArmorClass(a_entryObject)
-   {
-      if(a_entryObject.weightClass == skyui.defines.Armor.WEIGHT_NONE)
-      {
-         a_entryObject.weightClass = null;
-      }
-      a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Other");
-      switch(a_entryObject.weightClass)
-      {
-         case skyui.defines.Armor.WEIGHT_LIGHT:
-            a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Light");
-            return;
-         case skyui.defines.Armor.WEIGHT_HEAVY:
-            a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Heavy");
-            return;
-         default:
-            if(a_entryObject.keywords == undefined)
-            {
-               return;
-            }
-            if(a_entryObject.keywords.VendorItemClothing != undefined)
-            {
-               a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_CLOTHING;
-               a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Clothing");
-               return;
-            }
-            if(a_entryObject.keywords.VendorItemJewelry != undefined)
-            {
-               a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
-               a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
-               return;
-            }
-            return;
-      }
-   }
-   function processMaterialKeywords(a_entryObject)
-   {
-      a_entryObject.material = null;
-      a_entryObject.materialDisplay = skyui.util.Translator.translate("$Other");
-      if(a_entryObject.keywords == undefined)
-      {
-         return undefined;
-      }
+  /* INITIALIZATION */
 
-      if(a_entryObject.keywords.ArmorMaterialDaedric != undefined || a_entryObject.keywords.WeapMaterialDaedric != undefined || a_entryObject.keywords.ccBGSSSE025_ArmorMaterialDark != undefined || a_entryObject.keywords.ccBGSSSE025_WeapMaterialDark != undefined || a_entryObject.keywords.ccBGSSSE025_ArmorMaterialGolden != undefined || a_entryObject.keywords.ccBGSSSE025_WeapMaterialGolden != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.DAEDRIC;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Daedric");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialDragonplate != undefined || a_entryObject.keywords.ArmorMaterialDragonscale != undefined || a_entryObject.keywords.DLC1WeapMaterialDragonbone != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.DRAGON;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dragon");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialDwarven != undefined || a_entryObject.keywords.WeapMaterialDwarven != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.DWARVEN;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialEbony != undefined || a_entryObject.keywords.WeapMaterialEbony != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.EBONY;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ebony");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialElven != undefined || a_entryObject.keywords.WeapMaterialElven != undefined || a_entryObject.keywords.ArmorMaterialElvenGilded != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.ELVEN;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialGlass != undefined || a_entryObject.keywords.WeapMaterialGlass != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.GLASS;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Glass");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialHide != undefined || a_entryObject.keywords.ArmorMaterialScaled != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.HIDE;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Hide");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialStormcloak != undefined || a_entryObject.keywords.ArmorMaterialBearStormcloak != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.STORMCLOAK;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Stormcloak");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialImperialHeavy != undefined || a_entryObject.keywords.ArmorMaterialImperialLight != undefined || a_entryObject.keywords.WeapMaterialImperial != undefined || a_entryObject.keywords.ArmorMaterialImperialStudded != undefined || a_entryObject.keywords.ArmorMaterialStudded != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.IMPERIAL;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Imperial");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialIron != undefined || a_entryObject.keywords.WeapMaterialIron != undefined || a_entryObject.keywords.ArmorMaterialIronBanded != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.IRON;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialLeather != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.LEATHER;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Leather");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialOrcish != undefined || a_entryObject.keywords.WeapMaterialOrcish != undefined || a_entryObject.keywords.ccBGSSSE055_ArmorMaterialOrcishLight != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.ORCISH;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Orcish");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialSteel != undefined || a_entryObject.keywords.WeapMaterialSteel != undefined || a_entryObject.keywords.ArmorMaterialSteelPlate != undefined || a_entryObject.keywords.WeapMaterialDraugr != undefined || a_entryObject.keywords.WeapMaterialDraugrHoned != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.STEEL;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
-      }
-      else if(a_entryObject.keywords.WeapMaterialSilver != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.SILVER;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Silver");
-      }
-      else if(a_entryObject.keywords.ArmorMaterialFalmer != undefined || a_entryObject.keywords.DLC1ArmorMaterialFalmerHardened != undefined || a_entryObject.keywords.DLC1ArmorMaterielFalmerHeavy != undefined || a_entryObject.keywords.DLC1ArmorMaterielFalmerHeavyOriginal != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.FALMER;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
-      }
-      else if(a_entryObject.keywords.DLC2ArmorMaterialBonemoldHeavy != undefined || a_entryObject.keywords.DLC2ArmorMaterialBonemoldLight != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.BONEMOLD;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Bonemold");
-      }
-      else if(a_entryObject.keywords.DLC2ArmorMaterialChitinHeavy != undefined || a_entryObject.keywords.DLC2ArmorMaterialChitinLight != undefined || a_entryObject.keywords.DLC2ArmorMaterialMoragTong != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.CHITIN;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Chitin");
-      }
-      else if(a_entryObject.keywords.DLC2ArmorMaterialNordicHeavy != undefined || a_entryObject.keywords.DLC2ArmorMaterialNordicLight != undefined || a_entryObject.keywords.DLC2WeaponMaterialNordic != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.NORDIC;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Nordic");
-      }
-      else if(a_entryObject.keywords.DLC2ArmorMaterialStalhrimHeavy != undefined || a_entryObject.keywords.DLC2ArmorMaterialStalhrimLight != undefined || a_entryObject.keywords.DLC2WeaponMaterialStalhrim != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.STALHRIM;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Stalhrim");
-      }
-      else if(a_entryObject.keywords.WeapMaterialFalmer != undefined || a_entryObject.keywords.WeapMaterialFalmerHoned != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.FALMER;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
-      }
-      else if(a_entryObject.keywords.ccASVSSE001_ArmorOrdinator != undefined || a_entryObject.keywords.ccASVSSE001_ArmorOrdinatorIndoril != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.ORDINATOR;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ordinator");
-      }
-      else if(a_entryObject.keywords.ccBGSSSE025_ArmorMaterialAmber != undefined || a_entryObject.keywords.ccBGSSSE025_WeapMaterialAmber != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.AMBER;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Amber");
-      }
-      else if(a_entryObject.keywords.ccBGSSSE025_ArmorMaterialMadness != undefined || a_entryObject.keywords.ccBGSSSE025_WeapMaterialMadness != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.MADNESS;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Madness");
-      }
-      else if(a_entryObject.keywords.WeapMaterialWood != undefined)
-      {
-         a_entryObject.material = skyui.defines.Material.WOOD;
-         a_entryObject.materialDisplay = skyui.util.Translator.translate("$Wood");
-      }
-   }
-   function processWeaponType(a_entryObject)
-   {
-      a_entryObject.subType = null;
-      a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Weapon");
-      switch(a_entryObject.weaponType)
-      {
-         case skyui.defines.Weapon.ANIM_HANDTOHANDMELEE:
-         case skyui.defines.Weapon.ANIM_H2H:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_MELEE;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Melee");
-            break;
-         case skyui.defines.Weapon.ANIM_ONEHANDSWORD:
-         case skyui.defines.Weapon.ANIM_1HS:
-            if(a_entryObject.keywords != undefined && a_entryObject.keywords.ccBGSSSE001_FishingPoleKW != undefined)
-            {
-               a_entryObject.subType = skyui.defines.Weapon.TYPE_FISHINGROD;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$FishingRod");
-               return;
-            }
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_SWORD;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Sword");
-            break;
-         case skyui.defines.Weapon.ANIM_ONEHANDDAGGER:
-         case skyui.defines.Weapon.ANIM_1HD:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_DAGGER;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Dagger");
-            break;
-         case skyui.defines.Weapon.ANIM_ONEHANDAXE:
-         case skyui.defines.Weapon.ANIM_1HA:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_WARAXE;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$War Axe");
-            break;
-         case skyui.defines.Weapon.ANIM_ONEHANDMACE:
-         case skyui.defines.Weapon.ANIM_1HM:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_MACE;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Mace");
-            break;
-         case skyui.defines.Weapon.ANIM_TWOHANDSWORD:
-         case skyui.defines.Weapon.ANIM_2HS:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_GREATSWORD;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Greatsword");
-            break;
-         case skyui.defines.Weapon.ANIM_TWOHANDAXE:
-         case skyui.defines.Weapon.ANIM_2HA:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_BATTLEAXE;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Battleaxe");
-            if(a_entryObject.keywords != undefined && a_entryObject.keywords.WeapTypeWarhammer != undefined)
-            {
-               a_entryObject.subType = skyui.defines.Weapon.TYPE_WARHAMMER;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Warhammer");
-            }
-            break;
-         case skyui.defines.Weapon.ANIM_BOW:
-         case skyui.defines.Weapon.ANIM_BOW2:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_BOW;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Bow");
-            break;
-         case skyui.defines.Weapon.ANIM_STAFF:
-         case skyui.defines.Weapon.ANIM_STAFF2:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_STAFF;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Staff");
-            break;
-         case skyui.defines.Weapon.ANIM_CROSSBOW:
-         case skyui.defines.Weapon.ANIM_CBOW:
-            a_entryObject.subType = skyui.defines.Weapon.TYPE_CROSSBOW;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Crossbow");
-         default:
-            return;
-      }
-   }
-   function processWeaponBaseId(a_entryObject)
-   {
-      switch(a_entryObject.formId >>> 24)
-      {
-         case 0x00:
-            switch(a_entryObject.baseId)
-            {
-               case skyui.defines.Form.FORMID_WEAPPICKAXE:
-               case skyui.defines.Form.FORMID_SSDROCKSPLINTERPICKAXE:
-               case skyui.defines.Form.FORMID_DUNVOLUNRUUDPICKAXE:
-                  a_entryObject.subType = skyui.defines.Weapon.TYPE_PICKAXE;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Pickaxe");
-                  break;
-               case skyui.defines.Form.FORMID_AXE01:
-               case skyui.defines.Form.FORMID_DUNHALTEDSTREAMPOACHERSAXE:
-                  a_entryObject.subType = skyui.defines.Weapon.TYPE_WOODAXE;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Wood Axe");
-                  break;
-               case skyui.defines.Form.FORMID_LONGBOW:
-               case skyui.defines.Form.FORMID_HUNTINGBOW:
-               case skyui.defines.Form.FORMID_DRAVINSBOW:
-                  a_entryObject.material = skyui.defines.Material.WOOD;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Wood");
-                  break;
-               case skyui.defines.Form.FORMID_FORSWORNAXE:
-               case skyui.defines.Form.FORMID_FORSWORNBOW:
-               case skyui.defines.Form.FORMID_FORSWORNSTAFF:
-               case skyui.defines.Form.FORMID_FORSWORNSWORD:
-                  break;
-            }
-            return;
-         case 0x04:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_DLC2PICKAXE1:
-               case skyui.defines.Form.FORMID_DLC2PICKAXE2:
-               case skyui.defines.Form.FORMID_DLC2PICKAXE3:
-                  a_entryObject.subType = skyui.defines.Weapon.TYPE_PICKAXE;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Pickaxe");
-                  a_entryObject.material = skyui.defines.Material.STEEL;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
-                  break;
-            }
-            return;
-         default:
-            return;
-      }
-   }
-   function processArmorPartMask(a_entryObject)
-   {
-      if(a_entryObject.partMask == undefined)
-      {
-         return undefined;
-      }
-      var _loc2_ = 0;
-      while(_loc2_ < skyui.defines.Armor.PARTMASK_PRECEDENCE.length)
-      {
-         if(a_entryObject.partMask & skyui.defines.Armor.PARTMASK_PRECEDENCE[_loc2_])
-         {
-            a_entryObject.mainPartMask = skyui.defines.Armor.PARTMASK_PRECEDENCE[_loc2_];
-            break;
-         }
-         _loc2_ = _loc2_ + 1;
-      }
-      if(a_entryObject.mainPartMask == undefined)
-      {
-         return undefined;
-      }
-      switch(a_entryObject.mainPartMask)
-      {
-         case skyui.defines.Armor.PARTMASK_HEAD:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_HEAD;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Head");
-            return;
-         case skyui.defines.Armor.PARTMASK_HAIR:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_HAIR;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Head");
-            return;
-         case skyui.defines.Armor.PARTMASK_LONGHAIR:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_LONGHAIR;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Head");
-            return;
-         case skyui.defines.Armor.PARTMASK_BODY:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_BODY;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Body");
-            return;
-         case skyui.defines.Armor.PARTMASK_HANDS:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_HANDS;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Hands");
-            return;
-         case skyui.defines.Armor.PARTMASK_FOREARMS:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_FOREARMS;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Forearms");
-            return;
-         case skyui.defines.Armor.PARTMASK_AMULET:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_AMULET;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Amulet");
-            return;
-         case skyui.defines.Armor.PARTMASK_RING:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_RING;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ring");
-            return;
-         case skyui.defines.Armor.PARTMASK_FEET:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_FEET;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Feet");
-            return;
-         case skyui.defines.Armor.PARTMASK_CALVES:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_CALVES;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Calves");
-            return;
-         case skyui.defines.Armor.PARTMASK_SHIELD:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_SHIELD;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Shield");
-            return;
-         case skyui.defines.Armor.PARTMASK_CIRCLET:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_CIRCLET;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Circlet");
-            return;
-         case skyui.defines.Armor.PARTMASK_EARS:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_EARS;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ears");
-            return;
-         case skyui.defines.Armor.PARTMASK_TAIL:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_TAIL;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Tail");
-            return;
-         case skyui.defines.Armor.PARTMASK_CLOAK:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_CLOAK;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ClothingCloak");
-            return;
-         case skyui.defines.Armor.PARTMASK_BACKPACK:
-            a_entryObject.subType = skyui.defines.Armor.EQUIP_BACKPACK;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Backpack");
-            return;
-         default:
-            a_entryObject.subType = a_entryObject.mainPartMask;
-            return;
-      }
-   }
-   function processArmorOther(a_entryObject)
-   {
-      if(a_entryObject.weightClass != null)
-      {
-         return undefined;
-      }
-      switch(a_entryObject.mainPartMask)
-      {
-         case skyui.defines.Armor.PARTMASK_HEAD:
-         case skyui.defines.Armor.PARTMASK_HAIR:
-         case skyui.defines.Armor.PARTMASK_LONGHAIR:
-         case skyui.defines.Armor.PARTMASK_BODY:
-         case skyui.defines.Armor.PARTMASK_HANDS:
-         case skyui.defines.Armor.PARTMASK_FOREARMS:
-         case skyui.defines.Armor.PARTMASK_FEET:
-         case skyui.defines.Armor.PARTMASK_CALVES:
-         case skyui.defines.Armor.PARTMASK_SHIELD:
-         case skyui.defines.Armor.PARTMASK_TAIL:
-         case skyui.defines.Armor.PARTMASK_CLOAK:
-         case skyui.defines.Armor.PARTMASK_BACKPACK:
-            a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_CLOTHING;
-            a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Clothing");
-            break;
-         case skyui.defines.Armor.PARTMASK_AMULET:
-         case skyui.defines.Armor.PARTMASK_RING:
-         case skyui.defines.Armor.PARTMASK_CIRCLET:
-         case skyui.defines.Armor.PARTMASK_EARS:
-            a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
-            a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
-         default:
-            return;
-      }
-   }
-   function processArmorBaseId(a_entryObject)
-   {
-      switch(a_entryObject.formId >>> 24)
-      {
-         case 0x00:
-            if(a_entryObject.baseId == skyui.defines.Form.FORMID_CLOTHESWEDDINGWREATH)
-            {
-               a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
-               a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
-            }
-            return;
-         case 0x02:
-            if(a_entryObject.formId == skyui.defines.Form.FORMID_DLC1CLOTHESVAMPIRELORDARMOR)
-            {
-               a_entryObject.subType = skyui.defines.Armor.EQUIP_BODY;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Body");
-            }
-            return;
-         default:
-            if(a_entryObject.baseId == skyui.defines.Form.BASEID_CC025ADVDSGSRING)
-            {
-               a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
-               a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
-               a_entryObject.subType = skyui.defines.Armor.EQUIP_RING;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ring");
-            }
-            return;
-      }
-   }
-   function processBookType(a_entryObject)
-   {
-      a_entryObject.subType = skyui.defines.Item.OTHER;
-      a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Book");
-      a_entryObject.isRead = (a_entryObject.flags & skyui.defines.Item.BOOKFLAG_READ) != 0;
-      if(a_entryObject.bookType == skyui.defines.Item.BOOKTYPE_NOTE)
-      {
-         a_entryObject.subType = skyui.defines.Item.BOOK_NOTE;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Note");
-      }
-      if(a_entryObject.keywords == undefined)
-      {
-         return undefined;
-      }
-      if(a_entryObject.keywords.VendorItemRecipe != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.BOOK_RECIPE;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Recipe");
-      }
-      else if(a_entryObject.keywords.VendorItemSpellTome != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.BOOK_SPELLTOME;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Spell Tome");
-      }
-   }
-   function processAmmoType(a_entryObject)
-   {
-      if((a_entryObject.flags & skyui.defines.Weapon.AMMOFLAG_NONBOLT) != 0)
-      {
-         a_entryObject.subType = skyui.defines.Weapon.AMMO_ARROW;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Arrow");
-      }
-      else
-      {
-         a_entryObject.subType = skyui.defines.Weapon.AMMO_BOLT;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Bolt");
-      }
-   }
-   function processAmmoBaseId(a_entryObject)
-   {
-      switch(a_entryObject.formId >>> 24)
-      {
-         case 0x00:
-            switch(a_entryObject.baseId)
-            {
-               case skyui.defines.Form.FORMID_DAEDRICARROW:
-                  a_entryObject.material = skyui.defines.Material.DAEDRIC;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Daedric");
-                  break;
-               case skyui.defines.Form.FORMID_EBONYARROW:
-                  a_entryObject.material = skyui.defines.Material.EBONY;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ebony");
-                  break;
-               case skyui.defines.Form.FORMID_GLASSARROW:
-                  a_entryObject.material = skyui.defines.Material.GLASS;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Glass");
-                  break;
-               case skyui.defines.Form.FORMID_ELVENARROW:
-                  a_entryObject.material = skyui.defines.Material.ELVEN;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
-                  break;
-               case skyui.defines.Form.FORMID_DWARVENARROW:
-               case skyui.defines.Form.FORMID_DWARVENSPHEREARROW:
-               case skyui.defines.Form.FORMID_DWARVENSPHEREBOLT01:
-               case skyui.defines.Form.FORMID_DWARVENSPHEREBOLT02:
-                  a_entryObject.material = skyui.defines.Material.DWARVEN;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
-                  break;
-               case skyui.defines.Form.FORMID_ORCISHARROW:
-                  a_entryObject.material = skyui.defines.Material.ORCISH;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Orcish");
-                  break;
-               case skyui.defines.Form.FORMID_NORDHEROARROW:
-                  a_entryObject.material = skyui.defines.Material.NORDIC;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Nordic");
-                  break;
-               case skyui.defines.Form.FORMID_FALMERARROW:
-                  a_entryObject.material = skyui.defines.Material.FALMER;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
-                  break;
-               case skyui.defines.Form.FORMID_STEELARROW:
-               case skyui.defines.Form.FORMID_MQ101STEELARROW:
-               case skyui.defines.Form.FORMID_DRAUGRARROW:
-               case skyui.defines.Form.FORMID_DUNGEIRMUNDSIGDISARROWSILLUSION:
-                  a_entryObject.material = skyui.defines.Material.STEEL;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
-                  break;
-               case skyui.defines.Form.FORMID_IRONARROW:
-               case skyui.defines.Form.FORMID_CWARROW:
-               case skyui.defines.Form.FORMID_CWARROWSHORT:
-               case skyui.defines.Form.FORMID_TRAPDART:
-               case skyui.defines.Form.FORMID_DUNARCHERPRATICEARROW:
-               case skyui.defines.Form.FORMID_FOLLOWERIRONARROW:
-                  a_entryObject.material = skyui.defines.Material.IRON;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
-            }
-            return;
-         case 0x02:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_DLC1ELVENARROWBLESSED:
-               case skyui.defines.Form.FORMID_DLC1ELVENARROWBLOOD:
-                  a_entryObject.material = skyui.defines.Material.ELVEN;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
-                  break;
-               case skyui.defines.Form.FORMID_TESTDLC1BOLT:
-                  a_entryObject.material = skyui.defines.Material.IRON;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
-            }
-            return;
-         case 0x04:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_DLC2DWARVENBALLISTABOLT:
-                  a_entryObject.material = skyui.defines.Material.DWARVEN;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2RIEKLINGSPEARTHROWN:
-                  a_entryObject.material = skyui.defines.Material.WOOD;
-                  a_entryObject.materialDisplay = skyui.util.Translator.translate("$Wood");
-            }
-            return;
-         default:
-            return;
-      }
-   }
-   function processKeyType(a_entryObject)
-   {
-      a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Key");
-      if(a_entryObject.infoValue <= 0)
-      {
-         a_entryObject.infoValue = null;
-      }
-      if(a_entryObject.infoValue <= 0)
-      {
-         a_entryObject.infoValue = null;
-      }
-   }
-   function processPotionType(a_entryObject)
-   {
-      a_entryObject.subType = skyui.defines.Item.POTION_POTION;
-      a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Potion");
-      if((a_entryObject.flags & skyui.defines.Item.ALCHFLAG_FOOD) != 0)
-      {
-         a_entryObject.subType = skyui.defines.Item.POTION_FOOD;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Food");
-         if(a_entryObject.useSound.formId != undefined && a_entryObject.useSound.formId == skyui.defines.Form.FORMID_ITMPotionUse)
-         {
-            a_entryObject.subType = skyui.defines.Item.POTION_DRINK;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Drink");
-         }
-      }
-      else if((a_entryObject.flags & skyui.defines.Item.ALCHFLAG_POISON) != 0)
-      {
-         a_entryObject.subType = skyui.defines.Item.POTION_POISON;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Poison");
-      }
-      else
-      {
-         switch(a_entryObject.actorValue)
-         {
-            case skyui.defines.Actor.AV_HEALTH:
-               a_entryObject.subType = skyui.defines.Item.POTION_HEALTH;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
-               break;
-            case skyui.defines.Actor.AV_MAGICKA:
-               a_entryObject.subType = skyui.defines.Item.POTION_MAGICKA;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
-               break;
-            case skyui.defines.Actor.AV_STAMINA:
-               a_entryObject.subType = skyui.defines.Item.POTION_STAMINA;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
-               break;
-            case skyui.defines.Actor.AV_HEALRATE:
-               a_entryObject.subType = skyui.defines.Item.POTION_HEALRATE;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
-               break;
-            case skyui.defines.Actor.AV_MAGICKARATE:
-               a_entryObject.subType = skyui.defines.Item.POTION_MAGICKARATE;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
-               break;
-            case skyui.defines.Actor.AV_STAMINARATE:
-               a_entryObject.subType = skyui.defines.Item.POTION_STAMINARATE;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
-               break;
-            case skyui.defines.Actor.AV_HEALRATEMULT:
-               a_entryObject.subType = skyui.defines.Item.POTION_HEALRATEMULT;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
-               break;
-            case skyui.defines.Actor.AV_MAGICKARATEMULT:
-               a_entryObject.subType = skyui.defines.Item.POTION_MAGICKARATEMULT;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
-               break;
-            case skyui.defines.Actor.AV_STAMINARATEMULT:
-               a_entryObject.subType = skyui.defines.Item.POTION_STAMINARATEMULT;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
-               break;
-            case skyui.defines.Actor.AV_FIRERESIST:
-               a_entryObject.subType = skyui.defines.Item.POTION_FIRERESIST;
-               break;
-            case skyui.defines.Actor.AV_ELECTRICRESIST:
-               a_entryObject.subType = skyui.defines.Item.POTION_ELECTRICRESIST;
-               break;
-            case skyui.defines.Actor.AV_FROSTRESIST:
-               a_entryObject.subType = skyui.defines.Item.POTION_FROSTRESIST;
+    public function InventoryDataSetter()
+    {
+        super();
+    }
+    
+    
+  /* PUBLIC FUNCTIONS */
+
+    // @override ItemcardDataExtender
+    public function processEntry(a_entryObject: Object, a_itemInfo: Object)
+    {
+        a_entryObject.baseId = a_entryObject.formId & 0x00FFFFFF;
+        a_entryObject.eslId = a_entryObject.formId & 0xFFF;
+        a_entryObject.type = a_itemInfo.type;
+
+        a_entryObject.isEquipped = (a_entryObject.equipState > 0);
+        a_entryObject.isStolen = (a_itemInfo.stolen == true);
+
+        a_entryObject.infoValue = (a_itemInfo.value > 0) ? (Math.round(a_itemInfo.value * 100) / 100) : null;
+        a_entryObject.infoWeight =(a_itemInfo.weight > 0) ? (Math.round(a_itemInfo.weight * 100) / 100) : null;
+        
+        a_entryObject.infoValueWeight = (a_itemInfo.weight > 0 && a_itemInfo.value > 0) ? Math.round(a_itemInfo.value / a_itemInfo.weight) : null;
+
+        switch (a_entryObject.formType) {
+            case skyui.defines.Form.TYPE_SCROLLITEM:
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Scroll");
+                
+                a_entryObject.duration = (a_entryObject.duration > 0) ? (Math.round(a_entryObject.duration * 100) / 100) : null;
+                a_entryObject.magnitude = (a_entryObject.magnitude > 0) ? (Math.round(a_entryObject.magnitude * 100) / 100) : null;
+                this.processScrollBaseId(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_ARMOR:
+                a_entryObject.isEnchanted = (a_itemInfo.effects != "");
+                a_entryObject.infoArmor = (a_itemInfo.armor > 0) ? (Math.round(a_itemInfo.armor * 100) / 100) : null;
+                
+                this.processArmorClass(a_entryObject);
+                this.processArmorPartMask(a_entryObject);
+                this.processMaterialKeywords(a_entryObject);
+                this.processArmorOther(a_entryObject);
+                this.processArmorBaseId(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_BOOK:
+                this.processBookType(a_entryObject);
+                this.processBookBaseId(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_INGREDIENT:
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingredient");
+                break;
+
+            case skyui.defines.Form.TYPE_LIGHT:
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Torch");
+                break;
+
+            case skyui.defines.Form.TYPE_MISC:
+                this.processMiscType(a_entryObject);
+                this.processMiscBaseId(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_WEAPON:
+                a_entryObject.isEnchanted = (a_itemInfo.effects != "");
+                a_entryObject.isPoisoned = (a_itemInfo.poisoned == true); 
+                a_entryObject.infoDamage = (a_itemInfo.damage > 0) ? (Math.round(a_itemInfo.damage * 100) / 100) : null;
+                
+                this.processWeaponType(a_entryObject);
+                this.processMaterialKeywords(a_entryObject);
+                this.processWeaponBaseId(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_AMMO:
+                a_entryObject.isEnchanted = (a_itemInfo.effects != "");
+                a_entryObject.infoDamage = (a_itemInfo.damage > 0) ? (Math.round(a_itemInfo.damage * 100) / 100) : null;
+                
+                this.processAmmoType(a_entryObject);
+                this.processMaterialKeywords(a_entryObject);
+                this.processAmmoBaseId(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_KEY:
+                this.processKeyType(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_POTION:
+                a_entryObject.duration = (a_entryObject.duration > 0) ? (Math.round(a_entryObject.duration * 100) / 100) : null;
+                a_entryObject.magnitude = (a_entryObject.magnitude > 0) ? (Math.round(a_entryObject.magnitude * 100) / 100) : null;
+            
+                this.processPotionType(a_entryObject);
+                this.processPotionBaseId(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_SOULGEM:
+                this.processSoulGemType(a_entryObject);
+                this.processSoulGemStatus(a_entryObject);
+                this.processSoulGemBaseId(a_entryObject);
+                break;
+        }
+    }
+
+
+  /* PRIVATE FUNCTIONS */
+
+    private function processArmorClass(a_entryObject: Object)
+    {
+        if (a_entryObject.weightClass == skyui.defines.Armor.WEIGHT_NONE)
+            a_entryObject.weightClass = null;
+            
+        a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Other");
+
+        switch (a_entryObject.weightClass) {
+            case skyui.defines.Armor.WEIGHT_LIGHT:
+                a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Light");
+                break;
+
+            case skyui.defines.Armor.WEIGHT_HEAVY:
+                a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Heavy");
+                break;
+
             default:
-               return;
-         }
-      }
-   }
-   function processSoulGemType(a_entryObject)
-   {
-      a_entryObject.subType = skyui.defines.Item.OTHER;
-      a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Soul Gem");
-      if(a_entryObject.gemSize != undefined && a_entryObject.gemSize != skyui.defines.Item.SOULGEM_NONE)
-      {
-         a_entryObject.subType = a_entryObject.gemSize;
-      }
-   }
-   function processSoulGemStatus(a_entryObject)
-   {
-      if(a_entryObject.gemSize == undefined || a_entryObject.soulSize == undefined || a_entryObject.soulSize == skyui.defines.Item.SOULGEM_NONE)
-      {
-         a_entryObject.status = skyui.defines.Item.SOULGEMSTATUS_EMPTY;
-      }
-      else if(a_entryObject.soulSize >= a_entryObject.gemSize)
-      {
-         a_entryObject.status = skyui.defines.Item.SOULGEMSTATUS_FULL;
-      }
-      else
-      {
-         a_entryObject.status = skyui.defines.Item.SOULGEMSTATUS_PARTIAL;
-      }
-   }
-   function processSoulGemBaseId(a_entryObject)
-   {
-      switch(a_entryObject.baseId)
-      {
-         case skyui.defines.Form.FORMID_DA01SOULGEMBLACKSTAR:
-         case skyui.defines.Form.FORMID_DA01SOULGEMAZURASSTAR:
-            a_entryObject.subType = skyui.defines.Item.SOULGEM_AZURA;
+                if (a_entryObject.keywords == undefined)
+                    break;
+
+                if (a_entryObject.keywords["VendorItemClothing"] != undefined) {
+                    a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_CLOTHING;
+                    a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Clothing");
+                } else if (a_entryObject.keywords["VendorItemJewelry"] != undefined) {
+                    a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
+                    a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
+                }
+                break;
+        }
+    }
+
+    private function processMaterialKeywords(a_entryObject: Object)
+    {
+        a_entryObject.material = null;
+        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Other");
+
+        if (a_entryObject.keywords == undefined)
             return;
-         case skyui.defines.Form.BASEID_CC025SOULTOMATO1:
-         case skyui.defines.Form.BASEID_CC025SOULTOMATO2:
-            a_entryObject.subType = skyui.defines.Item.SOULGEM_SOULTOMATO;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$SoulTomato");
+
+        if (a_entryObject.keywords["ArmorMaterialDaedric"] != undefined || a_entryObject.keywords["WeapMaterialDaedric"] != undefined  || a_entryObject.keywords["DLC1WeapMaterialDragonbone"] != undefined || a_entryObject.keywords["ccBGSSSE025_ArmorMaterialDark"] != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialDark"] != undefined || a_entryObject.keywords["ccBGSSSE025_ArmorMaterialGolden"] != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialGolden"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.DAEDRIC;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Daedric");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialDragonplate"] != undefined  || a_entryObject.keywords["ArmorMaterialDragonscale"] != undefined || a_entryObject.keywords["DLC1WeapMaterialDragonbone"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.DRAGON;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dragon");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialDwarven"] != undefined || a_entryObject.keywords["WeapMaterialDwarven"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.DWARVEN;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialEbony"] != undefined ||
+                a_entryObject.keywords["WeapMaterialEbony"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.EBONY;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ebony");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialElven"] != undefined || a_entryObject.keywords["WeapMaterialElven"] != undefined || a_entryObject.keywords["ArmorMaterialElvenGilded"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.ELVEN;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialGlass"] != undefined ||
+                a_entryObject.keywords["WeapMaterialGlass"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.GLASS;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Glass");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialHide"] != undefined  || a_entryObject.keywords["ArmorMaterialScaled"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.HIDE;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Hide");
+        
+        } else if(a_entryObject.keywords["ArmorMaterialStormcloak"] != undefined || a_entryObject.keywords["ArmorMaterialBearStormcloak"] != undefined)
+        {
+            a_entryObject.material = skyui.defines.Material.STORMCLOAK;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Stormcloak");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialImperialHeavy"] != undefined || a_entryObject.keywords["ArmorMaterialImperialLight"] != undefined || a_entryObject.keywords["WeapMaterialImperial"] != undefined || a_entryObject.keywords["ArmorMaterialImperialStudded"] != undefined || a_entryObject.keywords["ArmorMaterialStudded"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.IMPERIAL;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Imperial");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialIron"] != undefined || a_entryObject.keywords["WeapMaterialIron"] != undefined || a_entryObject.keywords["ArmorMaterialIronBanded"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.IRON;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialLeather"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.LEATHER;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Leather");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialOrcish"] != undefined || a_entryObject.keywords["WeapMaterialOrcish"] != undefined || a_entryObject.keywords["ccBGSSSE055_ArmorMaterialOrcishLight"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.ORCISH;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Orcish");
+        
+        } else if (a_entryObject.keywords["ArmorMaterialSteel"] != undefined || a_entryObject.keywords["WeapMaterialSteel"] != undefined || a_entryObject.keywords["ArmorMaterialSteelPlate"] != undefined || a_entryObject.keywords["WeapMaterialDraugr"] != undefined || a_entryObject.keywords["WeapMaterialDraugrHoned"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.STEEL;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
+        
+        } else if (a_entryObject.keywords["WeapMaterialSilver"] != undefined || a_entryObject.keywords["WeapMaterialSteel"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.SILVER;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Silver");
+        
+        } else if(a_entryObject.keywords["ArmorMaterialFalmer"] != undefined || a_entryObject.keywords["DLC1ArmorMaterialFalmerHardened"] != undefined || a_entryObject.keywords["DLC1ArmorMaterielFalmerHeavy"] != undefined || a_entryObject.keywords["DLC1ArmorMaterielFalmerHeavyOriginal"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.FALMER;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
+        
+        } else if (a_entryObject.keywords["DLC2ArmorMaterialBonemoldHeavy"] != undefined || a_entryObject.keywords["DLC2ArmorMaterialBonemoldLight"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.BONEMOLD;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Bonemold");
+
+        } else if (a_entryObject.keywords["DLC2ArmorMaterialChitinHeavy"] != undefined || a_entryObject.keywords["DLC2ArmorMaterialChitinLight"] != undefined || a_entryObject.keywords["DLC2ArmorMaterialMoragTong"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.CHITIN;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Chitin");
+        
+        } else if (a_entryObject.keywords["DLC2ArmorMaterialNordicHeavy"] != undefined || a_entryObject.keywords["DLC2ArmorMaterialNordicLight"] != undefined || a_entryObject.keywords["DLC2WeaponMaterialNordic"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.NORDIC;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Nordic");
+        
+        } else if (a_entryObject.keywords["DLC2ArmorMaterialStalhrimHeavy"] != undefined || a_entryObject.keywords["DLC2ArmorMaterialStalhrimLight"] != undefined || a_entryObject.keywords["DLC2WeaponMaterialStalhrim"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.STALHRIM;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Stalhrim");
+        
+        } else if (a_entryObject.keywords["WeapMaterialFalmer"] != undefined || a_entryObject.keywords["WeapMaterialFalmerHoned"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.FALMER;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
+        
+        } else if(a_entryObject.keywords.ccASVSSE001_ArmorOrdinator != undefined || a_entryObject.keywords["ccASVSSE001_ArmorOrdinatorIndoril"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.ORDINATOR;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ordinator");
+        
+        } else if(a_entryObject.keywords.ccBGSSSE025_ArmorMaterialAmber != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialAmber"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.AMBER;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Amber");
+        
+        } else if(a_entryObject.keywords.ccBGSSSE025_ArmorMaterialMadness != undefined || a_entryObject.keywords["ccBGSSSE025_WeapMaterialMadness"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.MADNESS;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Madness");
+        
+        } else if (a_entryObject.keywords["WeapMaterialWood"] != undefined) {
+            a_entryObject.material = skyui.defines.Material.WOOD;
+            a_entryObject.materialDisplay = skyui.util.Translator.translate("$Wood");
+        }
+    }
+
+    private function processWeaponType(a_entryObject: Object)
+    {
+        a_entryObject.subType = null;
+        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Weapon");
+
+        switch (a_entryObject.weaponType) {
+            case skyui.defines.Weapon.ANIM_HANDTOHANDMELEE:
+            case skyui.defines.Weapon.ANIM_H2H:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_MELEE;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Melee");
+                break;
+
+            case skyui.defines.Weapon.ANIM_ONEHANDSWORD:
+            case skyui.defines.Weapon.ANIM_1HS:
+                if (a_entryObject.keywords != undefined && a_entryObject.keywords["ccBGSSSE001_FishingPoleKW"] != undefined)
+                {
+                    a_entryObject.subType = skyui.defines.Weapon.TYPE_FISHINGROD;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$FishingRod");
+                    return;
+                }
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_SWORD;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Sword");
+                break;
+
+            case skyui.defines.Weapon.ANIM_ONEHANDDAGGER:
+            case skyui.defines.Weapon.ANIM_1HD:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_DAGGER;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Dagger");
+                break;
+
+            case skyui.defines.Weapon.ANIM_ONEHANDAXE:
+            case skyui.defines.Weapon.ANIM_1HA:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_WARAXE;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$War Axe");
+                break;
+
+            case skyui.defines.Weapon.ANIM_ONEHANDMACE:
+            case skyui.defines.Weapon.ANIM_1HM:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_MACE;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Mace");
+                break;
+
+            case skyui.defines.Weapon.ANIM_TWOHANDSWORD:
+            case skyui.defines.Weapon.ANIM_2HS:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_GREATSWORD;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Greatsword");
+                break;
+
+            case skyui.defines.Weapon.ANIM_TWOHANDAXE:
+            case skyui.defines.Weapon.ANIM_2HA:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_BATTLEAXE;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Battleaxe");
+
+                if (a_entryObject.keywords != undefined && a_entryObject.keywords["WeapTypeWarhammer"] != undefined) {
+                    a_entryObject.subType = skyui.defines.Weapon.TYPE_WARHAMMER;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Warhammer");
+                }
+                break;
+
+            case skyui.defines.Weapon.ANIM_BOW:
+            case skyui.defines.Weapon.ANIM_BOW2:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_BOW;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Bow");
+                break;
+
+            case skyui.defines.Weapon.ANIM_STAFF:
+            case skyui.defines.Weapon.ANIM_STAFF2:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_STAFF;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Staff");
+                break;
+
+            case skyui.defines.Weapon.ANIM_CROSSBOW:
+            case skyui.defines.Weapon.ANIM_CBOW:
+                a_entryObject.subType = skyui.defines.Weapon.TYPE_CROSSBOW;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Crossbow");
+                break;
+        }
+    }
+
+    private function processWeaponBaseId(a_entryObject: Object)
+    {
+        switch(a_entryObject.formId >>> 24) {
+            case 0x00:
+                switch (a_entryObject.baseId) {
+                    case skyui.defines.Form.FORMID_WEAPPICKAXE:
+                    case skyui.defines.Form.FORMID_SSDROCKSPLINTERPICKAXE:
+                    case skyui.defines.Form.FORMID_DUNVOLUNRUUDPICKAXE:
+                        a_entryObject.subType = skyui.defines.Weapon.TYPE_PICKAXE;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Pickaxe");
+                        break;
+                    case skyui.defines.Form.FORMID_AXE01:
+                    case skyui.defines.Form.FORMID_DUNHALTEDSTREAMPOACHERSAXE:
+                        a_entryObject.subType = skyui.defines.Weapon.TYPE_WOODAXE;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Wood Axe");
+                        break;
+                    case skyui.defines.Form.FORMID_LONGBOW:
+                    case skyui.defines.Form.FORMID_HUNTINGBOW:
+                    case skyui.defines.Form.FORMID_DRAVINSBOW:
+                        a_entryObject.material = skyui.defines.Material.WOOD;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Wood");
+                        break;
+                    case skyui.defines.Form.FORMID_FORSWORNAXE:
+                    case skyui.defines.Form.FORMID_FORSWORNBOW:
+                    case skyui.defines.Form.FORMID_FORSWORNSTAFF:
+                    case skyui.defines.Form.FORMID_FORSWORNSWORD:
+                        break;
+                }
+                break;
+
+            case 0x04:
+                switch (a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_DLC2PICKAXE1:
+                    case skyui.defines.Form.FORMID_DLC2PICKAXE2:
+                    case skyui.defines.Form.FORMID_DLC2PICKAXE3:
+                        a_entryObject.subType = skyui.defines.Weapon.TYPE_PICKAXE;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Pickaxe");
+                        a_entryObject.material = skyui.defines.Material.STEEL;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
+                        break;
+                }
+                break;
+        }
+    }
+
+    private function processArmorPartMask(a_entryObject: Object)
+    {
+        if (a_entryObject.partMask == undefined)
             return;
-         default:
-            return;
-      }
-   }
-   function processMiscType(a_entryObject)
-   {
-      a_entryObject.subType = skyui.defines.Item.OTHER;
-      a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Misc");
-      if(a_entryObject.keywords == undefined)
-      {
-         return undefined;
-      }
-      if(a_entryObject.keywords.BYOHAdoptionClothesKeyword != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_CHILDRENSCLOTHES;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Clothing");
-      }
-      else if(a_entryObject.keywords.BYOHAdoptionToyKeyword != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_TOY;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Toy");
-      }
-      else if(a_entryObject.keywords.BYOHHouseCraftingCategoryWeaponRacks != undefined || a_entryObject.keywords.BYOHHouseCraftingCategoryShelf != undefined || a_entryObject.keywords.BYOHHouseCraftingCategoryFurniture != undefined || a_entryObject.keywords.BYOHHouseCraftingCategoryExterior != undefined || a_entryObject.keywords.BYOHHouseCraftingCategoryContainers != undefined || a_entryObject.keywords.BYOHHouseCraftingCategoryBuilding != undefined || a_entryObject.keywords.BYOHHouseCraftingCategorySmithing != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_HOUSEPART;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$House Part");
-      }
-      else if(a_entryObject.keywords.VendorItemDaedricArtifact != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_ARTIFACT;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Artifact");
-      }
-      else if(a_entryObject.keywords.VendorItemGem != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_GEM;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
-      }
-      else if(a_entryObject.keywords.VendorItemAnimalHide != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_HIDE;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Hide");
-      }
-      else if(a_entryObject.keywords.VendorItemTool != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_TOOL;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Tool");
-      }
-      else if(a_entryObject.keywords.VendorItemAnimalPart != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
-      }
-      else if(a_entryObject.keywords.VendorItemOreIngot != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_INGOT;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingot");
-      }
-      else if(a_entryObject.keywords.VendorItemFireword != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_FIREWOOD;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Firewood");
-      }
-      else if(a_entryObject.keywords.VendorItemClutter != undefined)
-      {
-         a_entryObject.subType = skyui.defines.Item.MISC_CLUTTER;
-         a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Clutter");
-      }
-   }
-   function processMiscBaseId(a_entryObject)
-   {
-      switch(a_entryObject.formId >>> 24)
-      {
-         case 0x00:
-            switch(a_entryObject.baseId)
-            {
-               case skyui.defines.Form.FORMID_GEMAMETHYSTFLAWLESS:
-               case skyui.defines.Form.FORMID_GEM1:
-               case skyui.defines.Form.FORMID_GEM2:
-               case skyui.defines.Form.FORMID_GEM3:
-               case skyui.defines.Form.FORMID_GEM4:
-                  a_entryObject.subType = skyui.defines.Item.MISC_GEM;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
-                  break;
-               case skyui.defines.Form.FORMID_RUBYDRAGONCLAW:
-               case skyui.defines.Form.FORMID_IVORYDRAGONCLAW:
-               case skyui.defines.Form.FORMID_GLASSCLAW:
-               case skyui.defines.Form.FORMID_EBONYCLAW:
-               case skyui.defines.Form.FORMID_EMERALDDRAGONCLAW:
-               case skyui.defines.Form.FORMID_DIAMONDCLAW:
-               case skyui.defines.Form.FORMID_IRONCLAW:
-               case skyui.defines.Form.FORMID_CORALDRAGONCLAW:
-               case skyui.defines.Form.FORMID_E3GOLDENCLAW:
-               case skyui.defines.Form.FORMID_SAPPHIREDRAGONCLAW:
-               case skyui.defines.Form.FORMID_MS13GOLDENCLAW:
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Claw");
-                  a_entryObject.subType = skyui.defines.Item.MISC_DRAGONCLAW;
-                  break;
-               case skyui.defines.Form.FORMID_REMAINS1:
-               case skyui.defines.Form.FORMID_REMAINS2:
-               case skyui.defines.Form.FORMID_REMAINS3:
-               case skyui.defines.Form.FORMID_REMAINS4:
-               case skyui.defines.Form.FORMID_REMAINS5:
-                  a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
-                  break;
-               case skyui.defines.Form.FORMID_LOCKPICK:
-                  a_entryObject.subType = skyui.defines.Item.MISC_LOCKPICK;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Lockpick");
-                  break;
-               case skyui.defines.Form.FORMID_GOLD001:
-                  a_entryObject.subType = skyui.defines.Item.MISC_GOLD;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gold");
-                  break;
-               case skyui.defines.Form.FORMID_LEATHER01:
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Leather");
-                  a_entryObject.subType = skyui.defines.Item.MISC_LEATHER;
-                  break;
-               case skyui.defines.Form.FORMID_LEATHERSTRIPS:
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Strips");
-                  a_entryObject.subType = skyui.defines.Item.MISC_LEATHERSTRIPS;
-                  break;
-               case skyui.defines.Form.FORMID_CHITIN1:
-                  a_entryObject.subType = skyui.defines.Item.MISC_NETCHLEATHER;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$NetchLeather");
-                  break;
-               case skyui.defines.Form.FORMID_BROKENWEAPON1:
-               case skyui.defines.Form.FORMID_BROKENWEAPON2:
-               case skyui.defines.Form.FORMID_BROKENWEAPON3:
-               case skyui.defines.Form.FORMID_BROKENWEAPON4:
-               case skyui.defines.Form.FORMID_BROKENWEAPON5:
-               case skyui.defines.Form.FORMID_BROKENWEAPON6:
-               case skyui.defines.Form.FORMID_BROKENWEAPON7:
-               case skyui.defines.Form.FORMID_BROKENWEAPON8:
-               case skyui.defines.Form.FORMID_BROKENWEAPON9:
-               case skyui.defines.Form.FORMID_BROKENWEAPON10:
-               case skyui.defines.Form.FORMID_BROKENWEAPON11:
-               case skyui.defines.Form.FORMID_BROKENWEAPON12:
-               case skyui.defines.Form.FORMID_BROKENWEAPON13:
-               case skyui.defines.Form.FORMID_BROKENWEAPON14:
-               case skyui.defines.Form.FORMID_BROKENWEAPON15:
-               case skyui.defines.Form.FORMID_BROKENWEAPON16:
-               case skyui.defines.Form.FORMID_BROKENWEAPON17:
-               case skyui.defines.Form.FORMID_BROKENWEAPON18:
-               case skyui.defines.Form.FORMID_BROKENWEAPON19:
-               case skyui.defines.Form.FORMID_BROKENWEAPON20:
-               case skyui.defines.Form.FORMID_BROKENWEAPON21:
-               case skyui.defines.Form.FORMID_BROKENWEAPON22:
-               case skyui.defines.Form.FORMID_BROKENWEAPON23:
-               case skyui.defines.Form.FORMID_BROKENWEAPON24:
-               case skyui.defines.Form.FORMID_BROKENWEAPON25:
-               case skyui.defines.Form.FORMID_BROKENWEAPON26:
-               case skyui.defines.Form.FORMID_BROKENWEAPON27:
-               case skyui.defines.Form.FORMID_BROKENWEAPON28:
-               case skyui.defines.Form.FORMID_BROKENWEAPON29:
-               case skyui.defines.Form.FORMID_BROKENWEAPON30:
-               case skyui.defines.Form.FORMID_BROKENWEAPON31:
-                  a_entryObject.subType = skyui.defines.Item.MISC_BROKENWEAPON;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BrokenWeapon");
-                  break;
-               case skyui.defines.Form.FORMID_DWARVENSCRAP1:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP2:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP3:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP4:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP5:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP6:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP7:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP8:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP9:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP10:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP11:
-               case skyui.defines.Form.FORMID_DWARVENSCRAP12:
-                  a_entryObject.subType = skyui.defines.Item.MISC_DWARVENSCRAP;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$DwarvenScrap");
-                  break;
-               case skyui.defines.Form.FORMID_INSTRUMENT1:
-               case skyui.defines.Form.FORMID_INSTRUMENT2:
-               case skyui.defines.Form.FORMID_INSTRUMENT3:
-               case skyui.defines.Form.FORMID_INSTRUMENT4:
-               case skyui.defines.Form.FORMID_INSTRUMENT5:
-               case skyui.defines.Form.FORMID_INSTRUMENT6:
-               case skyui.defines.Form.FORMID_INSTRUMENT7:
-               case skyui.defines.Form.FORMID_INSTRUMENT8:
-               case skyui.defines.Form.FORMID_INSTRUMENT9:
-                  a_entryObject.subType = skyui.defines.Item.MISC_INSTRUMENT;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Instrument");
-                  break;
-               case skyui.defines.Form.FORMID_BUGJAR1:
-               case skyui.defines.Form.FORMID_BUGJAR2:
-               case skyui.defines.Form.FORMID_BUGJAR3:
-               case skyui.defines.Form.FORMID_BUGJAR4:
-               case skyui.defines.Form.FORMID_BUGJAR5:
-                  a_entryObject.subType = skyui.defines.Item.MISC_BUGJAR;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BugJar");
-                  break;
-               case skyui.defines.Form.FORMID_MISCMAP1:
-               case skyui.defines.Form.FORMID_MISCMAP2:
-                  a_entryObject.subType = skyui.defines.Item.MISC_MAP;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
-                  break;
-               case skyui.defines.Form.FORMID_MISCAZURASSTAR:
-                  a_entryObject.subType = skyui.defines.Item.MISC_ARTIFACT;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Artifact");
-                  break;
-               case skyui.defines.Form.FORMID_MISCARTIFACT1:
-               case skyui.defines.Form.FORMID_MISCARTIFACT2:
-                  a_entryObject.subType = skyui.defines.Item.MISC_ARTIFACT;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Artifact");
-                  a_entryObject.iconLabel = "default_potion";
-                  break;
-               case skyui.defines.Form.FORMID_MISCPOTION:
-                  a_entryObject.subType = skyui.defines.Item.MISC_POTION;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Potion");
-                  break;
-               case skyui.defines.Form.FORMID_MISCPOISON:
-                  a_entryObject.subType = skyui.defines.Item.MISC_POISON;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Poison");
-                  break;
-               case skyui.defines.Form.FORMID_MISCSCROLL1:
-               case skyui.defines.Form.FORMID_MISCSCROLL2:
-               case skyui.defines.Form.FORMID_MISCSCROLL3:
-                  a_entryObject.subType = skyui.defines.Item.MISC_SCROLL;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Scroll");
-                  break;
-               case skyui.defines.Form.FORMID_MISCBOOK1:
-               case skyui.defines.Form.FORMID_MISCBOOK2:
-               case skyui.defines.Form.FORMID_MISCBOOK3:
-               case skyui.defines.Form.FORMID_MISCBOOK4:
-                  a_entryObject.subType = skyui.defines.Item.MISC_BOOK;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Book");
-                  break;
-               case skyui.defines.Form.FORMID_MISCRING1:
-               case skyui.defines.Form.FORMID_MISCRING2:
-               case skyui.defines.Form.FORMID_MISCRING3:
-               case skyui.defines.Form.FORMID_MISCRING4:
-               case skyui.defines.Form.FORMID_MISCRING5:
-                  a_entryObject.subType = skyui.defines.Item.MISC_RING;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ring");
-                  break;
-               case skyui.defines.Form.FORMID_ORE1:
-               case skyui.defines.Form.FORMID_ORE2:
-               case skyui.defines.Form.FORMID_ORE3:
-               case skyui.defines.Form.FORMID_ORE4:
-               case skyui.defines.Form.FORMID_ORE5:
-               case skyui.defines.Form.FORMID_ORE6:
-               case skyui.defines.Form.FORMID_ORE7:
-               case skyui.defines.Form.FORMID_ORE8:
-               case skyui.defines.Form.FORMID_ORE9:
-               case skyui.defines.Form.FORMID_ORE10:
-                  a_entryObject.subType = skyui.defines.Item.MISC_ORE;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
+
+        // Sets subType as the most important bitmask index.
+        for (var i = 0; i < skyui.defines.Armor.PARTMASK_PRECEDENCE.length; i++) {
+            if (a_entryObject.partMask & skyui.defines.Armor.PARTMASK_PRECEDENCE[i]) {
+                a_entryObject.mainPartMask = skyui.defines.Armor.PARTMASK_PRECEDENCE[i];
+                break;
             }
+        }
+
+        if (a_entryObject.mainPartMask == undefined)
             return;
-         case 0x01:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_UPDATEHORSETACK1:
-               case skyui.defines.Form.FORMID_UPDATEHORSETACK2:
-                  a_entryObject.subType = skyui.defines.Item.MISC_HORSETACK;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$HorseTack");
+
+        switch (a_entryObject.mainPartMask) {
+            case skyui.defines.Armor.PARTMASK_HEAD:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_HEAD;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Head");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_HAIR:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_HAIR;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Head");
+                break;
+                
+            case skyui.defines.Armor.PARTMASK_LONGHAIR:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_LONGHAIR;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Head");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_BODY:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_BODY;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Body");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_HANDS:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_HANDS;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Hands");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_FOREARMS:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_FOREARMS;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Forearms");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_AMULET:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_AMULET;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Amulet");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_RING:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_RING;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ring");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_FEET:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_FEET;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Feet");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_CALVES:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_CALVES;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Calves");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_SHIELD:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_SHIELD;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Shield");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_CIRCLET:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_CIRCLET;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Circlet");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_EARS:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_EARS;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ears");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_TAIL:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_TAIL;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Tail");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_CLOAK:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_CLOAK;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ClothingCloak");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_BACKPACK:
+                a_entryObject.subType = skyui.defines.Armor.EQUIP_BACKPACK;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Backpack");
+                break;
+
+            default:
+                a_entryObject.subType = a_entryObject.mainPartMask;
+                break;
+        }
+    }
+
+    private function processArmorOther(a_entryObject)
+    {
+        if (a_entryObject.weightClass != null)
+            return;
+
+        switch (a_entryObject.mainPartMask) {
+            case skyui.defines.Armor.PARTMASK_HEAD:
+            case skyui.defines.Armor.PARTMASK_HAIR:
+            case skyui.defines.Armor.PARTMASK_LONGHAIR:
+            case skyui.defines.Armor.PARTMASK_BODY:
+            case skyui.defines.Armor.PARTMASK_HANDS:
+            case skyui.defines.Armor.PARTMASK_FOREARMS:
+            case skyui.defines.Armor.PARTMASK_FEET:
+            case skyui.defines.Armor.PARTMASK_CALVES:
+            case skyui.defines.Armor.PARTMASK_SHIELD:
+            case skyui.defines.Armor.PARTMASK_TAIL:
+            case skyui.defines.Armor.PARTMASK_CLOAK:
+            case skyui.defines.Armor.PARTMASK_BACKPACK:
+                a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_CLOTHING;
+                a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Clothing");
+                break;
+
+            case skyui.defines.Armor.PARTMASK_AMULET:
+            case skyui.defines.Armor.PARTMASK_RING:
+            case skyui.defines.Armor.PARTMASK_CIRCLET:
+            case skyui.defines.Armor.PARTMASK_EARS:
+                a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
+                a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
+                break;
+        }
+    }
+
+    private function processArmorBaseId(a_entryObject)
+    {
+        switch(a_entryObject.formId >>> 24) {
+            case 0x00:
+                if (a_entryObject.baseId == skyui.defines.Form.FORMID_CLOTHESWEDDINGWREATH) {
+                    a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
+                    a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
+                }
+                break;
+
+            case 0x02:
+                if (a_entryObject.formId == skyui.defines.Form.FORMID_DLC1CLOTHESVAMPIRELORDARMOR) {
+                    a_entryObject.subType = skyui.defines.Armor.EQUIP_BODY;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Body");
+                }
+                break;
+
+            default:
+                if (a_entryObject.baseId == skyui.defines.Form.BASEID_CC025ADVDSGSRING) {
+                    a_entryObject.weightClass = skyui.defines.Armor.WEIGHT_JEWELRY;
+                    a_entryObject.weightClassDisplay = skyui.util.Translator.translate("$Jewelry");
+                    a_entryObject.subType = skyui.defines.Armor.EQUIP_RING;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ring");
+                }
+                break;
+        }
+    }
+
+    private function processBookType(a_entryObject: Object)
+    {
+        a_entryObject.subType = skyui.defines.Item.OTHER;
+        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Book");
+
+        a_entryObject.isRead = ((a_entryObject.flags & skyui.defines.Item.BOOKFLAG_READ) != 0);
+        
+        if (a_entryObject.bookType == skyui.defines.Item.BOOKTYPE_NOTE) {
+            a_entryObject.subType = skyui.defines.Item.BOOK_NOTE;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Note");
+        }
+
+        if (a_entryObject.keywords == undefined)
+            return;
+
+        if (a_entryObject.keywords["VendorItemRecipe"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.BOOK_RECIPE;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Recipe");
+        } else if (a_entryObject.keywords["VendorItemSpellTome"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.BOOK_SPELLTOME;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Spell Tome");
+        }
+    }
+
+    private function processAmmoType(a_entryObject: Object)
+    {
+        if ((a_entryObject.flags & skyui.defines.Weapon.AMMOFLAG_NONBOLT) != 0) {
+            a_entryObject.subType = skyui.defines.Weapon.AMMO_ARROW;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Arrow");
+        } else {
+            a_entryObject.subType = skyui.defines.Weapon.AMMO_BOLT;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Bolt");
+        }
+    }
+
+    private function processAmmoBaseId(a_entryObject: Object)
+    {
+        switch(a_entryObject.formId >>> 24) {
+            case 0x00:
+                switch (a_entryObject.baseId) {
+                    case skyui.defines.Form.FORMID_DAEDRICARROW:
+                        a_entryObject.material = skyui.defines.Material.DAEDRIC;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Daedric");
+                        break;
+                    case skyui.defines.Form.FORMID_EBONYARROW:
+                        a_entryObject.material = skyui.defines.Material.EBONY;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Ebony");
+                        break;
+                    case skyui.defines.Form.FORMID_GLASSARROW:
+                        a_entryObject.material = skyui.defines.Material.GLASS;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Glass");
+                        break;
+                    case skyui.defines.Form.FORMID_ELVENARROW:
+                        a_entryObject.material = skyui.defines.Material.ELVEN;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
+                        break;
+                    case skyui.defines.Form.FORMID_DWARVENARROW:
+                    case skyui.defines.Form.FORMID_DWARVENSPHEREARROW:
+                    case skyui.defines.Form.FORMID_DWARVENSPHEREBOLT01:
+                    case skyui.defines.Form.FORMID_DWARVENSPHEREBOLT02:
+                        a_entryObject.material = skyui.defines.Material.DWARVEN;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
+                        break;
+                    case skyui.defines.Form.FORMID_ORCISHARROW:
+                        a_entryObject.material = skyui.defines.Material.ORCISH;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Orcish");
+                        break;
+                    case skyui.defines.Form.FORMID_NORDHEROARROW:
+                        a_entryObject.material = skyui.defines.Material.NORDIC;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Nordic");
+                        break;
+                    case skyui.defines.Form.FORMID_FALMERARROW:
+                        a_entryObject.material = skyui.defines.Material.FALMER;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Falmer");
+                        break;
+                    case skyui.defines.Form.FORMID_STEELARROW:
+                    case skyui.defines.Form.FORMID_MQ101STEELARROW:
+                    case skyui.defines.Form.FORMID_DRAUGRARROW:
+                    case skyui.defines.Form.FORMID_DUNGEIRMUNDSIGDISARROWSILLUSION:
+                        a_entryObject.material = skyui.defines.Material.STEEL;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Steel");
+                        break;
+                    case skyui.defines.Form.FORMID_IRONARROW:
+                    case skyui.defines.Form.FORMID_CWARROW:
+                    case skyui.defines.Form.FORMID_CWARROWSHORT:
+                    case skyui.defines.Form.FORMID_TRAPDART:
+                    case skyui.defines.Form.FORMID_DUNARCHERPRATICEARROW:
+                    case skyui.defines.Form.FORMID_FOLLOWERIRONARROW:
+                        a_entryObject.material = skyui.defines.Material.IRON;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
+                        break;
+                }
+                break;
+
+            case 0x02:
+                switch(a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_DLC1ELVENARROWBLESSED:
+                    case skyui.defines.Form.FORMID_DLC1ELVENARROWBLOOD:
+                        a_entryObject.material = skyui.defines.Material.ELVEN;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Elven");
+                        break;
+                    case skyui.defines.Form.FORMID_TESTDLC1BOLT:
+                        a_entryObject.material = skyui.defines.Material.IRON;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Iron");
+
+                }
+                break;
+
+            case 0x04:
+                switch(a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_DLC2DWARVENBALLISTABOLT:
+                        a_entryObject.material = skyui.defines.Material.DWARVEN;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Dwarven");
+                        break;
+                    case skyui.defines.Form.FORMID_DLC2RIEKLINGSPEARTHROWN:
+                        a_entryObject.material = skyui.defines.Material.WOOD;
+                        a_entryObject.materialDisplay = skyui.util.Translator.translate("$Wood");
+                        break;
+                }
+        }
+    }
+
+    private function processKeyType(a_entryObject: Object)
+    {
+        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Key");
+
+        if (a_entryObject.infoValue <= 0)
+            a_entryObject.infoValue = null;
+
+        if (a_entryObject.infoValue <= 0)
+            a_entryObject.infoValue = null;
+    }
+
+    private function processPotionType(a_entryObject: Object)
+    {
+        a_entryObject.subType = skyui.defines.Item.POTION_POTION;
+        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Potion");
+
+        if ((a_entryObject.flags & skyui.defines.Item.ALCHFLAG_FOOD) != 0) {
+            a_entryObject.subType = skyui.defines.Item.POTION_FOOD;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Food");
+
+            // SKSE >= 1.6.6
+            if (a_entryObject.useSound.formId != undefined && a_entryObject.useSound.formId == skyui.defines.Form.FORMID_ITMPotionUse) {
+                a_entryObject.subType = skyui.defines.Item.POTION_DRINK;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Drink");
             }
-            return;
-         case 0x02:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_DLC1GEM1:
-               case skyui.defines.Form.FORMID_DLC1GEM2:
-               case skyui.defines.Form.FORMID_DLC1GEM3:
-               case skyui.defines.Form.FORMID_DLC1GEM4:
-               case skyui.defines.Form.FORMID_DLC1GEM5:
-                  a_entryObject.subType = skyui.defines.Item.MISC_GEM;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
-                  break;
-               case skyui.defines.Form.FORMID_DLC1REMAINS1:
-               case skyui.defines.Form.FORMID_DLC1REMAINS2:
-               case skyui.defines.Form.FORMID_DLC1REMAINS3:
-               case skyui.defines.Form.FORMID_DLC1REMAINS4:
-               case skyui.defines.Form.FORMID_DLC1REMAINS5:
-               case skyui.defines.Form.FORMID_DLC1REMAINS6:
-               case skyui.defines.Form.FORMID_DLC1REMAINS7:
-                  a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
-                  break;
-               case skyui.defines.Form.FORMID_DLC1CHITIN1:
-                  a_entryObject.subType = skyui.defines.Item.MISC_NETCHLEATHER;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$NetchLeather");
+            
+        } else if ((a_entryObject.flags & skyui.defines.Item.ALCHFLAG_POISON) != 0) {
+            a_entryObject.subType = skyui.defines.Item.POTION_POISON;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Poison");
+        } else {
+            switch (a_entryObject.actorValue) {
+                case skyui.defines.Actor.AV_HEALTH:
+                    a_entryObject.subType = skyui.defines.Item.POTION_HEALTH;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
+                    break;
+                case skyui.defines.Actor.AV_MAGICKA:
+                    a_entryObject.subType = skyui.defines.Item.POTION_MAGICKA;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
+                    break;
+                case skyui.defines.Actor.AV_STAMINA:
+                    a_entryObject.subType = skyui.defines.Item.POTION_STAMINA;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
+                    break;
+
+                case skyui.defines.Actor.AV_HEALRATE:
+                    a_entryObject.subType = skyui.defines.Item.POTION_HEALRATE;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
+                    break;
+                case skyui.defines.Actor.AV_MAGICKARATE:
+                    a_entryObject.subType = skyui.defines.Item.POTION_MAGICKARATE;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
+                    break;
+                case skyui.defines.Actor.AV_STAMINARATE:
+                    a_entryObject.subType = skyui.defines.Item.POTION_STAMINARATE;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
+                    break;
+
+                case skyui.defines.Actor.AV_HEALRATEMULT:
+                    a_entryObject.subType = skyui.defines.Item.POTION_HEALRATEMULT;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Health");
+                    break;
+                case skyui.defines.Actor.AV_MAGICKARATEMULT:
+                    a_entryObject.subType = skyui.defines.Item.POTION_MAGICKARATEMULT;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Magicka");
+                    break;
+                case skyui.defines.Actor.AV_STAMINARATEMULT:
+                    a_entryObject.subType = skyui.defines.Item.POTION_STAMINARATEMULT;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Stamina");
+                    break;
+
+                case skyui.defines.Actor.AV_FIRERESIST:
+                    a_entryObject.subType = skyui.defines.Item.POTION_FIRERESIST;
+                    break;
+
+                case skyui.defines.Actor.AV_ELECTRICRESIST:
+                    a_entryObject.subType = skyui.defines.Item.POTION_ELECTRICRESIST;
+                    break;
+
+                case skyui.defines.Actor.AV_FROSTRESIST:
+                    a_entryObject.subType = skyui.defines.Item.POTION_FROSTRESIST;
+                    break;
             }
+        }
+    }
+
+    private function processSoulGemType(a_entryObject: Object)
+    {
+        a_entryObject.subType = skyui.defines.Item.OTHER;
+        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Soul Gem");
+
+        // Ignores soulgems that have a size of None
+        if (a_entryObject.gemSize != undefined && a_entryObject.gemSize != skyui.defines.Item.SOULGEM_NONE)
+            a_entryObject.subType = a_entryObject.gemSize;
+    }
+
+    private function processSoulGemStatus(a_entryObject: Object)
+    {
+        if (a_entryObject.gemSize == undefined || a_entryObject.soulSize == undefined || a_entryObject.soulSize == skyui.defines.Item.SOULGEM_NONE)
+            a_entryObject.status = skyui.defines.Item.SOULGEMSTATUS_EMPTY;
+        else if (a_entryObject.soulSize >= a_entryObject.gemSize)
+            a_entryObject.status = skyui.defines.Item.SOULGEMSTATUS_FULL;
+        else
+            a_entryObject.status = skyui.defines.Item.SOULGEMSTATUS_PARTIAL;
+    }
+
+    private function processSoulGemBaseId(a_entryObject: Object)
+    {
+        switch (a_entryObject.baseId) {
+            case skyui.defines.Form.FORMID_DA01SOULGEMBLACKSTAR:
+            case skyui.defines.Form.FORMID_DA01SOULGEMAZURASSTAR:
+                a_entryObject.subType = skyui.defines.Item.SOULGEM_AZURA;
+                break;
+
+            case skyui.defines.Form.BASEID_CC025SOULTOMATO1:
+            case skyui.defines.Form.BASEID_CC025SOULTOMATO2:
+                a_entryObject.subType = skyui.defines.Item.SOULGEM_SOULTOMATO;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$SoulTomato");
+                break;
+        }
+    }
+
+    private function processMiscType(a_entryObject: Object)
+    {
+        a_entryObject.subType = skyui.defines.Item.OTHER;
+        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Misc");
+
+        if (a_entryObject.keywords == undefined)
             return;
-         case 0x03:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_HFHOUSEPART1:
-               case skyui.defines.Form.FORMID_HFHOUSEPART2:
-               case skyui.defines.Form.FORMID_HFHOUSEPART3:
-               case skyui.defines.Form.FORMID_HFHOUSEPART4:
-               case skyui.defines.Form.FORMID_HFHOUSEPART5:
-               case skyui.defines.Form.FORMID_HFHOUSEPART6:
-               case skyui.defines.Form.FORMID_HFHOUSEPART7:
-               case skyui.defines.Form.FORMID_HFHOUSEPART8:
-               case skyui.defines.Form.FORMID_HFHOUSEPART9:
-               case skyui.defines.Form.FORMID_HFHOUSEPART10:
-                  a_entryObject.subType = skyui.defines.Item.MISC_HOUSEPART;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BuildingMaterial");
-            }
+
+        if (a_entryObject.keywords["BYOHAdoptionClothesKeyword"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_CHILDRENSCLOTHES;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Clothing");
+
+        } else if (a_entryObject.keywords["BYOHAdoptionToyKeyword"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_TOY;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Toy");
+
+        
+        } else if (a_entryObject.keywords["BYOHHouseCraftingCategoryWeaponRacks"] != undefined || a_entryObject.keywords["BYOHHouseCraftingCategoryShelf"] != undefined ||  a_entryObject.keywords["BYOHHouseCraftingCategoryFurniture"] != undefined || a_entryObject.keywords["BYOHHouseCraftingCategoryExterior"] != undefined ||  a_entryObject.keywords["BYOHHouseCraftingCategoryContainers"] != undefined || a_entryObject.keywords["BYOHHouseCraftingCategoryBuilding"] != undefined ||  a_entryObject.keywords["BYOHHouseCraftingCategorySmithing"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_HOUSEPART;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$House Part");
+        
+
+        } else if (a_entryObject.keywords["VendorItemDaedricArtifact"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_ARTIFACT;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Artifact");
+
+        } else if (a_entryObject.keywords["VendorItemGem"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_GEM;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
+
+        } else if (a_entryObject.keywords["VendorItemAnimalHide"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_HIDE;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Hide");
+
+        } else if (a_entryObject.keywords["VendorItemTool"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_TOOL;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Tool");
+
+        } else if (a_entryObject.keywords["VendorItemAnimalPart"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
+
+        } else if (a_entryObject.keywords["VendorItemOreIngot"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_INGOT;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingot");
+
+        } else if (a_entryObject.keywords["VendorItemFirewood"] != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_FIREWOOD;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Firewood");
+
+        } else if(a_entryObject.keywords.VendorItemClutter != undefined) {
+            a_entryObject.subType = skyui.defines.Item.MISC_CLUTTER;
+            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Clutter");
+        }
+    }
+
+    private function processMiscBaseId(a_entryObject: Object)
+    {
+        switch(a_entryObject.formId >>> 24) {
+            case 0x00:
+                switch (a_entryObject.baseId) {
+                    case skyui.defines.Form.FORMID_GEMAMETHYSTFLAWLESS:
+                    case skyui.defines.Form.FORMID_GEM1:
+                    case skyui.defines.Form.FORMID_GEM2:
+                    case skyui.defines.Form.FORMID_GEM3:
+                    case skyui.defines.Form.FORMID_GEM4:
+                        a_entryObject.subType = skyui.defines.Item.MISC_GEM;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
+                        break;
+
+                    case skyui.defines.Form.FORMID_RUBYDRAGONCLAW:
+                    case skyui.defines.Form.FORMID_IVORYDRAGONCLAW:
+                    case skyui.defines.Form.FORMID_GLASSCLAW:
+                    case skyui.defines.Form.FORMID_EBONYCLAW:
+                    case skyui.defines.Form.FORMID_EMERALDDRAGONCLAW:
+                    case skyui.defines.Form.FORMID_DIAMONDCLAW:
+                    case skyui.defines.Form.FORMID_IRONCLAW:
+                    case skyui.defines.Form.FORMID_CORALDRAGONCLAW:
+                    case skyui.defines.Form.FORMID_E3GOLDENCLAW:
+                    case skyui.defines.Form.FORMID_SAPPHIREDRAGONCLAW:
+                    case skyui.defines.Form.FORMID_MS13GOLDENCLAW:
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Claw");
+                        a_entryObject.subType = skyui.defines.Item.MISC_DRAGONCLAW;
+                        break;
+
+                    case skyui.defines.Form.FORMID_REMAINS1:
+                    case skyui.defines.Form.FORMID_REMAINS2:
+                    case skyui.defines.Form.FORMID_REMAINS3:
+                    case skyui.defines.Form.FORMID_REMAINS4:
+                    case skyui.defines.Form.FORMID_REMAINS5:
+                        a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
+                        break;
+
+                    case skyui.defines.Form.FORMID_LOCKPICK:
+                        a_entryObject.subType = skyui.defines.Item.MISC_LOCKPICK;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Lockpick");
+                        break;
+
+                    case skyui.defines.Form.FORMID_GOLD001:
+                        a_entryObject.subType = skyui.defines.Item.MISC_GOLD;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gold");
+                        break;
+
+                    case skyui.defines.Form.FORMID_LEATHER01:
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Leather");
+                        a_entryObject.subType = skyui.defines.Item.MISC_LEATHER;
+                        break;
+
+                    case skyui.defines.Form.FORMID_LEATHERSTRIPS:
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Strips");
+                        a_entryObject.subType = skyui.defines.Item.MISC_LEATHERSTRIPS;
+                        break;
+
+                    case skyui.defines.Form.FORMID_CHITIN1:
+                        a_entryObject.subType = skyui.defines.Item.MISC_NETCHLEATHER;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$NetchLeather");
+                        break;
+
+                    case skyui.defines.Form.FORMID_BROKENWEAPON1:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON2:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON3:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON4:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON5:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON6:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON7:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON8:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON9:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON10:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON11:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON12:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON13:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON14:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON15:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON16:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON17:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON18:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON19:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON20:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON21:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON22:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON23:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON24:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON25:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON26:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON27:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON28:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON29:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON30:
+                    case skyui.defines.Form.FORMID_BROKENWEAPON31:
+                        a_entryObject.subType = skyui.defines.Item.MISC_BROKENWEAPON;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BrokenWeapon");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP1:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP2:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP3:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP4:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP5:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP6:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP7:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP8:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP9:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP10:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP11:
+                    case skyui.defines.Form.FORMID_DWARVENSCRAP12:
+                        a_entryObject.subType = skyui.defines.Item.MISC_DWARVENSCRAP;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$DwarvenScrap");
+                        break;
+
+                    case skyui.defines.Form.FORMID_INSTRUMENT1:
+                    case skyui.defines.Form.FORMID_INSTRUMENT2:
+                    case skyui.defines.Form.FORMID_INSTRUMENT3:
+                    case skyui.defines.Form.FORMID_INSTRUMENT4:
+                    case skyui.defines.Form.FORMID_INSTRUMENT5:
+                    case skyui.defines.Form.FORMID_INSTRUMENT6:
+                    case skyui.defines.Form.FORMID_INSTRUMENT7:
+                    case skyui.defines.Form.FORMID_INSTRUMENT8:
+                    case skyui.defines.Form.FORMID_INSTRUMENT9:
+                        a_entryObject.subType = skyui.defines.Item.MISC_INSTRUMENT;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Instrument");
+                        break;
+
+                    case skyui.defines.Form.FORMID_BUGJAR1:
+                    case skyui.defines.Form.FORMID_BUGJAR2:
+                    case skyui.defines.Form.FORMID_BUGJAR3:
+                    case skyui.defines.Form.FORMID_BUGJAR4:
+                    case skyui.defines.Form.FORMID_BUGJAR5:
+                        a_entryObject.subType = skyui.defines.Item.MISC_BUGJAR;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BugJar");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCMAP1:
+                    case skyui.defines.Form.FORMID_MISCMAP2:
+                        a_entryObject.subType = skyui.defines.Item.MISC_MAP;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCAZURASSTAR:
+                        a_entryObject.subType = skyui.defines.Item.MISC_ARTIFACT;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Artifact");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCARTIFACT1:
+                    case skyui.defines.Form.FORMID_MISCARTIFACT2:
+                        a_entryObject.subType = skyui.defines.Item.MISC_ARTIFACT;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Artifact");
+                        a_entryObject.iconLabel = "default_potion";
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCPOTION:
+                        a_entryObject.subType = skyui.defines.Item.MISC_POTION;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Potion");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCPOISON:
+                        a_entryObject.subType = skyui.defines.Item.MISC_POISON;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Poison");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCSCROLL1:
+                    case skyui.defines.Form.FORMID_MISCSCROLL2:
+                    case skyui.defines.Form.FORMID_MISCSCROLL3:
+                        a_entryObject.subType = skyui.defines.Item.MISC_SCROLL;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Scroll");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCBOOK1:
+                    case skyui.defines.Form.FORMID_MISCBOOK2:
+                    case skyui.defines.Form.FORMID_MISCBOOK3:
+                    case skyui.defines.Form.FORMID_MISCBOOK4:
+                        a_entryObject.subType = skyui.defines.Item.MISC_BOOK;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Book");
+                        break;
+
+                    case skyui.defines.Form.FORMID_MISCRING1:
+                    case skyui.defines.Form.FORMID_MISCRING2:
+                    case skyui.defines.Form.FORMID_MISCRING3:
+                    case skyui.defines.Form.FORMID_MISCRING4:
+                    case skyui.defines.Form.FORMID_MISCRING5:
+                        a_entryObject.subType = skyui.defines.Item.MISC_RING;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ring");
+                        break;
+
+                    case skyui.defines.Form.FORMID_ORE1:
+                    case skyui.defines.Form.FORMID_ORE2:
+                    case skyui.defines.Form.FORMID_ORE3:
+                    case skyui.defines.Form.FORMID_ORE4:
+                    case skyui.defines.Form.FORMID_ORE5:
+                    case skyui.defines.Form.FORMID_ORE6:
+                    case skyui.defines.Form.FORMID_ORE7:
+                    case skyui.defines.Form.FORMID_ORE8:
+                    case skyui.defines.Form.FORMID_ORE9:
+                    case skyui.defines.Form.FORMID_ORE10:
+                        a_entryObject.subType = skyui.defines.Item.MISC_ORE;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
+                        break
+                }
+                break;
+
+            case 0x01:
+                switch (a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_UPDATEHORSETACK1:
+                    case skyui.defines.Form.FORMID_UPDATEHORSETACK2:
+                        a_entryObject.subType = skyui.defines.Item.MISC_HORSETACK;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$HorseTack");
+                        break;
+                }
+                break;
+
+            case 0x02:
+                switch (a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_DLC1GEM1:
+                    case skyui.defines.Form.FORMID_DLC1GEM2:
+                    case skyui.defines.Form.FORMID_DLC1GEM3:
+                    case skyui.defines.Form.FORMID_DLC1GEM4:
+                    case skyui.defines.Form.FORMID_DLC1GEM5:
+                        a_entryObject.subType = skyui.defines.Item.MISC_GEM;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC1REMAINS1:
+                    case skyui.defines.Form.FORMID_DLC1REMAINS2:
+                    case skyui.defines.Form.FORMID_DLC1REMAINS3:
+                    case skyui.defines.Form.FORMID_DLC1REMAINS4:
+                    case skyui.defines.Form.FORMID_DLC1REMAINS5:
+                    case skyui.defines.Form.FORMID_DLC1REMAINS6:
+                    case skyui.defines.Form.FORMID_DLC1REMAINS7:
+                        a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC1CHITIN1:
+                        a_entryObject.subType = skyui.defines.Item.MISC_NETCHLEATHER;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$NetchLeather");
+                        break
+                }
+                break;
+
+            case 0x03:
+                switch (a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_HFHOUSEPART1:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART2:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART3:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART4:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART5:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART6:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART7:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART8:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART9:
+                    case skyui.defines.Form.FORMID_HFHOUSEPART10:
+                        a_entryObject.subType = skyui.defines.Item.MISC_HOUSEPART;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BuildingMaterial");
+                        break;
+                }
+                break;
+
+            case 0x04:
+                switch (a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_DLC2DRAGONCLAW1:
+                    case skyui.defines.Form.FORMID_DLC2DRAGONCLAW2:
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Claw");
+                        a_entryObject.subType = skyui.defines.Item.MISC_DRAGONCLAW;
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2GEM1:
+                    case skyui.defines.Form.FORMID_DLC2GEM2:
+                    case skyui.defines.Form.FORMID_DLC2GEM3:
+                    case skyui.defines.Form.FORMID_DLC2GEM4:
+                    case skyui.defines.Form.FORMID_DLC2GEM5:
+                        a_entryObject.subType = skyui.defines.Item.MISC_GEM;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2CHITIN1:
+                    case skyui.defines.Form.FORMID_DLC2NETCHLEATHER:
+                        a_entryObject.subType = skyui.defines.Item.MISC_NETCHLEATHER;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$NetchLeather");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2TROLLSKULL:
+                        a_entryObject.subType = skyui.defines.Item.MISC_TROLLSKULL;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2SCROLLSPIDERMISC1:
+                    case skyui.defines.Form.FORMID_DLC2SCROLLSPIDERMISC2:
+                        a_entryObject.subType = skyui.defines.Item.MISC_SCROLLSPIDER;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ScrollSpider");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2MISCMAP:
+                        a_entryObject.subType = skyui.defines.Item.MISC_MAP;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2INGREDIENT:
+                        a_entryObject.subType = skyui.defines.Item.MISC_INGREDIENT;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingredient");
+                        break;
+
+                    case skyui.defines.Form.FORMID_DLC2ORE1:
+                    case skyui.defines.Form.FORMID_DLC2ORE2:
+                    case skyui.defines.Form.FORMID_DLC2ORE3:
+                        a_entryObject.subType = skyui.defines.Item.MISC_ORE;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
+                        break;
+                }
+                break;
+
+            case 0xFE:
+                switch (a_entryObject.eslId) {
+                    case skyui.defines.Form.ESLID_CC019STAFFREMAINS:
+                    case skyui.defines.Form.ESLID_CC036PETWOLFREMAINS:
+                        a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
+                        break;
+
+                    case skyui.defines.Form.ESLID_CCKRTALTARGOLD:
+                        a_entryObject.subType = skyui.defines.Item.MISC_GOLD;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gold");
+                        break;
+
+                    case skyui.defines.Form.ESLID_CCVSV002PETGEAR:
+                    case skyui.defines.Form.ESLID_CCVSV002PETAMULET:
+                        a_entryObject.subType = skyui.defines.Item.MISC_PETGEAR;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$PetGear");
+                        break;
+                }
+                break;
+
+            default:
+                switch (a_entryObject.baseId)
+                {
+                    case skyui.defines.Form.BASEID_CCALMSIVIGEM1:
+                    case skyui.defines.Form.BASEID_CCALMSIVIGEM2:
+                    case skyui.defines.Form.BASEID_CCALMSIVIGEM3:
+                    case skyui.defines.Form.BASEID_CCALMSIVIGEM4:
+                        a_entryObject.subType = skyui.defines.Item.MISC_GEM;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL1:
+                    case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL2:
+                    case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL3:
+                    case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL4:
+                    case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL5:
+                    case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL6:
+                        a_entryObject.subType = skyui.defines.Item.MISC_AYLEIDCRYSTAL;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$AyleidCrystal");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CC001DWESCRAP:
+                        a_entryObject.subType = skyui.defines.Item.MISC_DWARVENSCRAP;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$DwarvenScrap");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CC025BUGJAR1:
+                    case skyui.defines.Form.BASEID_CC025BUGJAR2:
+                    case skyui.defines.Form.BASEID_CC025BUGJAR3:
+                        a_entryObject.subType = skyui.defines.Item.MISC_BUGJAR;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BugJar");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CC031MISCMAP:
+                        a_entryObject.subType = skyui.defines.Item.MISC_MAP;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CCALMSIVIPOTION:
+                        a_entryObject.subType = skyui.defines.Item.MISC_POTION;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Potion");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT1:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT2:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT3:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT4:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT5:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT6:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT7:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT8:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT9:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT10:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT11:
+                    case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT12:
+                        a_entryObject.subType = skyui.defines.Item.MISC_INGREDIENT;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingredient");
+                        break;
+
+                    case skyui.defines.Form.BASEID_CC025ORE1:
+                    case skyui.defines.Form.BASEID_CC025ORE2:
+                        a_entryObject.subType = skyui.defines.Item.MISC_ORE;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
+                        break;
+                }
+                break;
+        }
+    }
+    function processBookBaseId(a_entryObject)
+    {
+        switch (a_entryObject.formId >>> 24) {
+            case 0x00:
+                switch (a_entryObject.baseId) {
+                    case skyui.defines.Form.FORMID_BOOKMAP1:
+                    case skyui.defines.Form.FORMID_BOOKMAP2:
+                    case skyui.defines.Form.FORMID_BOOKMAP3:
+                    case skyui.defines.Form.FORMID_BOOKMAP4:
+                    case skyui.defines.Form.FORMID_BOOKMAP5:
+                    case skyui.defines.Form.FORMID_BOOKMAP6:
+                    case skyui.defines.Form.FORMID_BOOKMAP7:
+                    case skyui.defines.Form.FORMID_BOOKMAP8:
+                    case skyui.defines.Form.FORMID_BOOKMAP9:
+                    case skyui.defines.Form.FORMID_BOOKMAP10:
+                    case skyui.defines.Form.FORMID_BOOKMAP11:
+                    case skyui.defines.Form.FORMID_BOOKMAP12:
+                        a_entryObject.subType = skyui.defines.Item.BOOK_MAP;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
+                        break;
+
+                    case skyui.defines.Form.FORMID_ELDERSCROLL1:
+                    case skyui.defines.Form.FORMID_ELDERSCROLL2:
+                        a_entryObject.subType = skyui.defines.Item.BOOK_ELDERSCROLL;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ElderScroll");
+                        break;
+                }
+                break;
+                
+            case 0x02:
+                switch (a_entryObject.formId) {
+                    case skyui.defines.Form.FORMID_DLC1ELDERSCROLL1:
+                    case skyui.defines.Form.FORMID_DLC1ELDERSCROLL2:
+                    case skyui.defines.Form.FORMID_DLC1ELDERSCROLL3:
+                        a_entryObject.subType = skyui.defines.Item.BOOK_ELDERSCROLL;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ElderScroll");
+                        break;
+                }
+                break;
+
+            case 0x04:
+                if (a_entryObject.formId == skyui.defines.Form.FORMID_DLC2BOOKMAP) {
+                    a_entryObject.subType = skyui.defines.Item.BOOK_MAP;
+                    a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
+                }
+                break;
+
+            default:
+                switch (a_entryObject.baseId) {
+                    case skyui.defines.Form.BASEID_CC001FISHBOOKMAP1:
+                    case skyui.defines.Form.BASEID_CC001FISHBOOKMAP2:
+                    case skyui.defines.Form.BASEID_CC001FISHBOOKMAP3:
+                    case skyui.defines.Form.BASEID_CC001FISHBOOKMAP4:
+                    case skyui.defines.Form.BASEID_CC001FISHBOOKMAP5:
+                    case skyui.defines.Form.BASEID_CC001FISHBOOKMAP6:
+                    case skyui.defines.Form.BASEID_CC001FISHBOOKMAP7:
+                    case skyui.defines.Form.BASEID_CC001FISHBOOKMAP8:
+                    case skyui.defines.Form.BASEID_CC001FISHBOOKMAP9:
+                    case skyui.defines.Form.BASEID_CC001FISHBOOKMAP10:
+                    case skyui.defines.Form.BASEID_CC001FISHBOOKMAP11:
+                    case skyui.defines.Form.BASEID_CC001FISHBOOKMAP12:
+                        a_entryObject.subType = skyui.defines.Item.BOOK_MAP;
+                        a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
+                        break;
+                }
+                break;
+        }
+    }
+    function processScrollBaseId(a_entryObject)
+    {
+        if (a_entryObject.formId >>> 24 != 0x04)
             return;
-         case 0x04:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_DLC2DRAGONCLAW1:
-               case skyui.defines.Form.FORMID_DLC2DRAGONCLAW2:
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Claw");
-                  a_entryObject.subType = skyui.defines.Item.MISC_DRAGONCLAW;
-                  break;
-               case skyui.defines.Form.FORMID_DLC2GEM1:
-               case skyui.defines.Form.FORMID_DLC2GEM2:
-               case skyui.defines.Form.FORMID_DLC2GEM3:
-               case skyui.defines.Form.FORMID_DLC2GEM4:
-               case skyui.defines.Form.FORMID_DLC2GEM5:
-                  a_entryObject.subType = skyui.defines.Item.MISC_GEM;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2CHITIN1:
-               case skyui.defines.Form.FORMID_DLC2NETCHLEATHER:
-                  a_entryObject.subType = skyui.defines.Item.MISC_NETCHLEATHER;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$NetchLeather");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2TROLLSKULL:
-                  a_entryObject.subType = skyui.defines.Item.MISC_TROLLSKULL;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2SCROLLSPIDERMISC1:
-               case skyui.defines.Form.FORMID_DLC2SCROLLSPIDERMISC2:
-                  a_entryObject.subType = skyui.defines.Item.MISC_SCROLLSPIDER;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ScrollSpider");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2MISCMAP:
-                  a_entryObject.subType = skyui.defines.Item.MISC_MAP;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2INGREDIENT:
-                  a_entryObject.subType = skyui.defines.Item.MISC_INGREDIENT;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingredient");
-                  break;
-               case skyui.defines.Form.FORMID_DLC2ORE1:
-               case skyui.defines.Form.FORMID_DLC2ORE2:
-               case skyui.defines.Form.FORMID_DLC2ORE3:
-                  a_entryObject.subType = skyui.defines.Item.MISC_ORE;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
-            }
-            return;
-         case 0xFE:
-            switch(a_entryObject.eslId)
-            {
-               case skyui.defines.Form.ESLID_CC019STAFFREMAINS:
-               case skyui.defines.Form.ESLID_CC036PETWOLFREMAINS:
-                  a_entryObject.subType = skyui.defines.Item.MISC_REMAINS;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Remains");
-                  break;
-               case skyui.defines.Form.ESLID_CCKRTALTARGOLD:
-                  a_entryObject.subType = skyui.defines.Item.MISC_GOLD;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gold");
-                  break;
-               case skyui.defines.Form.ESLID_CCVSV002PETGEAR:
-               case skyui.defines.Form.ESLID_CCVSV002PETAMULET:
-                  a_entryObject.subType = skyui.defines.Item.MISC_PETGEAR;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$PetGear");
-            }
-            return;
-         default:
-            switch(a_entryObject.baseId)
-            {
-               case skyui.defines.Form.BASEID_CCALMSIVIGEM1:
-               case skyui.defines.Form.BASEID_CCALMSIVIGEM2:
-               case skyui.defines.Form.BASEID_CCALMSIVIGEM3:
-               case skyui.defines.Form.BASEID_CCALMSIVIGEM4:
-                  a_entryObject.subType = skyui.defines.Item.MISC_GEM;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Gem");
-                  break;
-               case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL1:
-               case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL2:
-               case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL3:
-               case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL4:
-               case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL5:
-               case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTAL6:
-                  a_entryObject.subType = skyui.defines.Item.MISC_AYLEIDCRYSTAL;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$AyleidCrystal");
-                  break;
-               case skyui.defines.Form.BASEID_CC001DWESCRAP:
-                  a_entryObject.subType = skyui.defines.Item.MISC_DWARVENSCRAP;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$DwarvenScrap");
-                  break;
-               case skyui.defines.Form.BASEID_CC025BUGJAR1:
-               case skyui.defines.Form.BASEID_CC025BUGJAR2:
-               case skyui.defines.Form.BASEID_CC025BUGJAR3:
-                  a_entryObject.subType = skyui.defines.Item.MISC_BUGJAR;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$BugJar");
-                  break;
-               case skyui.defines.Form.BASEID_CC031MISCMAP:
-                  a_entryObject.subType = skyui.defines.Item.MISC_MAP;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
-                  break;
-               case skyui.defines.Form.BASEID_CCALMSIVIPOTION:
-                  a_entryObject.subType = skyui.defines.Item.MISC_POTION;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Potion");
-                  break;
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT1:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT2:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT3:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT4:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT5:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT6:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT7:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT8:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT9:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT10:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT11:
-               case skyui.defines.Form.BASEID_CC001PUZZLEINGREDIENT12:
-                  a_entryObject.subType = skyui.defines.Item.MISC_INGREDIENT;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ingredient");
-                  break;
-               case skyui.defines.Form.BASEID_CC025ORE1:
-               case skyui.defines.Form.BASEID_CC025ORE2:
-                  a_entryObject.subType = skyui.defines.Item.MISC_ORE;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Ore");
-            }
-            return;
-      }
-   }
-   function processBookBaseId(a_entryObject)
-   {
-      switch(a_entryObject.formId >>> 24)
-      {
-         case 0x00:
-            switch(a_entryObject.baseId)
-            {
-               case skyui.defines.Form.FORMID_BOOKMAP1:
-               case skyui.defines.Form.FORMID_BOOKMAP2:
-               case skyui.defines.Form.FORMID_BOOKMAP3:
-               case skyui.defines.Form.FORMID_BOOKMAP4:
-               case skyui.defines.Form.FORMID_BOOKMAP5:
-               case skyui.defines.Form.FORMID_BOOKMAP6:
-               case skyui.defines.Form.FORMID_BOOKMAP7:
-               case skyui.defines.Form.FORMID_BOOKMAP8:
-               case skyui.defines.Form.FORMID_BOOKMAP9:
-               case skyui.defines.Form.FORMID_BOOKMAP10:
-               case skyui.defines.Form.FORMID_BOOKMAP11:
-               case skyui.defines.Form.FORMID_BOOKMAP12:
-                  a_entryObject.subType = skyui.defines.Item.BOOK_MAP;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
-                  break;
-               case skyui.defines.Form.FORMID_ELDERSCROLL1:
-               case skyui.defines.Form.FORMID_ELDERSCROLL2:
-                  a_entryObject.subType = skyui.defines.Item.BOOK_ELDERSCROLL;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ElderScroll");
-            }
-            return;
-         case 0x02:
-            switch(a_entryObject.formId)
-            {
-               case skyui.defines.Form.FORMID_DLC1ELDERSCROLL1:
-               case skyui.defines.Form.FORMID_DLC1ELDERSCROLL2:
-               case skyui.defines.Form.FORMID_DLC1ELDERSCROLL3:
-                  a_entryObject.subType = skyui.defines.Item.BOOK_ELDERSCROLL;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ElderScroll");
-            }
-            return;
-         case 0x04:
-            if(a_entryObject.formId == skyui.defines.Form.FORMID_DLC2BOOKMAP)
-            {
-               a_entryObject.subType = skyui.defines.Item.BOOK_MAP;
-               a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
-            }
-            return;
-         default:
-            switch(a_entryObject.baseId)
-            {
-               case skyui.defines.Form.BASEID_CC001FISHBOOKMAP1:
-               case skyui.defines.Form.BASEID_CC001FISHBOOKMAP2:
-               case skyui.defines.Form.BASEID_CC001FISHBOOKMAP3:
-               case skyui.defines.Form.BASEID_CC001FISHBOOKMAP4:
-               case skyui.defines.Form.BASEID_CC001FISHBOOKMAP5:
-               case skyui.defines.Form.BASEID_CC001FISHBOOKMAP6:
-               case skyui.defines.Form.BASEID_CC001FISHBOOKMAP7:
-               case skyui.defines.Form.BASEID_CC001FISHBOOKMAP8:
-               case skyui.defines.Form.BASEID_CC001FISHBOOKMAP9:
-               case skyui.defines.Form.BASEID_CC001FISHBOOKMAP10:
-               case skyui.defines.Form.BASEID_CC001FISHBOOKMAP11:
-               case skyui.defines.Form.BASEID_CC001FISHBOOKMAP12:
-                  a_entryObject.subType = skyui.defines.Item.BOOK_MAP;
-                  a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$Map");
-            }
-            return;
-      }
-   }
-   function processScrollBaseId(a_entryObject)
-   {
-      if(a_entryObject.formId >>> 24 != 0x04)
-      {
-         return;
-      }
-      switch(a_entryObject.formId)
-      {
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER1:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER2:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER3:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER4:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER5:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER6:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER7:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER8:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER9:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER10:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER11:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER12:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER13:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER14:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER15:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER16:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER17:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER18:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER19:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER20:
-         case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER21:
-            a_entryObject.subType = skyui.defines.Item.SCROLL_SPIDER;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ScrollSpider");
-         default:
-            return;
-      }
-   }
-   function processPotionBaseId(a_entryObject)
-   {
-      switch(a_entryObject.baseId)
-      {
-         case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTALPOTION:
-         case skyui.defines.Form.BASEID_HEARTLANDAYLEIDCRYSTALPOTION1:
-         case skyui.defines.Form.BASEID_HEARTLANDAYLEIDCRYSTALPOTION2:
-            a_entryObject.subType = skyui.defines.Item.POTION_AYLEIDCRYSTAL;
-            a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$AyleidCrystal");
-         default:
-            return;
-      }
-   }
+        
+        switch (a_entryObject.formId) {
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER1:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER2:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER3:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER4:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER5:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER6:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER7:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER8:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER9:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER10:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER11:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER12:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER13:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER14:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER15:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER16:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER17:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER18:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER19:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER20:
+            case skyui.defines.Form.FORMID_DLC2SCROLLSPIDER21:
+                a_entryObject.subType = skyui.defines.Item.SCROLL_SPIDER;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$ScrollSpider");
+                break;
+        }
+    }
+    function processPotionBaseId(a_entryObject)
+    {
+        switch (a_entryObject.baseId) {
+            case skyui.defines.Form.BASEID_CC067AYLEIDCRYSTALPOTION:
+            case skyui.defines.Form.BASEID_HEARTLANDAYLEIDCRYSTALPOTION1:
+            case skyui.defines.Form.BASEID_HEARTLANDAYLEIDCRYSTALPOTION2:
+                a_entryObject.subType = skyui.defines.Item.POTION_AYLEIDCRYSTAL;
+                a_entryObject.subTypeDisplay = skyui.util.Translator.translate("$AyleidCrystal");
+                break;
+        }
+    }
 }

--- a/source/actionscript/ItemMenus/InventoryIconSetter.as
+++ b/source/actionscript/ItemMenus/InventoryIconSetter.as
@@ -1,609 +1,729 @@
 class InventoryIconSetter implements skyui.components.list.IListProcessor
 {
-   var _noIconColors;
-   function InventoryIconSetter(a_configAppearance)
-   {
-      this._noIconColors = a_configAppearance.icons.item.noColor;
-   }
-   function processList(a_list)
-   {
-      var _loc3_ = a_list.entryList;
-      var _loc2_ = 0;
-      while(_loc2_ < _loc3_.length)
-      {
-         this.processEntry(_loc3_[_loc2_]);
-         _loc2_ = _loc2_ + 1;
-      }
-   }
-   function processEntry(a_entryObject)
-   {
-      switch(a_entryObject.formType)
-      {
-         case skyui.defines.Form.TYPE_SCROLLITEM:
-            this.processScrollIcon(a_entryObject);
-            this.processResist(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_ARMOR:
-            this.processArmorIcon(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_BOOK:
-            this.processBookIcon(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_INGREDIENT:
-            a_entryObject.iconLabel = "default_ingredient";
-            break;
-         case skyui.defines.Form.TYPE_LIGHT:
-            a_entryObject.iconLabel = "misc_torch";
-            break;
-         case skyui.defines.Form.TYPE_MISC:
-            this.processMiscIcon(a_entryObject);
-            this.processMiscBaseIdIcon(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_WEAPON:
-            this.processWeaponIcon(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_AMMO:
-            this.processAmmoIcon(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_KEY:
-            a_entryObject.iconLabel = "default_key";
-            break;
-         case skyui.defines.Form.TYPE_POTION:
-            this.processPotionIcon(a_entryObject);
-            break;
-         case skyui.defines.Form.TYPE_SOULGEM:
-            this.processSoulGemIcon(a_entryObject);
-      }
-      if(this._noIconColors && a_entryObject.iconColor != undefined)
-      {
-         delete a_entryObject.iconColor;
-      }
-   }
-   function processResist(a_entryObject)
-   {
-      if(a_entryObject.resistance == undefined || a_entryObject.resistance == skyui.defines.Actor.AV_NONE)
-      {
-         return undefined;
-      }
-      switch(a_entryObject.resistance)
-      {
-         case skyui.defines.Actor.AV_FIRERESIST:
-            a_entryObject.iconColor = 13055542;
-            break;
-         case skyui.defines.Actor.AV_ELECTRICRESIST:
-            a_entryObject.iconColor = 16776960;
-            break;
-         case skyui.defines.Actor.AV_FROSTRESIST:
-            a_entryObject.iconColor = 2096127;
-         default:
+  /* PRIVATE VARIABLES */
+
+    private var _noIconColors: Boolean;
+
+
+  /* INITIALIZATION */
+
+    public function InventoryIconSetter(a_configAppearance: Object)
+    {
+        this._noIconColors = a_configAppearance.icons.item.noColor;
+    }
+
+
+  /* PUBLIC FUNCTIONS */
+    
+    // @override IListProcessor
+    public function processList(a_list: BasicList)
+    {
+        var entryList: Array = a_list.entryList;
+        
+        for (var i: Number = 0; i < entryList.length; i++)
+            this.processEntry(entryList[i]);
+    }
+
+
+  /* PRIVATE FUNCTIONS */
+
+    private function processEntry(a_entryObject: Object)
+    {
+        switch (a_entryObject.formType) {
+            case skyui.defines.Form.TYPE_SCROLLITEM:
+                this.processScrollIcon(a_entryObject);
+                this.processResist(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_ARMOR:
+                this.processArmorIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_BOOK:
+                this.processBookIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_INGREDIENT:
+                a_entryObject.iconLabel = "default_ingredient";
+                break;
+
+            case skyui.defines.Form.TYPE_LIGHT:
+                a_entryObject.iconLabel = "misc_torch";
+                break;
+
+            case skyui.defines.Form.TYPE_MISC:
+                this.processMiscIcon(a_entryObject);
+                this.processMiscBaseIdIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_WEAPON:
+                this.processWeaponIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_AMMO:
+                this.processAmmoIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_KEY:
+                a_entryObject.iconLabel = "default_key";
+                break;
+
+            case skyui.defines.Form.TYPE_POTION:
+                this.processPotionIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Form.TYPE_SOULGEM:
+                this.processSoulGemIcon(a_entryObject);
+                break;
+        }
+
+        if (this._noIconColors && a_entryObject.iconColor != undefined)
+            delete(a_entryObject.iconColor);
+    }
+
+    private function processResist(a_entryObject: Object)
+    {
+        if (a_entryObject.resistance == undefined || a_entryObject.resistance == skyui.defines.Actor.AV_NONE)
             return;
-      }
-   }
-   function processArmorIcon(a_entryObject)
-   {
-      a_entryObject.iconLabel = "default_armor";
-      a_entryObject.iconColor = 15587975;
-      if(a_entryObject.subType == skyui.defines.Armor.EQUIP_CLOAK)
-      {
-         a_entryObject.iconLabel = "clothing_cloak";
-         return;
-      }
-      if(a_entryObject.subType == skyui.defines.Armor.EQUIP_BACKPACK)
-      {
-         a_entryObject.iconLabel = "clothing_backpack";
-         return;
-      }
-      switch(a_entryObject.weightClass)
-      {
-         case skyui.defines.Armor.WEIGHT_LIGHT:
-            this.processLightArmorIcon(a_entryObject);
+
+        switch(a_entryObject.resistance) {
+            case skyui.defines.Actor.AV_FIRERESIST:
+                a_entryObject.iconColor = 0xC73636;
+                break;
+
+            case skyui.defines.Actor.AV_ELECTRICRESIST:
+                a_entryObject.iconColor = 0xFFFF00;
+                break;
+
+            case skyui.defines.Actor.AV_FROSTRESIST:
+                a_entryObject.iconColor = 0x1FFBFF;
+                break;
+        }
+    }
+
+    private function processArmorIcon(a_entryObject: Object)
+    {
+        a_entryObject.iconLabel = "default_armor";
+        a_entryObject.iconColor = 0xEDDA87;
+
+        switch(a_entryObject.subType)
+        {
+            case skyui.defines.Armor.EQUIP_CLOAK:
+                a_entryObject.iconLabel = "clothing_cloak";
+                break;
+            case skyui.defines.Armor.EQUIP_BACKPACK:
+                a_entryObject.iconLabel = "clothing_backpack";
+                break;
+        }
+
+        switch(a_entryObject.weightClass) {
+            case skyui.defines.Armor.WEIGHT_LIGHT:
+                this.processLightArmorIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Armor.WEIGHT_HEAVY:
+                this.processHeavyArmorIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Armor.WEIGHT_JEWELRY:
+                this.processJewelryArmorIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Armor.WEIGHT_CLOTHING:
+            default:
+                this.processClothingArmorIcon(a_entryObject);
+                break;
+        }
+    }
+
+    private function processLightArmorIcon(a_entryObject: Object)
+    {
+        a_entryObject.iconColor = 0x756000;
+
+        switch(a_entryObject.subType) {
+            case skyui.defines.Armor.EQUIP_HEAD:
+            case skyui.defines.Armor.EQUIP_HAIR:
+            case skyui.defines.Armor.EQUIP_LONGHAIR:
+                a_entryObject.iconLabel = "lightarmor_head";
+                break;
+
+            case skyui.defines.Armor.EQUIP_BODY:
+            case skyui.defines.Armor.EQUIP_TAIL:
+                a_entryObject.iconLabel = "lightarmor_body";
+                break;
+
+            case skyui.defines.Armor.EQUIP_HANDS:
+                a_entryObject.iconLabel = "lightarmor_hands";
+                break;
+
+            case skyui.defines.Armor.EQUIP_FOREARMS:
+                a_entryObject.iconLabel = "lightarmor_forearms";
+                break;
+
+            case skyui.defines.Armor.EQUIP_FEET:
+                a_entryObject.iconLabel = "lightarmor_feet";
+                break;
+
+            case skyui.defines.Armor.EQUIP_CALVES:
+                a_entryObject.iconLabel = "lightarmor_calves";
+                break;
+
+            case skyui.defines.Armor.EQUIP_SHIELD:
+                a_entryObject.iconLabel = "lightarmor_shield";
+                break;
+
+            case skyui.defines.Armor.EQUIP_AMULET:
+            case skyui.defines.Armor.EQUIP_RING:
+            case skyui.defines.Armor.EQUIP_CIRCLET:
+            case skyui.defines.Armor.EQUIP_EARS:
+                this.processJewelryArmorIcon(a_entryObject);
+                break;
+
+
+        }
+    }
+
+    private function processHeavyArmorIcon(a_entryObject: Object)
+    {
+        a_entryObject.iconColor = 0x6B7585;
+
+        switch(a_entryObject.subType) {
+            case skyui.defines.Armor.EQUIP_HEAD:
+            case skyui.defines.Armor.EQUIP_HAIR:
+            case skyui.defines.Armor.EQUIP_LONGHAIR:
+                a_entryObject.iconLabel = "armor_head";
+                break;
+
+            case skyui.defines.Armor.EQUIP_BODY:
+            case skyui.defines.Armor.EQUIP_TAIL:
+                a_entryObject.iconLabel = "armor_body";
+                break;
+
+            case skyui.defines.Armor.EQUIP_HANDS:
+                a_entryObject.iconLabel = "armor_hands";
+                break;
+
+            case skyui.defines.Armor.EQUIP_FOREARMS:
+                a_entryObject.iconLabel = "armor_forearms";
+                break;
+
+            case skyui.defines.Armor.EQUIP_FEET:
+                a_entryObject.iconLabel = "armor_feet";
+                break;
+
+            case skyui.defines.Armor.EQUIP_CALVES:
+                a_entryObject.iconLabel = "armor_calves";
+                break;
+
+            case skyui.defines.Armor.EQUIP_SHIELD:
+                a_entryObject.iconLabel = "armor_shield";
+                break;
+
+            case skyui.defines.Armor.EQUIP_AMULET:
+            case skyui.defines.Armor.EQUIP_RING:
+            case skyui.defines.Armor.EQUIP_CIRCLET:
+            case skyui.defines.Armor.EQUIP_EARS:
+                this.processJewelryArmorIcon(a_entryObject);
+                break;
+
+        }
+    }
+
+    private function processJewelryArmorIcon(a_entryObject: Object)
+    {
+        switch(a_entryObject.subType) {
+            case skyui.defines.Armor.EQUIP_AMULET:
+                a_entryObject.iconLabel = "armor_amulet";
+                break;
+
+            case skyui.defines.Armor.EQUIP_RING:
+                a_entryObject.iconLabel = "armor_ring";
+                break;
+
+            case skyui.defines.Armor.EQUIP_CIRCLET:
+                a_entryObject.iconLabel = "armor_circlet";
+                break;
+
+            case skyui.defines.Armor.EQUIP_EARS:
+                break;
+        }
+    }
+
+    private function processClothingArmorIcon(a_entryObject: Object)
+    {
+        switch(a_entryObject.subType) {
+            case skyui.defines.Armor.EQUIP_HEAD:
+            case skyui.defines.Armor.EQUIP_HAIR:
+            case skyui.defines.Armor.EQUIP_LONGHAIR:
+                a_entryObject.iconLabel = "clothing_head";
+                break;
+
+            case skyui.defines.Armor.EQUIP_BODY:
+            case skyui.defines.Armor.EQUIP_TAIL:
+                a_entryObject.iconLabel = "clothing_body";
+                break;
+
+            case skyui.defines.Armor.EQUIP_HANDS:
+                a_entryObject.iconLabel = "clothing_hands";
+                break;
+
+            case skyui.defines.Armor.EQUIP_FOREARMS:
+                a_entryObject.iconLabel = "clothing_forearms";
+                break;
+
+            case skyui.defines.Armor.EQUIP_FEET:
+                a_entryObject.iconLabel = "clothing_feet";
+                break;
+
+            case skyui.defines.Armor.EQUIP_CALVES:
+                a_entryObject.iconLabel = "clothing_calves";
+                break;
+
+            case skyui.defines.Armor.EQUIP_SHIELD:
+                a_entryObject.iconLabel = "clothing_shield";
+                break;
+
+            case skyui.defines.Armor.EQUIP_EARS:
+                break;
+
+        }
+    }
+
+    // Scrolls
+    private function processScrollIcon(a_entryObject: Object)
+    {
+        a_entryObject.iconLabel = "default_scroll";
+        switch(a_entryObject.subType)
+        {
+            case skyui.defines.Item.SCROLL_SPIDER:
+                a_entryObject.iconLabel = "scroll_spider";
+                break;
+        }
+    }
+
+    // Books
+    private function processBookIcon(a_entryObject: Object)
+    {
+        a_entryObject.iconLabel = "default_book";
+
+        switch(a_entryObject.subType) {
+            case skyui.defines.Item.BOOK_RECIPE:
+            case skyui.defines.Item.BOOK_NOTE:
+                a_entryObject.iconLabel = "book_note";
+                break;
+
+            case skyui.defines.Item.BOOK_SPELLTOME:
+                a_entryObject.iconLabel = "book_tome";
+                break;
+            case skyui.defines.Item.BOOK_MAP:
+                a_entryObject.iconLabel = "book_map";
+                break;
+            case skyui.defines.Item.BOOK_ELDERSCROLL:
+                a_entryObject.iconLabel = "misc_elderscroll";
+                a_entryObject.iconColor = 0x75664D;
+                break;
+        }
+    }
+
+    // Weapons
+    private function processWeaponIcon(a_entryObject: Object)
+    {
+        a_entryObject.iconLabel = "default_weapon";
+        a_entryObject.iconColor = 0xA4A5BF;
+
+        switch(a_entryObject.subType) {
+            case skyui.defines.Weapon.TYPE_SWORD:
+                a_entryObject.iconLabel = "weapon_sword";
+                break;
+
+            case skyui.defines.Weapon.TYPE_DAGGER:
+                a_entryObject.iconLabel = "weapon_dagger";
+                break;
+
+            case skyui.defines.Weapon.TYPE_WARAXE:
+                a_entryObject.iconLabel = "weapon_waraxe";
+                break;
+
+            case skyui.defines.Weapon.TYPE_MACE:
+                a_entryObject.iconLabel = "weapon_mace";
+                break;
+
+            case skyui.defines.Weapon.TYPE_GREATSWORD:
+                a_entryObject.iconLabel = "weapon_greatsword";
+                break;
+
+            case skyui.defines.Weapon.TYPE_BATTLEAXE:
+                a_entryObject.iconLabel = "weapon_battleaxe";
+                break;
+
+            case skyui.defines.Weapon.TYPE_WARHAMMER:
+                a_entryObject.iconLabel = "weapon_hammer";
+                break;
+
+            case skyui.defines.Weapon.TYPE_BOW:
+                a_entryObject.iconLabel = "weapon_bow";
+                break;
+
+            case skyui.defines.Weapon.TYPE_STAFF:
+                a_entryObject.iconLabel = "weapon_staff";
+                break;
+
+            case skyui.defines.Weapon.TYPE_CROSSBOW:
+                a_entryObject.iconLabel = "weapon_crossbow";
+                break;
+
+            case skyui.defines.Weapon.TYPE_PICKAXE:
+                a_entryObject.iconLabel = "weapon_pickaxe";
+                break;
+            case skyui.defines.Weapon.TYPE_FISHINGROD:
+                a_entryObject.iconLabel = "weapon_fishingrod";
+                break;
+
+            case skyui.defines.Weapon.TYPE_WOODAXE:
+                a_entryObject.iconLabel = "weapon_woodaxe";
+                break;
+
+            case skyui.defines.Weapon.TYPE_MELEE:
+                break;
+        }
+    }
+
+    // Ammo
+    private function processAmmoIcon(a_entryObject: Object)
+    {
+        a_entryObject.iconLabel = "weapon_arrow";
+        a_entryObject.iconColor = 0xA89E8C;
+
+        switch(a_entryObject.subType) {
+            case skyui.defines.Weapon.AMMO_ARROW:
+                a_entryObject.iconLabel = "weapon_arrow";
+                break;
+            case skyui.defines.Weapon.AMMO_BOLT:
+                a_entryObject.iconLabel = "weapon_bolt";
+                break;
+        }
+    }
+
+    private function processPotionIcon(a_entryObject: Object)
+    {
+        a_entryObject.iconLabel = "default_potion";
+
+        switch(a_entryObject.subType) {
+            case skyui.defines.Item.POTION_DRINK:
+                a_entryObject.iconLabel = "food_wine";
+                break;
+
+            case skyui.defines.Item.POTION_FOOD:
+                a_entryObject.iconLabel = "default_food";
+                break;
+                
+            case skyui.defines.Item.POTION_POISON:
+                a_entryObject.iconLabel = "potion_poison";
+                a_entryObject.iconColor = 0xAD00B3;
+                break;
+                
+            case skyui.defines.Item.POTION_HEALTH:
+            case skyui.defines.Item.POTION_HEALRATE:
+            case skyui.defines.Item.POTION_HEALRATEMULT:
+                a_entryObject.iconLabel = "potion_health";
+                a_entryObject.iconColor = 0xDB2E73;
+                break;
+                
+            case skyui.defines.Item.POTION_MAGICKA:
+            case skyui.defines.Item.POTION_MAGICKARATE:
+            case skyui.defines.Item.POTION_MAGICKARATEMULT:
+                a_entryObject.iconLabel = "potion_magic";
+                a_entryObject.iconColor = 0x2E9FDB;
+                break;
+                
+            case skyui.defines.Item.POTION_STAMINA:	
+            case skyui.defines.Item.POTION_STAMINARATE:
+            case skyui.defines.Item.POTION_STAMINARATEMULT:
+                a_entryObject.iconLabel = "potion_stam";
+                a_entryObject.iconColor = 0x51DB2E;
+                break;
+
+            case skyui.defines.Item.POTION_FIRERESIST:
+                a_entryObject.iconLabel = "potion_fire";
+                a_entryObject.iconColor = 0xC73636;
+                break;
+
+            case skyui.defines.Item.POTION_ELECTRICRESIST:
+                a_entryObject.iconLabel = "potion_shock";
+                a_entryObject.iconColor = 0xEAAB00;
+                break;
+
+            case skyui.defines.Item.POTION_AYLEIDCRYSTAL:
+                a_entryObject.iconLabel = "soulgem_ayleidcrystalfull";
+                a_entryObject.iconColor = 0x5BC4C9;
+                break;
+
+            case skyui.defines.Item.POTION_FROSTRESIST:
+                a_entryObject.iconLabel = "potion_frost";
+                a_entryObject.iconColor = 0x1FFBFF;
+                break;
+        }
+
+    }
+
+    private function processSoulGemIcon(a_entryObject: Object)
+    {
+        a_entryObject.iconLabel = "misc_soulgem";
+        a_entryObject.iconColor = 0xE3E0FF;
+
+        switch(a_entryObject.subType) {
+            case skyui.defines.Item.SOULGEM_PETTY:
+                a_entryObject.iconColor = 0xD7D4FF;
+                this.processSoulGemStatusIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Item.SOULGEM_LESSER:
+                a_entryObject.iconColor = 0xC0BAFF;
+                this.processSoulGemStatusIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Item.SOULGEM_COMMON:
+                a_entryObject.iconColor = 0xABA3FF;
+                this.processSoulGemStatusIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Item.SOULGEM_GREATER:
+                a_entryObject.iconColor = 0x948BFC;
+                this.processGrandSoulGemIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Item.SOULGEM_GRAND:
+                a_entryObject.iconColor = 0x7569FF;
+                this.processGrandSoulGemIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Item.SOULGEM_SOULTOMATO:
+                a_entryObject.iconColor = 0xD14A38;
+                this.processSoulTomatoIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Item.SOULGEM_AZURA:
+                a_entryObject.iconColor = 0x7569FF;
+                a_entryObject.iconLabel = "soulgem_azura";
+                break;
+        }
+    }
+
+    private function processSoulTomatoIcon(a_entryObject: Object)
+    {
+        switch(a_entryObject.status)
+        {
+            case skyui.defines.Item.SOULGEMSTATUS_EMPTY:
+                a_entryObject.iconLabel = "soulgem_tomatoempty";
+                break;
+            case skyui.defines.Item.SOULGEMSTATUS_PARTIAL:
+                a_entryObject.iconLabel = "soulgem_tomatopartial";
+                break;
+            case skyui.defines.Item.SOULGEMSTATUS_FULL:
+                a_entryObject.iconLabel = "soulgem_tomatofull";
+            default:
+                return;
+        }
+    }
+
+    private function processGrandSoulGemIcon(a_entryObject: Object) {
+        switch(a_entryObject.status) {
+            case skyui.defines.Item.SOULGEMSTATUS_EMPTY:
+                a_entryObject.iconLabel = "soulgem_grandempty";
+                break;
+
+            case skyui.defines.Item.SOULGEMSTATUS_FULL:
+                a_entryObject.iconLabel = "soulgem_grandfull";
+                break;
+
+            case skyui.defines.Item.SOULGEMSTATUS_PARTIAL:
+                a_entryObject.iconLabel = "soulgem_grandpartial";
+                break;
+        }
+    }
+
+    private function processSoulGemStatusIcon(a_entryObject: Object) {
+        switch(a_entryObject.status) {
+            case skyui.defines.Item.SOULGEMSTATUS_EMPTY:
+                a_entryObject.iconLabel = "soulgem_empty";
+                break;
+
+            case skyui.defines.Item.SOULGEMSTATUS_FULL:
+                a_entryObject.iconLabel = "soulgem_full";
+                break;
+
+            case skyui.defines.Item.SOULGEMSTATUS_PARTIAL:
+                a_entryObject.iconLabel = "soulgem_partial";
+                break;
+        }
+    }
+
+    private function processMiscIcon(a_entryObject: Object)
+    {
+        if(a_entryObject.iconLabel != undefined)
             return;
-         case skyui.defines.Armor.WEIGHT_HEAVY:
-            this.processHeavyArmorIcon(a_entryObject);
-            return;
-         case skyui.defines.Armor.WEIGHT_JEWELRY:
-            this.processJewelryArmorIcon(a_entryObject);
-            return;
-         case skyui.defines.Armor.WEIGHT_CLOTHING:
-         default:
-            this.processClothingArmorIcon(a_entryObject);
-            return;
-      }
-   }
-   function processLightArmorIcon(a_entryObject)
-   {
-      a_entryObject.iconColor = 0x6B4D16;
-      switch(a_entryObject.subType)
-      {
-         case skyui.defines.Armor.EQUIP_HEAD:
-         case skyui.defines.Armor.EQUIP_HAIR:
-         case skyui.defines.Armor.EQUIP_LONGHAIR:
-            a_entryObject.iconLabel = "lightarmor_head";
-            break;
-         case skyui.defines.Armor.EQUIP_BODY:
-         case skyui.defines.Armor.EQUIP_TAIL:
-            a_entryObject.iconLabel = "lightarmor_body";
-            break;
-         case skyui.defines.Armor.EQUIP_HANDS:
-            a_entryObject.iconLabel = "lightarmor_hands";
-            break;
-         case skyui.defines.Armor.EQUIP_FOREARMS:
-            a_entryObject.iconLabel = "lightarmor_forearms";
-            break;
-         case skyui.defines.Armor.EQUIP_FEET:
-            a_entryObject.iconLabel = "lightarmor_feet";
-            break;
-         case skyui.defines.Armor.EQUIP_CALVES:
-            a_entryObject.iconLabel = "lightarmor_calves";
-            break;
-         case skyui.defines.Armor.EQUIP_SHIELD:
-            a_entryObject.iconLabel = "lightarmor_shield";
-            break;
-         case skyui.defines.Armor.EQUIP_AMULET:
-         case skyui.defines.Armor.EQUIP_RING:
-         case skyui.defines.Armor.EQUIP_CIRCLET:
-         case skyui.defines.Armor.EQUIP_EARS:
-            this.processJewelryArmorIcon(a_entryObject);
-         default:
-            return;
-      }
-   }
-   function processHeavyArmorIcon(a_entryObject)
-   {
-      a_entryObject.iconColor = 7042437;
-      switch(a_entryObject.subType)
-      {
-         case skyui.defines.Armor.EQUIP_HEAD:
-         case skyui.defines.Armor.EQUIP_HAIR:
-         case skyui.defines.Armor.EQUIP_LONGHAIR:
-            a_entryObject.iconLabel = "armor_head";
-            break;
-         case skyui.defines.Armor.EQUIP_BODY:
-         case skyui.defines.Armor.EQUIP_TAIL:
-            a_entryObject.iconLabel = "armor_body";
-            break;
-         case skyui.defines.Armor.EQUIP_HANDS:
-            a_entryObject.iconLabel = "armor_hands";
-            break;
-         case skyui.defines.Armor.EQUIP_FOREARMS:
-            a_entryObject.iconLabel = "armor_forearms";
-            break;
-         case skyui.defines.Armor.EQUIP_FEET:
-            a_entryObject.iconLabel = "armor_feet";
-            break;
-         case skyui.defines.Armor.EQUIP_CALVES:
-            a_entryObject.iconLabel = "armor_calves";
-            break;
-         case skyui.defines.Armor.EQUIP_SHIELD:
-            a_entryObject.iconLabel = "armor_shield";
-            break;
-         case skyui.defines.Armor.EQUIP_AMULET:
-         case skyui.defines.Armor.EQUIP_RING:
-         case skyui.defines.Armor.EQUIP_CIRCLET:
-         case skyui.defines.Armor.EQUIP_EARS:
-            this.processJewelryArmorIcon(a_entryObject);
-         default:
-            return;
-      }
-   }
-   function processJewelryArmorIcon(a_entryObject)
-   {
-      switch(a_entryObject.subType)
-      {
-         case skyui.defines.Armor.EQUIP_AMULET:
-            a_entryObject.iconLabel = "armor_amulet";
-            break;
-         case skyui.defines.Armor.EQUIP_RING:
-            a_entryObject.iconLabel = "armor_ring";
-            break;
-         case skyui.defines.Armor.EQUIP_CIRCLET:
-            a_entryObject.iconLabel = "armor_circlet";
-         case skyui.defines.Armor.EQUIP_EARS:
-         default:
-            return;
-      }
-   }
-   function processClothingArmorIcon(a_entryObject)
-   {
-      switch(a_entryObject.subType)
-      {
-         case skyui.defines.Armor.EQUIP_HEAD:
-         case skyui.defines.Armor.EQUIP_HAIR:
-         case skyui.defines.Armor.EQUIP_LONGHAIR:
-            a_entryObject.iconLabel = "clothing_head";
-            break;
-         case skyui.defines.Armor.EQUIP_BODY:
-         case skyui.defines.Armor.EQUIP_TAIL:
-            a_entryObject.iconLabel = "clothing_body";
-            break;
-         case skyui.defines.Armor.EQUIP_HANDS:
-            a_entryObject.iconLabel = "clothing_hands";
-            break;
-         case skyui.defines.Armor.EQUIP_FOREARMS:
-            a_entryObject.iconLabel = "clothing_forearms";
-            break;
-         case skyui.defines.Armor.EQUIP_FEET:
-            a_entryObject.iconLabel = "clothing_feet";
-            break;
-         case skyui.defines.Armor.EQUIP_CALVES:
-            a_entryObject.iconLabel = "clothing_calves";
-            break;
-         case skyui.defines.Armor.EQUIP_SHIELD:
-            a_entryObject.iconLabel = "clothing_shield";
-         case skyui.defines.Armor.EQUIP_EARS:
-         default:
-            return;
-      }
-   }
-   function processScrollIcon(a_entryObject)
-   {
-      a_entryObject.iconLabel = "default_scroll";
-      switch(a_entryObject.subType)
-      {
-         case skyui.defines.Item.SCROLL_SPIDER:
-            a_entryObject.iconLabel = "scroll_spider";
-         default:
-            return;
-      }
-   }
-   function processBookIcon(a_entryObject)
-   {
-      a_entryObject.iconLabel = "default_book";
-      switch(a_entryObject.subType)
-      {
-         case skyui.defines.Item.BOOK_RECIPE:
-         case skyui.defines.Item.BOOK_NOTE:
-            a_entryObject.iconLabel = "book_note";
-            break;
-         case skyui.defines.Item.BOOK_SPELLTOME:
-            a_entryObject.iconLabel = "book_tome";
-            break;
-         case skyui.defines.Item.BOOK_MAP:
-            a_entryObject.iconLabel = "book_map";
-            break;
-         case skyui.defines.Item.BOOK_ELDERSCROLL:
-            a_entryObject.iconLabel = "misc_elderscroll";
-            a_entryObject.iconColor = 7693901;
-         default:
-            return;
-      }
-   }
-   function processWeaponIcon(a_entryObject)
-   {
-      a_entryObject.iconLabel = "default_weapon";
-      a_entryObject.iconColor = 10790335;
-      switch(a_entryObject.subType)
-      {
-         case skyui.defines.Weapon.TYPE_SWORD:
-            a_entryObject.iconLabel = "weapon_sword";
-            break;
-         case skyui.defines.Weapon.TYPE_DAGGER:
-            a_entryObject.iconLabel = "weapon_dagger";
-            break;
-         case skyui.defines.Weapon.TYPE_WARAXE:
-            a_entryObject.iconLabel = "weapon_waraxe";
-            break;
-         case skyui.defines.Weapon.TYPE_MACE:
-            a_entryObject.iconLabel = "weapon_mace";
-            break;
-         case skyui.defines.Weapon.TYPE_GREATSWORD:
-            a_entryObject.iconLabel = "weapon_greatsword";
-            break;
-         case skyui.defines.Weapon.TYPE_BATTLEAXE:
-            a_entryObject.iconLabel = "weapon_battleaxe";
-            break;
-         case skyui.defines.Weapon.TYPE_WARHAMMER:
-            a_entryObject.iconLabel = "weapon_hammer";
-            break;
-         case skyui.defines.Weapon.TYPE_BOW:
-            a_entryObject.iconLabel = "weapon_bow";
-            break;
-         case skyui.defines.Weapon.TYPE_STAFF:
-            a_entryObject.iconLabel = "weapon_staff";
-            break;
-         case skyui.defines.Weapon.TYPE_CROSSBOW:
-            a_entryObject.iconLabel = "weapon_crossbow";
-            break;
-         case skyui.defines.Weapon.TYPE_PICKAXE:
-            a_entryObject.iconLabel = "weapon_pickaxe";
-            break;
-         case skyui.defines.Weapon.TYPE_FISHINGROD:
-            a_entryObject.iconLabel = "weapon_fishingrod";
-            break;
-         case skyui.defines.Weapon.TYPE_WOODAXE:
-            a_entryObject.iconLabel = "weapon_woodaxe";
-         case skyui.defines.Weapon.TYPE_MELEE:
-         default:
-            return;
-      }
-   }
-   function processAmmoIcon(a_entryObject)
-   {
-      a_entryObject.iconLabel = "weapon_arrow";
-      a_entryObject.iconColor = 11050636;
-      switch(a_entryObject.subType)
-      {
-         case skyui.defines.Weapon.AMMO_ARROW:
-            a_entryObject.iconLabel = "weapon_arrow";
-            break;
-         case skyui.defines.Weapon.AMMO_BOLT:
-            a_entryObject.iconLabel = "weapon_bolt";
-         default:
-            return;
-      }
-   }
-   function processPotionIcon(a_entryObject)
-   {
-      a_entryObject.iconLabel = "default_potion";
-      switch(a_entryObject.subType)
-      {
-         case skyui.defines.Item.POTION_DRINK:
-            a_entryObject.iconLabel = "food_wine";
-            break;
-         case skyui.defines.Item.POTION_FOOD:
-            a_entryObject.iconLabel = "default_food";
-            break;
-         case skyui.defines.Item.POTION_POISON:
-            a_entryObject.iconLabel = "potion_poison";
-            a_entryObject.iconColor = 11337907;
-            break;
-         case skyui.defines.Item.POTION_HEALTH:
-         case skyui.defines.Item.POTION_HEALRATE:
-         case skyui.defines.Item.POTION_HEALRATEMULT:
-            a_entryObject.iconLabel = "potion_health";
-            a_entryObject.iconColor = 14364275;
-            break;
-         case skyui.defines.Item.POTION_MAGICKA:
-         case skyui.defines.Item.POTION_MAGICKARATE:
-         case skyui.defines.Item.POTION_MAGICKARATEMULT:
-            a_entryObject.iconLabel = "potion_magic";
-            a_entryObject.iconColor = 3055579;
-            break;
-         case skyui.defines.Item.POTION_STAMINA:
-         case skyui.defines.Item.POTION_STAMINARATE:
-         case skyui.defines.Item.POTION_STAMINARATEMULT:
-            a_entryObject.iconLabel = "potion_stam";
-            a_entryObject.iconColor = 5364526;
-            break;
-         case skyui.defines.Item.POTION_FIRERESIST:
-            a_entryObject.iconLabel = "potion_fire";
-            a_entryObject.iconColor = 13055542;
-            break;
-         case skyui.defines.Item.POTION_ELECTRICRESIST:
-            a_entryObject.iconLabel = "potion_shock";
-            a_entryObject.iconColor = 15379200;
-            break;
-         case skyui.defines.Item.POTION_AYLEIDCRYSTAL:
-            a_entryObject.iconLabel = "soulgem_ayleidcrystalfull";
-            a_entryObject.iconColor = 6014153;
-            break;
-         case skyui.defines.Item.POTION_FROSTRESIST:
-            a_entryObject.iconLabel = "potion_frost";
-            a_entryObject.iconColor = 2096127;
-         default:
-            return;
-      }
-   }
-   function processSoulGemIcon(a_entryObject)
-   {
-      a_entryObject.iconLabel = "misc_soulgem";
-      a_entryObject.iconColor = 14934271;
-      switch(a_entryObject.subType)
-      {
-         case skyui.defines.Item.SOULGEM_PETTY:
-            a_entryObject.iconColor = 14144767;
-            this.processSoulGemStatusIcon(a_entryObject);
-            break;
-         case skyui.defines.Item.SOULGEM_LESSER:
-            a_entryObject.iconColor = 12630783;
-            this.processSoulGemStatusIcon(a_entryObject);
-            break;
-         case skyui.defines.Item.SOULGEM_COMMON:
-            a_entryObject.iconColor = 11248639;
-            this.processSoulGemStatusIcon(a_entryObject);
-            break;
-         case skyui.defines.Item.SOULGEM_GREATER:
-            a_entryObject.iconColor = 9735164;
-            this.processGrandSoulGemIcon(a_entryObject);
-            break;
-         case skyui.defines.Item.SOULGEM_GRAND:
-            a_entryObject.iconColor = 7694847;
-            this.processGrandSoulGemIcon(a_entryObject);
-            break;
-         case skyui.defines.Item.SOULGEM_SOULTOMATO:
-            a_entryObject.iconColor = 13716024;
-            this.processSoulTomatoIcon(a_entryObject);
-            break;
-         case skyui.defines.Item.SOULGEM_AZURA:
-            a_entryObject.iconColor = 7694847;
-            a_entryObject.iconLabel = "soulgem_azura";
-         default:
-            return;
-      }
-   }
-   function processSoulTomatoIcon(a_entryObject)
-   {
-      switch(a_entryObject.status)
-      {
-         case skyui.defines.Item.SOULGEMSTATUS_EMPTY:
-            a_entryObject.iconLabel = "soulgem_tomatoempty";
-            break;
-         case skyui.defines.Item.SOULGEMSTATUS_PARTIAL:
-            a_entryObject.iconLabel = "soulgem_tomatopartial";
-            break;
-         case skyui.defines.Item.SOULGEMSTATUS_FULL:
-            a_entryObject.iconLabel = "soulgem_tomatofull";
-         default:
-            return;
-      }
-   }
-   function processGrandSoulGemIcon(a_entryObject)
-   {
-      switch(a_entryObject.status)
-      {
-         case skyui.defines.Item.SOULGEMSTATUS_EMPTY:
-            a_entryObject.iconLabel = "soulgem_grandempty";
-            break;
-         case skyui.defines.Item.SOULGEMSTATUS_FULL:
-            a_entryObject.iconLabel = "soulgem_grandfull";
-            break;
-         case skyui.defines.Item.SOULGEMSTATUS_PARTIAL:
-            a_entryObject.iconLabel = "soulgem_grandpartial";
-         default:
-            return;
-      }
-   }
-   function processSoulGemStatusIcon(a_entryObject)
-   {
-      switch(a_entryObject.status)
-      {
-         case skyui.defines.Item.SOULGEMSTATUS_EMPTY:
-            a_entryObject.iconLabel = "soulgem_empty";
-            break;
-         case skyui.defines.Item.SOULGEMSTATUS_FULL:
-            a_entryObject.iconLabel = "soulgem_full";
-            break;
-         case skyui.defines.Item.SOULGEMSTATUS_PARTIAL:
-            a_entryObject.iconLabel = "soulgem_partial";
-         default:
-            return;
-      }
-   }
-   function processMiscIcon(a_entryObject)
-   {
-      if(a_entryObject.iconLabel != undefined)
-      {
-         return;
-      }
-      a_entryObject.iconLabel = "default_misc";
-      switch(a_entryObject.subType)
-      {
-         case skyui.defines.Item.MISC_ARTIFACT:
-            a_entryObject.iconLabel = "misc_artifact";
-            break;
-         case skyui.defines.Item.MISC_GEM:
-            a_entryObject.iconLabel = "misc_gem";
-            a_entryObject.iconColor = 16756945;
-            break;
-         case skyui.defines.Item.MISC_HIDE:
-            a_entryObject.iconLabel = "misc_hide";
-            a_entryObject.iconColor = 14398318;
-            break;
-         case skyui.defines.Item.MISC_REMAINS:
-            a_entryObject.iconLabel = "misc_remains";
-            break;
-         case skyui.defines.Item.MISC_INGOT:
-            a_entryObject.iconLabel = "misc_ingot";
-            a_entryObject.iconColor = 8553090;
-            break;
-         case skyui.defines.Item.MISC_CLUTTER:
-            a_entryObject.iconLabel = "misc_clutter";
-            break;
-         case skyui.defines.Item.MISC_FIREWOOD:
-            a_entryObject.iconLabel = "misc_wood";
-            a_entryObject.iconColor = 12553824;
-            break;
-         case skyui.defines.Item.MISC_DRAGONCLAW:
-            a_entryObject.iconLabel = "misc_dragonclaw";
-            break;
-         case skyui.defines.Item.MISC_LOCKPICK:
-            a_entryObject.iconLabel = "misc_lockpick";
-            break;
-         case skyui.defines.Item.MISC_GOLD:
-            a_entryObject.iconLabel = "misc_gold";
-            a_entryObject.iconColor = 13421619;
-            break;
-         case skyui.defines.Item.MISC_LEATHER:
-            a_entryObject.iconLabel = "misc_leather";
-            a_entryObject.iconColor = 12225827;
-            break;
-         case skyui.defines.Item.MISC_NETCHLEATHER:
-            a_entryObject.iconLabel = "misc_strips";
-            a_entryObject.iconColor = 7886222;
-            break;
-         case skyui.defines.Item.MISC_LEATHERSTRIPS:
-            a_entryObject.iconLabel = "misc_strips";
-            a_entryObject.iconColor = 12225827;
-            break;
-         case skyui.defines.Item.MISC_TROLLSKULL:
-            a_entryObject.iconLabel = "misc_trollskull";
-            break;
-         case skyui.defines.Item.MISC_CHILDRENSCLOTHES:
-            a_entryObject.iconColor = 15587975;
-            a_entryObject.iconLabel = "clothing_body";
-            break;
-         case skyui.defines.Item.MISC_ORE:
-            a_entryObject.iconLabel = "misc_ore";
-            a_entryObject.iconColor = 8553090;
-            break;
-         case skyui.defines.Item.MISC_HOUSEPART:
-            a_entryObject.iconLabel = "misc_housepart";
-            a_entryObject.iconColor = 16777215;
-            break;
-         case skyui.defines.Item.MISC_BROKENWEAPON:
-            a_entryObject.iconLabel = "default_weapon";
-            a_entryObject.iconColor = 16777215;
-            break;
-         case skyui.defines.Item.MISC_AYLEIDCRYSTAL:
-            a_entryObject.iconLabel = "soulgem_ayleidcrystalfull";
-            a_entryObject.iconColor = 6014153;
-            break;
-         case skyui.defines.Item.MISC_HORSETACK:
-            a_entryObject.iconLabel = "misc_horsetack";
-            break;
-         case skyui.defines.Item.MISC_DWARVENSCRAP:
-            a_entryObject.iconLabel = "misc_dwarvenscrap";
-            a_entryObject.iconColor = 7364402;
-            break;
-         case skyui.defines.Item.MISC_SCROLLSPIDER:
-            a_entryObject.iconLabel = "scroll_spider";
-            break;
-         case skyui.defines.Item.MISC_INSTRUMENT:
-            a_entryObject.iconLabel = "misc_instrument";
-            a_entryObject.iconColor = 16777215;
-            break;
-         case skyui.defines.Item.MISC_BUGJAR:
-            a_entryObject.iconLabel = "misc_jar";
-            a_entryObject.iconColor = 16777215;
-            break;
-         case skyui.defines.Item.MISC_MAP:
-            a_entryObject.iconLabel = "book_map";
-            break;
-         case skyui.defines.Item.MISC_POTION:
-            a_entryObject.iconLabel = "default_potion";
-            break;
-         case skyui.defines.Item.MISC_POISON:
-            a_entryObject.iconLabel = "potion_poison";
-            break;
-         case skyui.defines.Item.MISC_SCROLL:
-            a_entryObject.iconLabel = "default_scroll";
-            break;
-         case skyui.defines.Item.MISC_BOOK:
-            a_entryObject.iconLabel = "default_book";
-            break;
-         case skyui.defines.Item.MISC_RING:
-            a_entryObject.iconLabel = "armor_ring";
-            break;
-         case skyui.defines.Item.MISC_INGREDIENT:
-            a_entryObject.iconLabel = "default_ingredient";
-            break;
-         case skyui.defines.Item.MISC_PETGEAR:
-            a_entryObject.iconLabel = "clothing_backpack";
-         default:
-            return;
-      }
-   }
-   function processMiscBaseIdIcon(a_entryObject)
-   {
-      switch(a_entryObject.formId >>> 24)
-      {
-         case 0xFE:
-            switch(a_entryObject.eslId)
-            {
-               case skyui.defines.Form.ESLID_CCVSV002PETAMULET:
-                  a_entryObject.iconLabel = "armor_amulet";
-                  break;
-            }
-      }
-   }
+
+        a_entryObject.iconLabel = "default_misc";
+
+        switch(a_entryObject.subType) {
+            case skyui.defines.Item.MISC_ARTIFACT:
+                a_entryObject.iconLabel = "misc_artifact";
+                break;
+
+            case skyui.defines.Item.MISC_GEM:
+                a_entryObject.iconLabel = "misc_gem";
+                a_entryObject.iconColor = 0xFFB0D1;
+                break;
+
+            case skyui.defines.Item.MISC_HIDE:
+                a_entryObject.iconLabel = "misc_hide";
+                a_entryObject.iconColor = 0xDBB36E;
+                break;
+
+            case skyui.defines.Item.MISC_REMAINS:
+                a_entryObject.iconLabel = "misc_remains";
+                break;
+
+            case skyui.defines.Item.MISC_INGOT:
+                a_entryObject.iconLabel = "misc_ingot";
+                a_entryObject.iconColor = 0x828282;
+                break;
+
+            case skyui.defines.Item.MISC_CLUTTER:
+                a_entryObject.iconLabel = "misc_clutter";
+                break;
+
+            case skyui.defines.Item.MISC_FIREWOOD:
+                a_entryObject.iconLabel = "misc_wood";
+                a_entryObject.iconColor = 0xA89E8C;
+                break;
+
+            case skyui.defines.Item.MISC_DRAGONCLAW:
+                a_entryObject.iconLabel = "misc_dragonclaw";
+                break;
+
+            case skyui.defines.Item.MISC_LOCKPICK:
+                a_entryObject.iconLabel = "misc_lockpick";
+                break;
+
+            case skyui.defines.Item.MISC_GOLD:
+                a_entryObject.iconLabel = "misc_gold";
+                a_entryObject.iconColor = 0xCCCC33;
+                break;
+
+            case skyui.defines.Item.MISC_LEATHER:
+                a_entryObject.iconLabel = "misc_leather";
+                a_entryObject.iconColor = 0xBA8D23;
+                break;
+
+            case skyui.defines.Item.MISC_NETCHLEATHER:
+                a_entryObject.iconLabel = "misc_strips";
+                a_entryObject.iconColor = 0x78558E;
+                break;
+
+            case skyui.defines.Item.MISC_LEATHERSTRIPS:
+                a_entryObject.iconLabel = "misc_strips";
+                a_entryObject.iconColor = 0xBA8D23;
+                break;
+
+            case skyui.defines.Item.MISC_TROLLSKULL:
+                a_entryObject.iconLabel = "misc_trollskull";
+                break;
+
+            case skyui.defines.Item.MISC_CHILDRENSCLOTHES:
+                a_entryObject.iconColor = 0xEDDA87;
+                a_entryObject.iconLabel = "clothing_body";
+                break;
+            
+            case skyui.defines.Item.MISC_ORE:
+                a_entryObject.iconLabel = "misc_ore";
+                a_entryObject.iconColor = 0x828282;
+                break;
+
+            case skyui.defines.Item.MISC_HOUSEPART:
+                a_entryObject.iconLabel = "misc_housepart";
+                a_entryObject.iconColor = 0xFFFFFF;
+                break;
+
+            case skyui.defines.Item.MISC_BROKENWEAPON:
+                a_entryObject.iconLabel = "default_weapon";
+                a_entryObject.iconColor = 0xFFFFFF;
+                break;
+
+            case skyui.defines.Item.MISC_AYLEIDCRYSTAL:
+                a_entryObject.iconLabel = "soulgem_ayleidcrystalfull";
+                a_entryObject.iconColor = 0x5BC4C9;
+                break;
+
+            case skyui.defines.Item.MISC_HORSETACK:
+                a_entryObject.iconLabel = "misc_horsetack";
+                break;
+
+            case skyui.defines.Item.MISC_DWARVENSCRAP:
+                a_entryObject.iconLabel = "misc_dwarvenscrap";
+                a_entryObject.iconColor = 0x705F32;
+                break;
+
+            case skyui.defines.Item.MISC_SCROLLSPIDER:
+                a_entryObject.iconLabel = "scroll_spider";
+                break;
+                
+            case skyui.defines.Item.MISC_INSTRUMENT:
+                a_entryObject.iconLabel = "misc_instrument";
+                a_entryObject.iconColor = 0xFFFFFF;
+                break;
+                
+            case skyui.defines.Item.MISC_BUGJAR:
+                a_entryObject.iconLabel = "misc_jar";
+                a_entryObject.iconColor = 0xFFFFFF;
+                break;
+                
+            case skyui.defines.Item.MISC_MAP:
+                a_entryObject.iconLabel = "book_map";
+                break;
+                
+            case skyui.defines.Item.MISC_POTION:
+                a_entryObject.iconLabel = "default_potion";
+                break;
+                
+            case skyui.defines.Item.MISC_POISON:
+                a_entryObject.iconLabel = "potion_poison";
+                break;
+                
+            case skyui.defines.Item.MISC_SCROLL:
+                a_entryObject.iconLabel = "default_scroll";
+                break;
+                
+            case skyui.defines.Item.MISC_BOOK:
+                a_entryObject.iconLabel = "default_book";
+                break;
+                
+            case skyui.defines.Item.MISC_RING:
+                a_entryObject.iconLabel = "armor_ring";
+                break;
+                
+            case skyui.defines.Item.MISC_INGREDIENT:
+                a_entryObject.iconLabel = "default_ingredient";
+                break;
+                
+            case skyui.defines.Item.MISC_PETGEAR:
+                a_entryObject.iconLabel = "clothing_backpack";
+                break;
+        }
+    }
+
+    private function processMiscBaseIdIcon(a_entryObject: Object)
+    {
+        switch(a_entryObject.formId >>> 24)
+        {
+            case 0xFE:
+                switch(a_entryObject.eslId)
+                {
+                    case skyui.defines.Form.ESLID_CCVSV002PETAMULET:
+                        a_entryObject.iconLabel = "armor_amulet";
+                        break;
+                }
+        }
+    }
 }
+

--- a/source/actionscript/ItemMenus/InventoryLists.as
+++ b/source/actionscript/ItemMenus/InventoryLists.as
@@ -1,440 +1,529 @@
 class InventoryLists extends MovieClip
-{
-   var _columnSelectDialog;
-   var _columnSelectDialogX;
-   var _columnSelectInterval;
-   var _currCategoryIndex;
-   var _currentState;
-   var _leftTabText;
-   var _nameFilter;
-   var _platform;
-   var _rightTabText;
-   var _sortFilter;
-   var _tabBarIconArt;
-   var _typeFilter;
-   var categoryLabel;
-   var categoryList;
-   var columnSelectButton;
-   var dispatchEvent;
-   var itemList;
-   var panelContainer;
-   var searchWidget;
-   var tabBar;
-   static var HIDE_PANEL = 0;
-   static var SHOW_PANEL = 1;
-   static var TRANSITIONING_TO_HIDE_PANEL = 2;
-   static var TRANSITIONING_TO_SHOW_PANEL = 3;
-   var _savedSelectionIndex = -1;
-   var _searchKey = -1;
-   var _switchTabKey = -1;
-   var _sortOrderKey = -1;
-   var _sortOrderKeyHeld = false;
-   var _bTabbed = false;
-   function InventoryLists()
-   {
-      super();
-      skyui.util.GlobalFunctions.addArrayFunctions();
-      gfx.events.EventDispatcher.initialize(this);
-      this.gotoAndStop("NoPanels");
-      gfx.io.GameDelegate.addCallBack("SetCategoriesList",this,"SetCategoriesList");
-      gfx.io.GameDelegate.addCallBack("InvalidateListData",this,"InvalidateListData");
-      this._typeFilter = new skyui.filter.ItemTypeFilter();
-      this._nameFilter = new skyui.filter.NameFilter();
-      this._sortFilter = new skyui.filter.SortFilter();
-      this.categoryList = this.panelContainer.categoryList;
-      this.categoryLabel = this.panelContainer.categoryLabel;
-      this.itemList = this.panelContainer.itemList;
-      this.searchWidget = this.panelContainer.searchWidget;
-      this.columnSelectButton = this.panelContainer.columnSelectButton;
-      skyui.util.ConfigManager.registerLoadCallback(this,"onConfigLoad");
-      skyui.util.ConfigManager.registerUpdateCallback(this,"onConfigUpdate");
-   }
-   function get currentState()
-   {
-      return this._currentState;
-   }
-   function set currentState(a_newState)
-   {
-      if(a_newState == InventoryLists.SHOW_PANEL)
-      {
-         gfx.managers.FocusHandler.instance.setFocus(this.itemList,0);
-      }
-      this._currentState = a_newState;
-   }
-   function set tabBarIconArt(a_iconArt)
-   {
-      this._tabBarIconArt = a_iconArt;
-      if(this.tabBar)
-      {
-         this.tabBar.setIcons(this._tabBarIconArt[0],this._tabBarIconArt[1]);
-      }
-   }
-   function get tabBarIconArt()
-   {
-      return this._tabBarIconArt;
-   }
-   function InitExtensions()
-   {
-      Shared.GlobalFunc.SetLockFunction();
-      this.categoryList.listEnumeration = new skyui.components.list.BasicEnumeration(this.categoryList.entryList);
-      var _loc2_ = new skyui.components.list.FilteredEnumeration(this.itemList.entryList);
-      _loc2_.addFilter(this._typeFilter);
-      _loc2_.addFilter(this._nameFilter);
-      _loc2_.addFilter(this._sortFilter);
-      this.itemList.listEnumeration = _loc2_;
-      this.itemList.listState.maxTextLength = 80;
-      this._typeFilter.addEventListener("filterChange",this,"onFilterChange");
-      this._nameFilter.addEventListener("filterChange",this,"onFilterChange");
-      this._sortFilter.addEventListener("filterChange",this,"onFilterChange");
-      this.categoryList.addEventListener("itemPress",this,"onCategoriesItemPress");
-      this.categoryList.addEventListener("itemPressAux",this,"onCategoriesItemPress");
-      this.categoryList.addEventListener("selectionChange",this,"onCategoriesListSelectionChange");
-      this.itemList.disableInput = false;
-      this.itemList.addEventListener("selectionChange",this,"onItemsListSelectionChange");
-      this.itemList.addEventListener("sortChange",this,"onSortChange");
-      this.searchWidget.addEventListener("inputStart",this,"onSearchInputStart");
-      this.searchWidget.addEventListener("inputEnd",this,"onSearchInputEnd");
-      this.searchWidget.addEventListener("inputChange",this,"onSearchInputChange");
-      this.columnSelectButton.addEventListener("press",this,"onColumnSelectButtonPress");
-      this.categoryList.suspended = true;
-      this.itemList.suspended = true;
-   }
-   function showPanel(a_bPlayBladeSound)
-   {
-      this.categoryList.suspended = false;
-      this.itemList.suspended = false;
-      this._currentState = InventoryLists.TRANSITIONING_TO_SHOW_PANEL;
-      this.gotoAndPlay("PanelShow");
-      this.dispatchEvent({type:"categoryChange",index:this.categoryList.selectedIndex});
-      if(a_bPlayBladeSound != false)
-      {
-         gfx.io.GameDelegate.call("PlaySound",["UIMenuBladeOpenSD"]);
-      }
-   }
-   function hidePanel()
-   {
-      this._currentState = InventoryLists.TRANSITIONING_TO_HIDE_PANEL;
-      this.gotoAndPlay("PanelHide");
-      gfx.io.GameDelegate.call("PlaySound",["UIMenuBladeCloseSD"]);
-   }
-   function enableTabBar()
-   {
-      this._bTabbed = true;
-      this.panelContainer.gotoAndPlay("tabbed");
-      this.itemList.listHeight = 480;
-   }
-   function setPlatform(a_platform, a_bPS3Switch)
-   {
-      this._platform = a_platform;
-      this.categoryList.setPlatform(a_platform,a_bPS3Switch);
-      this.itemList.setPlatform(a_platform,a_bPS3Switch);
-   }
-   function handleInput(details, pathToFocus)
-   {
-      if(this._currentState != InventoryLists.SHOW_PANEL)
-      {
-         return false;
-      }
-      if(this._platform != 0)
-      {
-         if(details.skseKeycode == this._sortOrderKey)
-         {
-            if(details.value == "keyDown")
-            {
-               this._sortOrderKeyHeld = true;
-               if(this._columnSelectDialog)
-               {
-                  skyui.util.DialogManager.close();
-               }
-               else
-               {
-                  this._columnSelectInterval = setInterval(this,"onColumnSelectButtonPress",1000,{type:"timeout"});
-               }
-               return true;
+{   
+  /* CONSTANTS */
+    
+    static var HIDE_PANEL = 0;
+    static var SHOW_PANEL = 1;
+    static var TRANSITIONING_TO_HIDE_PANEL = 2;
+    static var TRANSITIONING_TO_SHOW_PANEL = 3;
+    
+    
+  /* STAGE ELEMENTS */
+
+    public var panelContainer: MovieClip;
+    public var zoomButtonHolder: MovieClip;
+
+
+  /* PRIVATE VARIABLES */
+
+    private var _typeFilter: ItemTypeFilter;
+    private var _nameFilter: NameFilter;
+    private var _sortFilter: SortFilter;
+    
+    private var _platform: Number;
+    
+    private var _currCategoryIndex: Number;
+    private var _savedSelectionIndex: Number = -1;
+    
+    private var _searchKey: Number = -1;
+    private var _switchTabKey: Number = -1;
+    private var _sortOrderKey: Number = -1;
+    private var _sortOrderKeyHeld: Boolean = false;
+    
+    private var _bTabbed = false;
+    private var _leftTabText: String;
+    private var _rightTabText: String;
+
+    private var _columnSelectDialog: MovieClip;
+    private var _columnSelectDialogX: Number;
+    private var _columnSelectInterval: Number;
+    
+
+  /* PROPERTIES */
+
+    public var itemList: TabularList;
+
+    public var categoryList: CategoryList;
+    
+    public var tabBar: TabBar;
+    
+    public var searchWidget: SearchWidget;
+    
+    public var categoryLabel: MovieClip;
+    
+    public var columnSelectButton: Button;
+    
+    private var _currentState: Number;
+    
+    public function get currentState()
+    {
+        return this._currentState;
+    }
+
+    public function set currentState(a_newState: Number)
+    {
+        if (a_newState == InventoryLists.SHOW_PANEL)
+            gfx.managers.FocusHandler.instance.setFocus(this.itemList, 0);
+
+        this._currentState = a_newState;
+    }
+    
+    private var _tabBarIconArt: Array;
+    
+    public function set tabBarIconArt(a_iconArt: Array)
+    {
+        this._tabBarIconArt = a_iconArt;
+        
+        if (this.tabBar)
+            this.tabBar.setIcons(this._tabBarIconArt[0], this._tabBarIconArt[1]);
+    }
+    
+    public function get tabBarIconArt()
+    {
+        return this._tabBarIconArt;
+    }
+
+
+  /* INITIALIZATION */
+
+    public function InventoryLists()
+    {
+        super();
+
+        skyui.util.GlobalFunctions.addArrayFunctions();
+
+        gfx.events.EventDispatcher.initialize(this);
+
+        this.gotoAndStop("NoPanels");
+
+        gfx.io.GameDelegate.addCallBack("SetCategoriesList", this, "SetCategoriesList");
+        gfx.io.GameDelegate.addCallBack("InvalidateListData", this, "InvalidateListData");
+
+        this._typeFilter = new skyui.filter.ItemTypeFilter();
+        this._nameFilter = new skyui.filter.NameFilter();
+        this._sortFilter = new skyui.filter.SortFilter();
+        
+        this.categoryList = this.panelContainer.categoryList;
+        this.categoryLabel = this.panelContainer.categoryLabel;
+        this.itemList = this.panelContainer.itemList;
+        this.searchWidget = this.panelContainer.searchWidget;
+        this.columnSelectButton = this.panelContainer.columnSelectButton;
+
+        skyui.util.ConfigManager.registerLoadCallback(this, "onConfigLoad");
+        skyui.util.ConfigManager.registerUpdateCallback(this, "onConfigUpdate");
+    }
+    
+    
+  /* PUBLIC FUNCTIONS */
+
+    // @mixin by gfx.events.gfx.events.EventDispatcher
+    public var dispatchEvent: Function;
+    public var dispatchQueue: Function;
+    public var hasEventListener: Function;
+    public var addEventListener: Function;
+    public var removeEventListener: Function;
+    public var removeAllEventListeners: Function;
+    public var cleanUpEvents: Function;
+    
+    // @mixin by Shared.Shared.GlobalFunc
+    public var Lock: Function;
+    
+    public function InitExtensions()
+    {
+        Shared.GlobalFunc.SetLockFunction();
+
+        this.categoryList.listEnumeration = new skyui.components.list.BasicEnumeration(this.categoryList.entryList);
+
+        var listEnumeration = new skyui.components.list.FilteredEnumeration(this.itemList.entryList);
+        listEnumeration.addFilter(this._typeFilter);
+        listEnumeration.addFilter(this._nameFilter);
+        listEnumeration.addFilter(this._sortFilter);
+        this.itemList.listEnumeration = listEnumeration;
+        // data processors are initialized by the top-level menu since they differ in each case
+        
+        this.itemList.listState.maxTextLength = 80;
+
+        this._typeFilter.addEventListener("filterChange", this, "onFilterChange");
+        this._nameFilter.addEventListener("filterChange", this, "onFilterChange");
+        this._sortFilter.addEventListener("filterChange", this, "onFilterChange");
+
+        this.categoryList.addEventListener("itemPress", this, "onCategoriesItemPress");
+        this.categoryList.addEventListener("itemPressAux", this, "onCategoriesItemPress");
+        this.categoryList.addEventListener("selectionChange", this, "onCategoriesListSelectionChange");
+
+        this.itemList.disableInput = false;
+
+        this.itemList.addEventListener("selectionChange", this, "onItemsListSelectionChange");
+        this.itemList.addEventListener("sortChange", this, "onSortChange");
+
+        this.searchWidget.addEventListener("inputStart", this, "onSearchInputStart");
+        this.searchWidget.addEventListener("inputEnd", this, "onSearchInputEnd");
+        this.searchWidget.addEventListener("inputChange", this, "onSearchInputChange");
+        
+        this.columnSelectButton.addEventListener("press", this, "onColumnSelectButtonPress");
+        
+        // Delay updates until config is ready
+        this.categoryList.suspended = true;
+        this.itemList.suspended = true;
+    }
+
+    public function showPanel(a_bPlayBladeSound: Boolean)
+    {
+        // Release itemlist for updating
+        this.categoryList.suspended = false;
+        this.itemList.suspended = false;
+        
+        this._currentState = InventoryLists.TRANSITIONING_TO_SHOW_PANEL;
+        this.gotoAndPlay("PanelShow");
+
+        this.dispatchEvent({type:"categoryChange", index: this.categoryList.selectedIndex});
+
+        if (a_bPlayBladeSound != false)
+            gfx.io.GameDelegate.call("PlaySound",["UIMenuBladeOpenSD"]);
+    }
+
+    public function hidePanel()
+    {
+        this._currentState = InventoryLists.TRANSITIONING_TO_HIDE_PANEL;
+        this.gotoAndPlay("PanelHide");
+        gfx.io.GameDelegate.call("PlaySound",["UIMenuBladeCloseSD"]);
+    }
+    
+    public function enableTabBar()
+    {
+        this._bTabbed = true;
+        this.panelContainer.gotoAndPlay("tabbed");
+        this.itemList.listHeight = 480;
+    }
+
+    public function setPlatform(a_platform: Number, a_bPS3Switch: Boolean)
+    {
+        this._platform = a_platform;
+
+        this.categoryList.setPlatform(a_platform,a_bPS3Switch);
+        this.itemList.setPlatform(a_platform,a_bPS3Switch);
+    }
+
+    // @GFx
+    public function handleInput(details: InputDetails, pathToFocus: Array)
+    {
+        if (this._currentState != InventoryLists.SHOW_PANEL)
+            return false;
+
+        if (this._platform != 0) {
+            if (details.skseKeycode == this._sortOrderKey) {
+                if (details.value == "keyDown") {
+                    this._sortOrderKeyHeld = true;
+
+                    if (this._columnSelectDialog)
+                        skyui.util.DialogManager.close();
+                    else
+                        this._columnSelectInterval = setInterval(this, "onColumnSelectButtonPress", 1000, {type: "timeout"});
+
+                    return true;
+                } else if (details.value == "keyUp") {
+                    this._sortOrderKeyHeld = false;
+
+                    if (this._columnSelectInterval == undefined)
+                        // keyPress handled: Key was released after the interval expired, don't process any further
+                        return true;
+
+                    // keyPress not handled: Clear intervals and change value to keyDown to be processed later
+                    clearInterval(this._columnSelectInterval);
+                    delete(this._columnSelectInterval);
+                    // Continue processing the event as a normal keyDown event
+                    details.value = "keyDown";
+                } else if (this._sortOrderKeyHeld && details.value == "keyHold") {
+                    // Fix for opening journal menu while key is depressed
+                    // For some reason this is the only time we receive a keyHold event
+                    this._sortOrderKeyHeld = false;
+
+                    if (this._columnSelectDialog)
+                        skyui.util.DialogManager.close();
+
+                    return true;
+                }
             }
-            if(details.value == "keyUp")
-            {
-               this._sortOrderKeyHeld = false;
-               if(this._columnSelectInterval == undefined)
-               {
-                  return true;
-               }
-               clearInterval(this._columnSelectInterval);
-               delete this._columnSelectInterval;
-               details.value = "keyDown";
+
+            if (this._sortOrderKeyHeld) // Disable extra input while interval is active
+                return true;
+        }
+
+        if (Shared.GlobalFunc.IsKeyPressed(details)) {
+            // Search hotkey (default space)
+            if (details.skseKeycode == this._searchKey) {
+                this.searchWidget.startInput();
+                return true;
             }
-            else if(this._sortOrderKeyHeld && details.value == "keyHold")
-            {
-               this._sortOrderKeyHeld = false;
-               if(this._columnSelectDialog)
-               {
-                  skyui.util.DialogManager.close();
-               }
-               return true;
+            
+            // Toggle tab (default ALT)
+            if (this.tabBar != undefined && details.skseKeycode == this._switchTabKey) {
+                this.tabBar.tabToggle();
+                return true;
             }
-         }
-         if(this._sortOrderKeyHeld)
-         {
+        }
+        
+        if (this.categoryList.handleInput(details, pathToFocus))
             return true;
-         }
-      }
-      if(Shared.GlobalFunc.IsKeyPressed(details))
-      {
-         if(details.skseKeycode == this._searchKey)
-         {
-            this.searchWidget.startInput();
-            return true;
-         }
-         if(this.tabBar != undefined && details.skseKeycode == this._switchTabKey)
-         {
-            this.tabBar.tabToggle();
-            return true;
-         }
-      }
-      if(this.categoryList.handleInput(details,pathToFocus))
-      {
-         return true;
-      }
-      var _loc4_ = pathToFocus.shift();
-      return _loc4_.handleInput(details,pathToFocus);
-   }
-   function getContentBounds()
-   {
-      var _loc2_ = this.panelContainer.ListBackground;
-      return [_loc2_._x,_loc2_._y,_loc2_._width,_loc2_._height];
-   }
-   function showItemsList()
-   {
-      this._currCategoryIndex = this.categoryList.selectedIndex;
-      this.categoryLabel.textField.SetText(this.categoryList.selectedEntry.text);
-      this.itemList.selectedIndex = -1;
-      this.itemList.scrollPosition = 0;
-      if(this.categoryList.selectedEntry != undefined)
-      {
-         this._typeFilter.changeFilterFlag(this.categoryList.selectedEntry.flag);
-         this.itemList.layout.changeFilterFlag(this.categoryList.selectedEntry.flag);
-      }
-      this.itemList.requestUpdate();
-      this.dispatchEvent({type:"itemHighlightChange",index:this.itemList.selectedIndex});
-      this.itemList.disableInput = false;
-   }
-   function SetCategoriesList()
-   {
-      var _loc14_ = 0;
-      var _loc13_ = 1;
-      var _loc6_ = 2;
-      var _loc12_ = 3;
-      this.categoryList.clearList();
-      var _loc3_ = 0;
-      var _loc5_ = 0;
-      var _loc4_;
-      while(_loc3_ < arguments.length)
-      {
-         _loc4_ = {text:arguments[_loc3_ + _loc14_],flag:arguments[_loc3_ + _loc13_],bDontHide:arguments[_loc3_ + _loc6_],savedItemIndex:0,filterFlag:(arguments[_loc3_ + _loc6_] != true ? 0 : 1)};
-         this.categoryList.entryList.push(_loc4_);
-         if(_loc4_.flag == 0)
-         {
-            this.categoryList.dividerIndex = _loc5_;
-         }
-         _loc3_ += _loc12_;
-         _loc5_++;
-      }
-      if(this._bTabbed)
-      {
-         this.categoryList.selectedIndex = 0;
-         this._leftTabText = this.categoryList.entryList[0].text;
-         this._rightTabText = this.categoryList.entryList[this.categoryList.dividerIndex + 1].text;
-         this.categoryList.entryList[0].text = this.categoryList.entryList[this.categoryList.dividerIndex + 1].text = "$ALL";
-      }
-      this.categoryList.InvalidateData();
-   }
-   function InvalidateListData()
-   {
-      var _loc4_ = this.categoryList.selectedEntry.flag;
-      var _loc3_ = 0;
-      while(_loc3_ < this.categoryList.entryList.length)
-      {
-         this.categoryList.entryList[_loc3_].filterFlag = !this.categoryList.entryList[_loc3_].bDontHide ? 0 : 1;
-         _loc3_ = _loc3_ + 1;
-      }
-      this.itemList.InvalidateData();
-      _loc3_ = 0;
-      var _loc2_;
-      while(_loc3_ < this.itemList.entryList.length)
-      {
-         _loc2_ = 0;
-         while(_loc2_ < this.categoryList.entryList.length)
-         {
-            if(this.categoryList.entryList[_loc2_].filterFlag == 0)
-            {
-               if(this.itemList.entryList[_loc3_].filterFlag & this.categoryList.entryList[_loc2_].flag)
-               {
-                  this.categoryList.entryList[_loc2_].filterFlag = 1;
-               }
+        
+        var nextClip = pathToFocus.shift();
+        return nextClip.handleInput(details, pathToFocus);
+    }
+
+    public function getContentBounds()
+    {
+        var lb = panelContainer.ListBackground;
+        return [lb._x, lb._y, lb._width, lb._height];
+    }
+    
+    public function showItemsList()
+    {
+        this._currCategoryIndex = this.categoryList.selectedIndex;
+        
+        this.categoryLabel.textField.SetText(this.categoryList.selectedEntry.text);
+
+        // Start with no selection
+        this.itemList.selectedIndex = -1;
+        this.itemList.scrollPosition = 0;
+
+        if (this.categoryList.selectedEntry != undefined) {
+            // Set filter type
+            this._typeFilter.changeFilterFlag(this.categoryList.selectedEntry.flag);
+            
+            // Not set yet before the config is loaded
+            this.itemList.layout.changeFilterFlag(this.categoryList.selectedEntry.flag);
+        }
+        
+        this.itemList.requestUpdate();
+        
+        this.dispatchEvent({type: "itemHighlightChange", index: this.itemList.selectedIndex});
+
+        this.itemList.disableInput = false;
+    }
+
+    // Called to initially set the category list.
+    // @API 
+    public function SetCategoriesList()
+    {
+        var textOffset = 0;
+        var flagOffset = 1;
+        var bDontHideOffset = 2;
+        var len = 3;
+
+        this.categoryList.clearList();
+
+        for (var i = 0, index = 0; i < arguments.length; i = i + len, index++) {
+            var entry = {text: arguments[i + textOffset], flag: arguments[i + flagOffset], bDontHide: arguments[i + bDontHideOffset], savedItemIndex: 0, filterFlag: arguments[i + bDontHideOffset] == true ? (1) : (0)};
+            this.categoryList.entryList.push(entry);
+
+            if (entry.flag == 0)
+                this.categoryList.dividerIndex = index;
+        }
+        
+        // Initialize tabbar labels and replace text of segment heads (name -> ALL)
+        if (this._bTabbed) {
+            // Restore 0 as default index for tabbed lists
+            this.categoryList.selectedIndex = 0;
+            this._leftTabText = this.categoryList.entryList[0].text;
+            this._rightTabText = this.categoryList.entryList[this.categoryList.dividerIndex + 1].text;
+            this.categoryList.entryList[0].text = this.categoryList.entryList[this.categoryList.dividerIndex + 1].text = "$ALL";
+        }
+
+        this.categoryList.InvalidateData();
+    }
+
+    // Called whenever the underlying entryList data is updated (using an item, equipping etc.)
+    // @API
+    public function InvalidateListData()
+    {
+        var flag = this.categoryList.selectedEntry.flag;
+
+        for (var i = 0; i < this.categoryList.entryList.length; i++)
+            this.categoryList.entryList[i].filterFlag = this.categoryList.entryList[i].bDontHide ? 1 : 0;
+
+        this.itemList.InvalidateData();
+
+        // Set filter flag = 1 for non-empty categories with bDontHideOffset=false
+        for (var i = 0; i < this.itemList.entryList.length; i++) {
+            for (var j = 0; j < this.categoryList.entryList.length; ++j) {
+                if (this.categoryList.entryList[j].filterFlag != 0)
+                    continue;
+
+                if (this.itemList.entryList[i].filterFlag & this.categoryList.entryList[j].flag)
+                    this.categoryList.entryList[j].filterFlag = 1;
             }
-            _loc2_ = _loc2_ + 1;
-         }
-         _loc3_ = _loc3_ + 1;
-      }
-      this.categoryList.UpdateList();
-      if(_loc4_ != this.categoryList.selectedEntry.flag)
-      {
-         this._typeFilter.itemFilter = this.categoryList.selectedEntry.flag;
-         this.dispatchEvent({type:"categoryChange",index:this.categoryList.selectedIndex});
-      }
-      if(this.itemList.selectedIndex == -1)
-      {
-         this.dispatchEvent({type:"showItemsList",index:-1});
-      }
-      else
-      {
-         this.dispatchEvent({type:"itemHighlightChange",index:this.itemList.selectedIndex});
-      }
-   }
-   function onConfigLoad(event)
-   {
-      var _loc2_ = event.config;
-      this._searchKey = _loc2_.Input.controls.pc.search;
-      if(this._platform == 0)
-      {
-         this._switchTabKey = _loc2_.Input.controls.pc.switchTab;
-      }
-      else
-      {
-         this._switchTabKey = _loc2_.Input.controls.gamepad.switchTab;
-         this._sortOrderKey = _loc2_.Input.controls.gamepad.sortOrder;
-      }
-   }
-   function onFilterChange()
-   {
-      this.itemList.requestInvalidate();
-   }
-   function onTabBarLoad()
-   {
-      this.tabBar = this.panelContainer.tabBar;
-      this.tabBar.setIcons(this._tabBarIconArt[0],this._tabBarIconArt[1]);
-      this.tabBar.addEventListener("tabPress",this,"onTabPress");
-      if(this.categoryList.dividerIndex != -1)
-      {
-         this.tabBar.setLabelText(this._leftTabText,this._rightTabText);
-      }
-      this.tabBar.Lock("B");
-      this.tabBar._y = this._parent.bottomBar._y - this.tabBar._height - Stage.safeRect.y - Stage.visibleRect.y + 17;
-   }
-   function onColumnSelectButtonPress(event)
-   {
-      if(event.type == "timeout")
-      {
-         clearInterval(this._columnSelectInterval);
-         delete this._columnSelectInterval;
-      }
-      if(this._columnSelectDialog)
-      {
-         skyui.util.DialogManager.close();
-         return undefined;
-      }
-      this._savedSelectionIndex = this.itemList.selectedIndex;
-      this.itemList.selectedIndex = -1;
-      this.categoryList.disableSelection = this.categoryList.disableInput = true;
-      this.itemList.disableSelection = this.itemList.disableInput = true;
-      this.searchWidget.isDisabled = true;
-      this._columnSelectDialog = skyui.util.DialogManager.open(this.panelContainer,"ColumnSelectDialog",{_x:this._columnSelectDialogX != undefined ? this._columnSelectDialogX : 554,_y:35,layout:this.itemList.layout});
-      this._columnSelectDialog.addEventListener("dialogClosed",this,"onColumnSelectDialogClosed");
-   }
-   function onColumnSelectDialogClosed(event)
-   {
-      this.categoryList.disableSelection = this.categoryList.disableInput = false;
-      this.itemList.disableSelection = this.itemList.disableInput = false;
-      this.searchWidget.isDisabled = false;
-      this.itemList.selectedIndex = this._savedSelectionIndex;
-   }
-   function onConfigUpdate(event)
-   {
-      this.itemList.layout.refresh();
-   }
-   function onCategoriesItemPress()
-   {
-      this.showItemsList();
-   }
-   function onTabPress(event)
-   {
-      if(this.categoryList.disableSelection || this.categoryList.disableInput || this.itemList.disableSelection || this.itemList.disableInput)
-      {
-         return undefined;
-      }
-      if(event.index == skyui.components.TabBar.LEFT_TAB)
-      {
-         this.tabBar.activeTab = skyui.components.TabBar.LEFT_TAB;
-         this.categoryList.activeSegment = CategoryList.LEFT_SEGMENT;
-      }
-      else if(event.index == skyui.components.TabBar.RIGHT_TAB)
-      {
-         this.tabBar.activeTab = skyui.components.TabBar.RIGHT_TAB;
-         this.categoryList.activeSegment = CategoryList.RIGHT_SEGMENT;
-      }
-      gfx.io.GameDelegate.call("PlaySound",["UIMenuBladeOpenSD"]);
-      this.showItemsList();
-   }
-   function onCategoriesListSelectionChange(event)
-   {
-      this.dispatchEvent({type:"categoryChange",index:event.index});
-      if(event.index != -1)
-      {
-         gfx.io.GameDelegate.call("PlaySound",["UIMenuFocus"]);
-      }
-   }
-   function onItemsListSelectionChange(event)
-   {
-      this.dispatchEvent({type:"itemHighlightChange",index:event.index});
-      if(event.index != -1)
-      {
-         gfx.io.GameDelegate.call("PlaySound",["UIMenuFocus"]);
-      }
-   }
-   function onSortChange(event)
-   {
-      this._sortFilter.setSortBy(event.attributes,event.options);
-   }
-   function onSearchInputStart(event)
-   {
-      this.categoryList.disableSelection = this.categoryList.disableInput = true;
-      this.itemList.disableSelection = this.itemList.disableInput = true;
-      this._nameFilter.filterText = "";
-   }
-   function onSearchInputChange(event)
-   {
-      this._nameFilter.filterText = event.data;
-   }
-   function onSearchInputEnd(event)
-   {
-      this.categoryList.disableSelection = this.categoryList.disableInput = false;
-      this.itemList.disableSelection = this.itemList.disableInput = false;
-      this._nameFilter.filterText = event.data;
-   }
+        }
 
+        this.categoryList.UpdateList();
 
-   function applyDynamicWidth(a_newWidth: Number)
-   {
-      var defaultWidth = 530;
-      var delta = a_newWidth - defaultWidth;
+        if (flag != this.categoryList.selectedEntry.flag) {
+            // Triggers an update if filter flag changed
+            this._typeFilter.itemFilter = this.categoryList.selectedEntry.flag;
+            this.dispatchEvent({type:"categoryChange", index: this.categoryList.selectedIndex});
+        }
+        
+        // This is called when an ItemCard list closes(ex. ShowSoulGemList) to refresh ItemCard data    
+        if (this.itemList.selectedIndex == -1)
+            this.dispatchEvent({type:"showItemsList", index: -1});
+        else
+            this.dispatchEvent({type:"itemHighlightChange", index: this.itemList.selectedIndex});
+    }
+    
+    
+  /* PRIVATE FUNCTIONS */
 
-      this.panelContainer.ListBackground._width += delta;
-      this.itemList.header.seperator._width += delta;
-      this.categoryList.background._width += delta;
+    private function onConfigLoad(event: Object)
+    {
+        var config = event.config;
+        this._searchKey = config["Input"].controls.pc.search;
+        
+        if (_platform == 0)
+            this._switchTabKey = config["Input"].controls.pc.switchTab;
+        else {
+            this._switchTabKey = config["Input"].controls.gamepad.switchTab;
+            this._sortOrderKey = config["Input"].controls.gamepad.sortOrder;
+        }
+    }
 
-      var tab = this.panelContainer.tabBar;
-      var halfDelta = delta / 2;
+    private function onFilterChange()
+    {
+        this.itemList.requestInvalidate();
+    }
+    
+    private function onTabBarLoad()
+    {
+        this.tabBar = this.panelContainer.tabBar;
+        this.tabBar.setIcons(this._tabBarIconArt[0], this._tabBarIconArt[1]);
+        this.tabBar.addEventListener("tabPress", this, "onTabPress");
+        
+        if (this.categoryList.dividerIndex != -1)
+            this.tabBar.setLabelText(this._leftTabText, this._rightTabText);
 
-      tab.image._width += delta;
-      tab.rightIcon._x += delta;
-      tab.rightLabel._x += delta;
-      tab.leftButton._width += halfDelta;
-      tab.rightButton._x += halfDelta;
-      tab.rightButton._width += halfDelta;
+        this.tabBar.Lock("B");
+        this.tabBar._y = this._parent.bottomBar._y - this.tabBar._height - Stage.safeRect.y - Stage.visibleRect.y + 17;
+    }
+    
+    private function onColumnSelectButtonPress(event: Object)
+    {
+        if (event.type == "timeout") {
+            clearInterval(this._columnSelectInterval);
+            delete(this._columnSelectInterval);
+        }
 
-      this.itemList.scrollbar._x += delta;
-      this.searchWidget._x += delta;
-      this.columnSelectButton._x += delta;
-      this._columnSelectDialogX = 554 + delta;
-   }
+        if (this._columnSelectDialog) {
+            skyui.util.DialogManager.close();
+            return;
+        }
+        
+        this._savedSelectionIndex = this.itemList.selectedIndex;
+        this.itemList.selectedIndex = -1;
+        
+        this.categoryList.disableSelection = this.categoryList.disableInput = true;
+        this.itemList.disableSelection = this.itemList.disableInput = true;
+        this.searchWidget.isDisabled = true;
+            
+        this._columnSelectDialog = skyui.util.DialogManager.open(this.panelContainer, "ColumnSelectDialog", {_x: this._columnSelectDialogX != undefined ? this._columnSelectDialogX : 554, _y: 35, layout: this.itemList.layout});
+        this._columnSelectDialog.addEventListener("dialogClosed", this, "onColumnSelectDialogClosed");
+    }
+    
+    private function onColumnSelectDialogClosed(event: Object)
+    {
+        this.categoryList.disableSelection = this.categoryList.disableInput = false;
+        this.itemList.disableSelection = this.itemList.disableInput = false;
+        this.searchWidget.isDisabled = false;
+        
+        this.itemList.selectedIndex = this._savedSelectionIndex;
+    }
+    
+    private function onConfigUpdate(event: Object)
+    {
+        this.itemList.layout.refresh();
+    }
+
+    private function onCategoriesItemPress()
+    {
+        this.showItemsList();
+    }
+    
+    private function onTabPress(event: Object)
+    {
+        if (this.categoryList.disableSelection || this.categoryList.disableInput || this.itemList.disableSelection || this.itemList.disableInput)
+            return;
+        
+        if (event.index == skyui.components.TabBar.LEFT_TAB) {
+            this.tabBar.activeTab = skyui.components.TabBar.LEFT_TAB;
+            this.categoryList.activeSegment = CategoryList.LEFT_SEGMENT;
+        } else if (event.index == skyui.components.TabBar.RIGHT_TAB) {
+            this.tabBar.activeTab = skyui.components.TabBar.RIGHT_TAB;
+            this.categoryList.activeSegment = CategoryList.RIGHT_SEGMENT;
+        }
+        
+        gfx.io.GameDelegate.call("PlaySound",["UIMenuBladeOpenSD"]);
+        this.showItemsList();
+    }
+
+    private function onCategoriesListSelectionChange(event: Object)
+    {
+        this.dispatchEvent({type:"categoryChange", index:event.index});
+        
+        if (event.index != -1)
+            gfx.io.GameDelegate.call("PlaySound",["UIMenuFocus"]);
+    }
+
+    private function onItemsListSelectionChange(event: Object)
+    {
+        this.dispatchEvent({type:"itemHighlightChange", index:event.index});
+
+        if (event.index != -1)
+            gfx.io.GameDelegate.call("PlaySound",["UIMenuFocus"]);
+    }
+
+    private function onSortChange(event: Object)
+    {
+        this._sortFilter.setSortBy(event.attributes, event.options);
+    }
+
+    private function onSearchInputStart(event: Object)
+    {
+        this.categoryList.disableSelection = this.categoryList.disableInput = true;
+        this.itemList.disableSelection = this.itemList.disableInput = true;
+        this._nameFilter.filterText = "";
+    }
+
+    private function onSearchInputChange(event: Object)
+    {
+        this._nameFilter.filterText = event.data;
+    }
+
+    private function onSearchInputEnd(event: Object)
+    {
+        this.categoryList.disableSelection = this.categoryList.disableInput = false;
+        this.itemList.disableSelection = this.itemList.disableInput = false;
+        this._nameFilter.filterText = event.data;
+    }
+
+    function applyDynamicWidth(a_newWidth: Number)
+    {
+        var defaultWidth = 530;
+        var delta = a_newWidth - defaultWidth;
+
+        this.panelContainer.ListBackground._width += delta;
+        this.itemList.header.seperator._width += delta;
+        this.categoryList.background._width += delta;
+
+        var tab = this.panelContainer.tabBar;
+        var halfDelta = delta / 2;
+
+        tab.image._width += delta;
+        tab.rightIcon._x += delta;
+        tab.rightLabel._x += delta;
+        tab.leftButton._width += halfDelta;
+        tab.rightButton._x += halfDelta;
+        tab.rightButton._width += halfDelta;
+
+        this.itemList.scrollbar._x += delta;
+        this.searchWidget._x += delta;
+        this.columnSelectButton._x += delta;
+        this._columnSelectDialogX = 554 + delta;
+    }
 }

--- a/source/actionscript/ItemMenus/InventoryLists.as
+++ b/source/actionscript/ItemMenus/InventoryLists.as
@@ -309,15 +309,18 @@ class InventoryLists extends MovieClip
         var flagOffset = 1;
         var bDontHideOffset = 2;
         var len = 3;
+        var index = 0;
 
         this.categoryList.clearList();
 
-        for (var i = 0, index = 0; i < arguments.length; i = i + len, index++) {
+        for (var i = 0; i < arguments.length; i = i + len) {
             var entry = {text: arguments[i + textOffset], flag: arguments[i + flagOffset], bDontHide: arguments[i + bDontHideOffset], savedItemIndex: 0, filterFlag: arguments[i + bDontHideOffset] == true ? (1) : (0)};
             this.categoryList.entryList.push(entry);
 
             if (entry.flag == 0)
                 this.categoryList.dividerIndex = index;
+            
+            index++;
         }
         
         // Initialize tabbar labels and replace text of segment heads (name -> ALL)

--- a/source/actionscript/ItemMenus/InventoryLists.as
+++ b/source/actionscript/ItemMenus/InventoryLists.as
@@ -272,7 +272,7 @@ class InventoryLists extends MovieClip
 
     public function getContentBounds()
     {
-        var lb = panelContainer.ListBackground;
+        var lb = this.panelContainer.ListBackground;
         return [lb._x, lb._y, lb._width, lb._height];
     }
     
@@ -380,7 +380,7 @@ class InventoryLists extends MovieClip
         var config = event.config;
         this._searchKey = config["Input"].controls.pc.search;
         
-        if (_platform == 0)
+        if (this._platform == 0)
             this._switchTabKey = config["Input"].controls.pc.switchTab;
         else {
             this._switchTabKey = config["Input"].controls.gamepad.switchTab;

--- a/source/actionscript/ItemMenus/InventoryMenu.as
+++ b/source/actionscript/ItemMenus/InventoryMenu.as
@@ -1,268 +1,290 @@
 class InventoryMenu extends ItemMenu
 {
-   var ToggleMenuFade;
-   var _acceptControls;
-   var _cancelControls;
-   var _categoryListIconArt;
-   var _platform;
-   var _quantityMinCount;
-   var _searchControls;
-   var _sortColumnControls;
-   var _sortOrderControls;
-   var _switchControls;
-   var _switchTabKey;
-   var bFadedIn;
-   var bottomBar;
-   var checkBook;
-   var confirmSelectedEntry;
-   var getEquipButtonData;
-   var inventoryLists;
-   var itemCard;
-   var navPanel;
-   var saveIndices;
-   var shouldProcessItemsListInput;
-   var _bMenuClosing = false;
-   var _bSwitchMenus = false;
-   var bPCControlsReady = true;
-   function InventoryMenu()
-   {
-      super();
-      this._categoryListIconArt = ["cat_favorites","inv_all","inv_weapons","inv_armor","inv_potions","inv_scrolls","inv_food","inv_ingredients","inv_books","inv_keys","inv_misc"];
-      gfx.io.GameDelegate.addCallBack("AttemptEquip",this,"AttemptEquip");
-      gfx.io.GameDelegate.addCallBack("DropItem",this,"DropItem");
-      gfx.io.GameDelegate.addCallBack("AttemptChargeItem",this,"AttemptChargeItem");
-      gfx.io.GameDelegate.addCallBack("ItemRotating",this,"ItemRotating");
-   }
-   function InitExtensions()
-   {
-      super.InitExtensions();
-      Shared.GlobalFunc.AddReverseFunctions();
-      this.inventoryLists.zoomButtonHolder.gotoAndStop(1);
-      var _loc3_ = this.inventoryLists.categoryList;
-      _loc3_.iconArt = this._categoryListIconArt;
-      this.itemCard.addEventListener("itemPress",this,"onItemCardListPress");
-   }
-   function setConfig(a_config)
-   {
-      super.setConfig(a_config);
-      var _loc3_ = this.inventoryLists.itemList;
-      _loc3_.addDataProcessor(new InventoryDataSetter());
-      _loc3_.addDataProcessor(new InventoryIconSetter(a_config.Appearance));
-      _loc3_.addDataProcessor(new skyui.props.PropertyDataExtender(a_config.Appearance,a_config.Properties,"itemProperties","itemIcons","itemCompoundProperties"));
-      var _loc5_ = skyui.components.list.ListLayoutManager.createLayout(a_config.ListLayout,"ItemListLayout");
-      _loc3_.layout = _loc5_;
-      if(this.inventoryLists.categoryList.selectedEntry)
-      {
-         _loc5_.changeFilterFlag(this.inventoryLists.categoryList.selectedEntry.flag);
-      }
-   }
-   function handleInput(details, pathToFocus)
-   {
-      if(!this.bFadedIn)
-      {
-         return true;
-      }
-      var _loc3_ = pathToFocus.shift();
-      if(_loc3_.handleInput(details,pathToFocus))
-      {
-         return true;
-      }
-      if(Shared.GlobalFunc.IsKeyPressed(details))
-      {
-         if(details.navEquivalent == gfx.ui.NavigationCode.TAB || details.navEquivalent == gfx.ui.NavigationCode.SHIFT_TAB)
-         {
-            this.startMenuFade();
-            gfx.io.GameDelegate.call("CloseTweenMenu",[]);
-         }
-         else if(!this.inventoryLists.itemList.disableInput)
-         {
-            if(details.skseKeycode == this._switchTabKey || details.control == "Quick Magic")
-            {
-               this.openMagicMenu(true);
+  /* PRIVATE VARIABLES */
+
+    private var _bMenuClosing: Boolean = false;
+    private var _bSwitchMenus: Boolean = false;
+
+    private var _categoryListIconArt: Array;
+    
+    
+  /* PROPERTIES */
+
+    // @GFx
+    public var bPCControlsReady: Boolean = true;
+
+
+  /* INITIALIZATION */
+
+    public function InventoryMenu()
+    {
+        super();
+        
+        this._categoryListIconArt = ["cat_favorites", "inv_all", "inv_weapons", "inv_armor",
+                            "inv_potions", "inv_scrolls", "inv_food", "inv_ingredients",
+                            "inv_books", "inv_keys", "inv_misc"];
+        
+        gfx.io.GameDelegate.addCallBack("AttemptEquip", this, "AttemptEquip");
+        gfx.io.GameDelegate.addCallBack("DropItem", this, "DropItem");
+        gfx.io.GameDelegate.addCallBack("AttemptChargeItem", this, "AttemptChargeItem");
+        gfx.io.GameDelegate.addCallBack("ItemRotating", this, "ItemRotating");
+    }
+
+
+/* PUBLIC FUNCTIONS */
+
+    // @override ItemMenu
+    public function InitExtensions()
+    {		
+        super.InitExtensions();
+
+        Shared.GlobalFunc.AddReverseFunctions();
+        
+        this.inventoryLists.zoomButtonHolder.gotoAndStop(1);
+    
+        // Initialize menu-specific list components
+        var categoryList: CategoryList = this.inventoryLists.categoryList;
+        categoryList.iconArt = this._categoryListIconArt;
+
+        this.itemCard.addEventListener("itemPress", this, "onItemCardListPress");
+    }
+
+    // @override ItemMenu
+    public function setConfig(a_config: Object)
+    {
+        super.setConfig(a_config);
+        
+        var itemList: TabularList = this.inventoryLists.itemList;
+        itemList.addDataProcessor(new InventoryDataSetter());
+        itemList.addDataProcessor(new InventoryIconSetter(a_config["Appearance"]));
+        itemList.addDataProcessor(new skyui.props.PropertyDataExtender(a_config["Appearance"], a_config["Properties"], "itemProperties", "itemIcons", "itemCompoundProperties"));
+        
+        var layout: ListLayout = skyui.components.list.ListLayoutManager.createLayout(a_config["ListLayout"], "ItemListLayout");
+        itemList.layout = layout;
+
+        // Not 100% happy with doing this here, but has to do for now.
+        if (this.inventoryLists.categoryList.selectedEntry)
+            layout.changeFilterFlag(this.inventoryLists.categoryList.selectedEntry.flag);
+    }
+
+    // @GFx
+    public function handleInput(details: InputDetails, pathToFocus: Array)
+    {
+        if (!this.bFadedIn)
+            return true;
+        
+        var nextClip = pathToFocus.shift();
+        if (nextClip.handleInput(details, pathToFocus))
+            return true;
+            
+        if (Shared.GlobalFunc.IsKeyPressed(details)) {
+            if (details.navEquivalent == gfx.ui.NavigationCode.TAB || details.navEquivalent == gfx.ui.NavigationCode.SHIFT_TAB ) {
+                this.startMenuFade();
+                gfx.io.GameDelegate.call("CloseTweenMenu", []);
+            } else if (!this.inventoryLists.itemList.disableInput) {
+                // Gamepad back || ALT (default) || 'P'
+                if (details.skseKeycode == this._switchTabKey || details.control == "Quick Magic")
+                    this.openMagicMenu(true);
             }
-         }
-      }
-      return true;
-   }
-   function AttemptEquip(a_slot, a_bCheckOverList)
-   {
-      var _loc2_ = a_bCheckOverList == undefined ? true : a_bCheckOverList;
-      if(this.shouldProcessItemsListInput(_loc2_) && this.confirmSelectedEntry())
-      {
-         gfx.io.GameDelegate.call("ItemSelect",[a_slot]);
-         this.checkBook(this.inventoryLists.itemList.selectedEntry);
-      }
-   }
-   function DropItem()
-   {
-      if(this.shouldProcessItemsListInput(false) && this.inventoryLists.itemList.selectedEntry != undefined)
-      {
-         if(this._quantityMinCount < 1 || this.inventoryLists.itemList.selectedEntry.count < this._quantityMinCount)
-         {
-            this.onQuantityMenuSelect({amount:1});
-         }
-         else
-         {
-            this.itemCard.ShowQuantityMenu(this.inventoryLists.itemList.selectedEntry.count);
-         }
-      }
-   }
-   function AttemptChargeItem()
-   {
-      if(this.inventoryLists.itemList.selectedIndex == -1)
-      {
-         return undefined;
-      }
-      if(this.shouldProcessItemsListInput(false) && this.itemCard.itemInfo.charge != undefined && this.itemCard.itemInfo.charge < 100)
-      {
-         gfx.io.GameDelegate.call("ShowSoulGemList",[]);
-      }
-   }
-   function SetPlatform(a_platform, a_bPS3Switch)
-   {
-      this.inventoryLists.zoomButtonHolder.gotoAndStop(1);
-      this.inventoryLists.zoomButtonHolder.ZoomButton._visible = a_platform != 0;
-      this.inventoryLists.zoomButtonHolder.ZoomButton.SetPlatform(a_platform,a_bPS3Switch);
-      super.SetPlatform(a_platform,a_bPS3Switch);
-   }
-   function ItemRotating()
-   {
-      this.inventoryLists.zoomButtonHolder.PlayForward(this.inventoryLists.zoomButtonHolder._currentframe);
-   }
-   function onExitMenuRectClick()
-   {
-      this.startMenuFade();
-      gfx.io.GameDelegate.call("ShowTweenMenu",[]);
-   }
-   function onFadeCompletion()
-   {
-      if(!this._bMenuClosing)
-      {
-         return undefined;
-      }
-      gfx.io.GameDelegate.call("CloseMenu",[]);
-      if(this._bSwitchMenus)
-      {
-         gfx.io.GameDelegate.call("CloseTweenMenu",[]);
-         skse.OpenMenu("MagicMenu");
-      }
-   }
-   function onShowItemsList(event)
-   {
-      super.onShowItemsList(event);
-      if(event.index != -1)
-      {
-         this.updateBottomBar(true);
-      }
-   }
-   function onItemHighlightChange(event)
-   {
-      super.onItemHighlightChange(event);
-      if(event.index != -1)
-      {
-         this.updateBottomBar(true);
-      }
-   }
-   function onHideItemsList(event)
-   {
-      super.onHideItemsList(event);
-      this.bottomBar.updatePerItemInfo({type:skyui.defines.Inventory.ICT_NONE});
-      this.updateBottomBar(false);
-   }
-   function onItemSelect(event)
-   {
-      if(event.entry.enabled && event.keyboardOrMouse != 0)
-      {
-         gfx.io.GameDelegate.call("ItemSelect",[]);
-         this.checkBook(event.entry);
-      }
-   }
-   function onQuantityMenuSelect(event)
-   {
-      gfx.io.GameDelegate.call("ItemDrop",[event.amount]);
-      gfx.io.GameDelegate.call("RequestItemCardInfo",[],this,"UpdateItemCardInfo");
-   }
-   function onMouseRotationFastClick(aiMouseButton)
-   {
-      gfx.io.GameDelegate.call("CheckForMouseEquip",[aiMouseButton],this,"AttemptEquip");
-   }
-   function onItemCardListPress(event)
-   {
-      gfx.io.GameDelegate.call("ItemCardListCallback",[event.index]);
-   }
-   function onItemCardSubMenuAction(event)
-   {
-      super.onItemCardSubMenuAction(event);
-      gfx.io.GameDelegate.call("QuantitySliderOpen",[event.opening]);
-      if(event.menu == "list")
-      {
-         if(event.opening == true)
-         {
-            this.navPanel.clearButtons();
-            this.navPanel.addButton({text:"$Select",controls:this._acceptControls});
-            this.navPanel.addButton({text:"$Cancel",controls:this._cancelControls});
-            this.navPanel.updateButtons(true);
-         }
-         else
-         {
-            gfx.io.GameDelegate.call("RequestItemCardInfo",[],this,"UpdateItemCardInfo");
+        }
+        
+        return true;
+    }
+
+    // @API
+    public function AttemptEquip(a_slot: Number, a_bCheckOverList: Boolean)
+    {
+        var bCheckOverList = a_bCheckOverList != undefined ? a_bCheckOverList : true;
+        if (this.shouldProcessItemsListInput(bCheckOverList) && this.confirmSelectedEntry()) {
+            gfx.io.GameDelegate.call("ItemSelect", [a_slot]);
+            this.checkBook(this.inventoryLists.itemList.selectedEntry);
+        }
+    }
+
+    // @API
+    public function DropItem()
+    {
+        if (this.shouldProcessItemsListInput(false) && this.inventoryLists.itemList.selectedEntry != undefined) {
+            if (this._quantityMinCount < 1 || (this.inventoryLists.itemList.selectedEntry.count < this._quantityMinCount))
+                this.onQuantityMenuSelect({amount:1});
+            else
+                this.itemCard.ShowQuantityMenu(this.inventoryLists.itemList.selectedEntry.count);
+        }
+    }
+
+    // @API
+    public function AttemptChargeItem()
+    {
+        if (this.inventoryLists.itemList.selectedIndex == -1)
+            return;
+        
+        if (this.shouldProcessItemsListInput(false) && this.itemCard.itemInfo.charge != undefined && this.itemCard.itemInfo.charge < 100)
+            gfx.io.GameDelegate.call("ShowSoulGemList", []);
+    }
+
+    // @override ItemMenu
+    public function SetPlatform(a_platform: Number, a_bPS3Switch: Boolean)
+    {		
+        this.inventoryLists.zoomButtonHolder.gotoAndStop(1);
+        this.inventoryLists.zoomButtonHolder.ZoomButton._visible = a_platform != 0;
+        this.inventoryLists.zoomButtonHolder.ZoomButton.SetPlatform(a_platform, a_bPS3Switch);
+        
+        super.SetPlatform(a_platform, a_bPS3Switch);
+    }
+
+    // @API
+    public function ItemRotating()
+    {
+        this.inventoryLists.zoomButtonHolder.PlayForward(this.inventoryLists.zoomButtonHolder._currentframe);
+    }
+    
+    
+/* PRIVATE FUNCTIONS */
+
+    // @override ItemMenu
+    private function onExitMenuRectClick()
+    {
+        this.startMenuFade();
+        gfx.io.GameDelegate.call("ShowTweenMenu", []);
+    }
+
+    private function onFadeCompletion()
+    {
+        if (!this._bMenuClosing)
+            return;
+
+        gfx.io.GameDelegate.call("CloseMenu", []);
+        if (this._bSwitchMenus) {
+            gfx.io.GameDelegate.call("CloseTweenMenu",[]);
+            skse.OpenMenu("MagicMenu");
+        }
+    }
+
+    // @override ItemMenu
+    private function onShowItemsList(event: Object)
+    {
+        super.onShowItemsList(event);
+        
+        if (event.index != -1)
             this.updateBottomBar(true);
-         }
-      }
-   }
-   function openMagicMenu(a_bFade)
-   {
-      if(a_bFade)
-      {
-         this._bSwitchMenus = true;
-         this.startMenuFade();
-      }
-      else
-      {
-         this.saveIndices();
-         gfx.io.GameDelegate.call("CloseMenu",[]);
-         gfx.io.GameDelegate.call("CloseTweenMenu",[]);
-         skse.OpenMenu("MagicMenu");
-      }
-   }
-   function startMenuFade()
-   {
-      this.inventoryLists.hidePanel();
-      this.ToggleMenuFade();
-      this.saveIndices();
-      this._bMenuClosing = true;
-   }
-   function updateBottomBar(a_bSelected)
-   {
-      this.navPanel.clearButtons();
-      if(a_bSelected)
-      {
-         this.navPanel.addButton(this.getEquipButtonData(this.itemCard.itemInfo.type));
-         this.navPanel.addButton({text:"$Drop",controls:skyui.defines.Input.XButton});
-         if(this.inventoryLists.itemList.selectedEntry.filterFlag & this.inventoryLists.categoryList.entryList[0].flag != 0)
-         {
-            this.navPanel.addButton({text:"$Unfavorite",controls:skyui.defines.Input.YButton});
-         }
-         else
-         {
-            this.navPanel.addButton({text:"$Favorite",controls:skyui.defines.Input.YButton});
-         }
-         if(this.itemCard.itemInfo.charge != undefined && this.itemCard.itemInfo.charge < 100)
-         {
-            this.navPanel.addButton({text:"$Charge",controls:skyui.defines.Input.ChargeItem});
-         }
-      }
-      else
-      {
-         this.navPanel.addButton({text:"$Exit",controls:this._cancelControls});
-         this.navPanel.addButton({text:"$Search",controls:this._searchControls});
-         if(this._platform != 0)
-         {
-            this.navPanel.addButton({text:"$Column",controls:this._sortColumnControls});
-            this.navPanel.addButton({text:"$Order",controls:this._sortOrderControls});
-         }
-         this.navPanel.addButton({text:"$Magic",controls:this._switchControls});
-      }
-      this.navPanel.updateButtons(true);
-   }
+    }
+
+    private function onItemHighlightChange(event: Object)
+    {
+        super.onItemHighlightChange(event);
+        
+        if (event.index != -1)
+            this.updateBottomBar(true);
+            
+    }
+
+    // @override ItemMenu
+    private function onHideItemsList(event: Object)
+    {
+        super.onHideItemsList(event);
+
+        this.bottomBar.updatePerItemInfo({type: skyui.defines.Inventory.ICT_NONE});
+        
+        this.updateBottomBar(false);
+    }
+
+    // @override ItemMenu
+    private function onItemSelect(event: Object)
+    {
+        if (event.entry.enabled && event.keyboardOrMouse != 0) {
+            gfx.io.GameDelegate.call("ItemSelect", []);
+            this.checkBook(event.entry);
+        }
+    }
+
+    // @override ItemMenu
+    private function onQuantityMenuSelect(event: Object)
+    {
+        gfx.io.GameDelegate.call("ItemDrop", [event.amount]);
+        
+        // Bug Fix: ItemCard does not update when attempting to drop quest items through the quantity menu
+        //   so let's request an update even though it may be redundant.
+        gfx.io.GameDelegate.call("RequestItemCardInfo", [], this, "UpdateItemCardInfo");
+    }
+
+
+    private function onMouseRotationFastClick(aiMouseButton: Number)
+    {
+        gfx.io.GameDelegate.call("CheckForMouseEquip", [aiMouseButton], this, "AttemptEquip");
+    }
+
+    private function onItemCardListPress(event: Object)
+    {
+        gfx.io.GameDelegate.call("ItemCardListCallback", [event.index]);
+    }
+
+    // @override ItemMenu
+    private function onItemCardSubMenuAction(event: Object)
+    {
+        super.onItemCardSubMenuAction(event);
+        gfx.io.GameDelegate.call("QuantitySliderOpen", [event.opening]);
+        
+        if (event.menu == "list") {
+            if (event.opening == true) {
+                this.navPanel.clearButtons();
+                this.navPanel.addButton({text: "$Select", controls: this._acceptControls});
+                this.navPanel.addButton({text: "$Cancel", controls: this._cancelControls});
+                this.navPanel.updateButtons(true);
+            } else {
+                gfx.io.GameDelegate.call("RequestItemCardInfo", [], this, "UpdateItemCardInfo");
+                this.updateBottomBar(true);
+            }
+        }
+    }
+    
+    private function openMagicMenu(a_bFade: Boolean)
+    {
+        if (a_bFade) {
+            this._bSwitchMenus = true;
+            this.startMenuFade();
+        } else {
+            this.saveIndices();
+            gfx.io.GameDelegate.call("CloseMenu",[]);
+            gfx.io.GameDelegate.call("CloseTweenMenu",[]);
+            skse.OpenMenu("MagicMenu");
+        }
+    }
+    
+    private function startMenuFade()
+    {
+        this.inventoryLists.hidePanel();
+        this.ToggleMenuFade();
+        this.saveIndices();
+        this._bMenuClosing = true;
+    }
+    
+    // @override ItemMenu
+    private function updateBottomBar(a_bSelected: Boolean)
+    {
+        this.navPanel.clearButtons();
+        
+        if (a_bSelected) {
+            this.navPanel.addButton(this.getEquipButtonData(this.itemCard.itemInfo.type));
+            this.navPanel.addButton({text: "$Drop", controls: skyui.defines.Input.XButton});
+            
+            if (this.inventoryLists.itemList.selectedEntry.filterFlag & this.inventoryLists.categoryList.entryList[0].flag != 0)
+                this.navPanel.addButton({text: "$Unfavorite", controls: skyui.defines.Input.YButton});
+            else
+                this.navPanel.addButton({text: "$Favorite", controls: skyui.defines.Input.YButton});
+    
+            if (this.itemCard.itemInfo.charge != undefined && this.itemCard.itemInfo.charge < 100)
+                this.navPanel.addButton({text: "$Charge", controls: skyui.defines.Input.ChargeItem});
+                
+        } else {
+            this.navPanel.addButton({text: "$Exit", controls: this._cancelControls});
+            this.navPanel.addButton({text: "$Search", controls: this._searchControls});
+            if (this._platform != 0) {
+                this.navPanel.addButton({text: "$Column", controls: this._sortColumnControls});
+                this.navPanel.addButton({text: "$Order", controls: this._sortOrderControls});
+            }
+            this.navPanel.addButton({text: "$Magic", controls: this._switchControls});
+        }
+        
+        this.navPanel.updateButtons(true);
+    }
 }

--- a/source/actionscript/ItemMenus/ItemCard.as
+++ b/source/actionscript/ItemMenus/ItemCard.as
@@ -1,816 +1,737 @@
 class ItemCard extends MovieClip
 {
-   var ActiveEffectTimeValue;
-   var ApparelArmorValue;
-   var ApparelEnchantedLabel;
-   var ApparelWarmthValue;
-   var BookDescriptionLabel;
-   var ButtonRect;
-   var ButtonRect_mc;
-   var CardList_mc;
-   var ChargeMeter_Default;
-   var ChargeMeter_Enchantment;
-   var ChargeMeter_SoulGem;
-   var ChargeMeter_Weapon;
-   var EnchantingSlider_mc;
-   var Enchanting_Background;
-   var Enchanting_Slim_Background;
-   var EnchantmentLabel;
-   var InputHandler;
-   var ItemCardMeters;
-   var ItemList;
-   var ItemName;
-   var ItemText;
-   var ItemValueText;
-   var ItemWeightText;
-   var LastUpdateObj;
-   var ListChargeMeter;
-   var MagicCostLabel;
-   var MagicCostPerSec;
-   var MagicCostTimeLabel;
-   var MagicCostTimeValue;
-   var MagicCostValue;
-   var MagicEffectsLabel;
-   var MessageText;
-   var PoisonInstance;
-   var PotionsLabel;
-   var PrevFocus;
-   var QuantitySlider_mc;
-   var SecsText;
-   var ShoutCostValue;
-   var ShoutEffectsLabel;
-   var SkillLevelText;
-   var SkillTextInstance;
-   var SliderValueText;
-   var SoulLevel;
-   var StolenTextInstance;
-   var TotalChargesValue;
-   var WeaponChargeMeter;
-   var WeaponDamageValue;
-   var WeaponEnchantedLabel;
-   var _bEditNameMode;
-   var bFadedIn;
-   var dispatchEvent;
-   function ItemCard()
-   {
-      super();
-      Shared.GlobalFunc.MaintainTextFormat();
-      Shared.GlobalFunc.AddReverseFunctions();
-      gfx.events.EventDispatcher.initialize(this);
-      this.QuantitySlider_mc = this.QuantitySlider_mc;
-      this.ButtonRect_mc = this.ButtonRect;
-      this.ItemList = this.CardList_mc.List_mc;
-      this.SetupItemName();
-      this.bFadedIn = false;
-      this.InputHandler = undefined;
-      this._bEditNameMode = false;
-   }
-   function get bEditNameMode()
-   {
-      return this._bEditNameMode;
-   }
-   function GetItemName()
-   {
-      return this.ItemName;
-   }
-   function SetupItemName(aPrevName)
-   {
-      this.ItemName = this.ItemText.ItemTextField;
-      if(this.ItemName != undefined)
-      {
-         this.ItemName.textAutoSize = "shrink";
-         this.ItemName.htmlText = aPrevName;
-         this.ItemName.selectable = false;
-      }
-   }
-   function onLoad()
-   {
-      this.QuantitySlider_mc.addEventListener("change",this,"onSliderChange");
-      this.ButtonRect_mc.AcceptMouseButton.addEventListener("click",this,"onAcceptMouseClick");
-      this.ButtonRect_mc.CancelMouseButton.addEventListener("click",this,"onCancelMouseClick");
-      this.ButtonRect_mc.AcceptMouseButton.SetPlatform(0,false);
-      this.ButtonRect_mc.CancelMouseButton.SetPlatform(0,false);
-   }
-   function SetPlatform(aiPlatform, abPS3Switch)
-   {
-      this.ButtonRect_mc.AcceptGamepadButton._visible = aiPlatform != 0;
-      this.ButtonRect_mc.CancelGamepadButton._visible = aiPlatform != 0;
-      this.ButtonRect_mc.AcceptMouseButton._visible = aiPlatform == 0;
-      this.ButtonRect_mc.CancelMouseButton._visible = aiPlatform == 0;
-      if(aiPlatform != 0)
-      {
-         this.ButtonRect_mc.AcceptGamepadButton.SetPlatform(aiPlatform,abPS3Switch);
-         this.ButtonRect_mc.CancelGamepadButton.SetPlatform(aiPlatform,abPS3Switch);
-      }
-      this.ItemList.SetPlatform(aiPlatform,abPS3Switch);
-   }
-   function onAcceptMouseClick()
-   {
-      var _loc2_;
-      if(this.ButtonRect_mc._alpha == 100 && this.ButtonRect_mc.AcceptMouseButton._visible == true && this.InputHandler != undefined)
-      {
-         _loc2_ = {value:"keyDown",navEquivalent:gfx.ui.NavigationCode.ENTER};
-         this.InputHandler(_loc2_);
-      }
-   }
-   function onCancelMouseClick()
-   {
-      var _loc2_;
-      if(this.ButtonRect_mc._alpha == 100 && this.ButtonRect_mc.CancelMouseButton._visible == true && this.InputHandler != undefined)
-      {
-         _loc2_ = {value:"keyDown",navEquivalent:gfx.ui.NavigationCode.TAB};
-         this.InputHandler(_loc2_);
-      }
-   }
-   function FadeInCard()
-   {
-      if(this.bFadedIn)
-      {
-         return undefined;
-      }
-      this._visible = true;
-      this._parent.gotoAndPlay("fadeIn");
-      this.bFadedIn = true;
-   }
-   function FadeOutCard()
-   {
-      if(this.bFadedIn)
-      {
-         this._parent.gotoAndPlay("fadeOut");
-         this.bFadedIn = false;
-      }
-   }
-   function get quantitySlider()
-   {
-      return this.QuantitySlider_mc;
-   }
-   function get weaponChargeMeter()
-   {
-      return this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON];
-   }
-   function get itemInfo()
-   {
-      return this.LastUpdateObj;
-   }
-   function set itemInfo(aUpdateObj)
-   {
-      this.ItemCardMeters = new Array();
-      var _loc3_ = this.ItemName != undefined ? this.ItemName.htmlText : "";
-      var _loc4_ = aUpdateObj.type;
-      var _loc5_;
-      var _loc6_;
-      var _loc7_;
-      var _loc8_;
-      var _loc9_;
-      var _loc10_;
-      var _loc11_;
-      var _loc12_;
-      switch(_loc4_)
-      {
-         case skyui.defines.Inventory.ICT_ARMOR:
-            if(aUpdateObj.effects.length == 0)
-            {
-               if(aUpdateObj.warmth != undefined)
-               {
-                  this.gotoAndStop("Apparel_Survival_reg");
-               }
-               else
-               {
-                  this.gotoAndStop("Apparel_reg");
-               }
-            }
-            else if(aUpdateObj.warmth != undefined)
-            {
-               this.gotoAndStop("Apparel_Survival_Enchanted");
-            }
-            else
-            {
-               this.gotoAndStop("Apparel_Enchanted");
-            }
-            this.ApparelWarmthValue.textAutoSize = "shrink";
-            this.ApparelWarmthValue.SetText(aUpdateObj.warmth);
-            this.ApparelArmorValue.textAutoSize = "shrink";
-            this.ApparelArmorValue.SetText(aUpdateObj.armor);
-            this.ApparelEnchantedLabel.enableShrinkToFit = true;
-            this.ApparelEnchantedLabel.overflowMode = "ellipsis";
-            this.ApparelEnchantedLabel.SetText(aUpdateObj.effects, true);
-            this.SkillTextInstance.text = aUpdateObj.skillText;
-            break;
-         case skyui.defines.Inventory.ICT_WEAPON:
-            if(aUpdateObj.effects.length == 0)
-            {
-               this.gotoAndStop("Weapons_reg");
-            }
-            else
-            {
-               this.gotoAndStop("Weapons_Enchanted");
-               if(this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON] == undefined)
-               {
-                  this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON] = new Components.DeltaMeter(this.WeaponChargeMeter.MeterInstance);
-               }
-               if(aUpdateObj.usedCharge != undefined && aUpdateObj.charge != undefined)
-               {
-                  this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON].SetPercent(aUpdateObj.usedCharge);
-                  this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON].SetDeltaPercent(aUpdateObj.charge);
-                  this.WeaponChargeMeter._visible = true;
-               }
-               else
-               {
-                  this.WeaponChargeMeter._visible = false;
-               }
-            }
-            _loc5_ = aUpdateObj.poisoned != true ? "Off" : "On";
-            this.PoisonInstance.gotoAndStop(_loc5_);
-            this.WeaponDamageValue.textAutoSize = "shrink";
-            this.WeaponDamageValue.SetText(aUpdateObj.damage);
-            this.WeaponEnchantedLabel.enableShrinkToFit = true;
-            this.WeaponEnchantedLabel.overflowMode = "ellipsis";
-            this.WeaponEnchantedLabel.SetText(aUpdateObj.effects, true);
-            break;
-         case skyui.defines.Inventory.ICT_BOOK:
-            if(aUpdateObj.description != undefined && aUpdateObj.description != "")
-            {
-               this.gotoAndStop("Books_Description");
-               this.BookDescriptionLabel.enableShrinkToFit = true;
-               this.BookDescriptionLabel.overflowMode = "ellipsis";
-               this.BookDescriptionLabel.SetText(aUpdateObj.description, true);
-               break;
-            }
-            this.gotoAndStop("Books_reg");
-            break;
-         case skyui.defines.Inventory.ICT_POTION:
-         case skyui.defines.Inventory.ICT_FOOD:
-            this.gotoAndStop("Potions_reg");
-            this.PotionsLabel.enableShrinkToFit = true;
-            this.PotionsLabel.overflowMode = "ellipsis";
-            this.PotionsLabel.SetText(aUpdateObj.effects, true);
-            this.SkillTextInstance.text = aUpdateObj.skillName != undefined ? aUpdateObj.skillName : "";
-            break;
-         case skyui.defines.Inventory.ICT_SPELL_DEFAULT:
-            this.gotoAndStop("Power_reg");
-            this.MagicEffectsLabel.enableShrinkToFit = true;
-            this.MagicEffectsLabel.overflowMode = "ellipsis";
-            this.MagicEffectsLabel.SetText(aUpdateObj.effects,true);
-            if(aUpdateObj.spellCost <= 0)
-            {
-               this.MagicCostValue._alpha = 0;
-               this.MagicCostTimeValue._alpha = 0;
-               this.MagicCostLabel._alpha = 0;
-               this.MagicCostTimeLabel._alpha = 0;
-               this.MagicCostPerSec._alpha = 0;
-               break;
-            }
-            this.MagicCostValue._alpha = 100;
-            this.MagicCostLabel._alpha = 100;
-            this.MagicCostValue.text = aUpdateObj.spellCost.toString();
-            break;
-         case skyui.defines.Inventory.ICT_SPELL:
-            _loc6_ = aUpdateObj.castTime == 0;
-            if(_loc6_)
-            {
-               this.gotoAndStop("Magic_time_label");
-            }
-            else
-            {
-               this.gotoAndStop("Magic_reg");
-            }
-            this.SkillLevelText.text = aUpdateObj.castLevel.toString();
-            this.MagicEffectsLabel.enableShrinkToFit = true;
-            this.MagicEffectsLabel.overflowMode = "ellipsis";
-            this.MagicEffectsLabel.SetText(aUpdateObj.effects,true);
-            this.MagicCostValue.textAutoSize = "shrink";
-            this.MagicCostTimeValue.textAutoSize = "shrink";
-            if(_loc6_)
-            {
-               this.MagicCostTimeValue.text = aUpdateObj.spellCost.toString();
-               break;
-            }
-            this.MagicCostValue.text = aUpdateObj.spellCost.toString();
-            break;
-         case skyui.defines.Inventory.ICT_INGREDIENT:
-            this.gotoAndStop("Ingredients_reg");
-            _loc7_ = 0;
-            while(_loc7_ < 4)
-            {
-               this["EffectLabel" + _loc7_].textAutoSize = "shrink";
-               if(aUpdateObj["itemEffect" + _loc7_] != undefined && aUpdateObj["itemEffect" + _loc7_] != "")
-               {
-                  this["EffectLabel" + _loc7_].textColor = 16777215;
-                  this["EffectLabel" + _loc7_].SetText(aUpdateObj["itemEffect" + _loc7_]);
-               }
-               else if(_loc7_ < aUpdateObj.numItemEffects)
-               {
-                  this["EffectLabel" + _loc7_].textColor = 10066329;
-                  this["EffectLabel" + _loc7_].SetText("$UNKNOWN");
-               }
-               else
-               {
-                  this["EffectLabel" + _loc7_].SetText("");
-               }
-               _loc7_ += 1;
-            }
-            break;
-         case skyui.defines.Inventory.ICT_MISC:
-            this.gotoAndStop("Misc_reg");
-            break;
-         case skyui.defines.Inventory.ICT_SHOUT:
-            this.gotoAndStop("Shouts_reg");
-            _loc8_ = 0;
-            _loc7_ = 0;
-            while(_loc7_ < 3)
-            {
-               if(aUpdateObj["word" + _loc7_] != undefined && aUpdateObj["word" + _loc7_] != "" && aUpdateObj["unlocked" + _loc7_] == true)
-               {
-                  _loc8_ = _loc7_;
-               }
-               _loc7_ += 1;
-            }
-            _loc7_ = 0;
-            while(_loc7_ < 3)
-            {
-               _loc9_ = aUpdateObj["dragonWord" + _loc7_] != undefined ? aUpdateObj["dragonWord" + _loc7_] : "";
-               _loc10_ = aUpdateObj["word" + _loc7_] != undefined ? aUpdateObj["word" + _loc7_] : "";
-               _loc11_ = aUpdateObj["unlocked" + _loc7_] == true;
-               this["ShoutTextInstance" + _loc7_].DragonShoutLabelInstance.ShoutWordsLabel.textAutoSize = "shrink";
-               this["ShoutTextInstance" + _loc7_].ShoutLabelInstance.ShoutWordsLabelTranslation.textAutoSize = "shrink";
-               this["ShoutTextInstance" + _loc7_].DragonShoutLabelInstance.ShoutWordsLabel.SetText(_loc9_.toUpperCase());
-               this["ShoutTextInstance" + _loc7_].ShoutLabelInstance.ShoutWordsLabelTranslation.SetText(_loc10_);
-               if(_loc11_ && _loc7_ == _loc8_ && this.LastUpdateObj.soulSpent == true)
-               {
-                  this["ShoutTextInstance" + _loc7_].gotoAndPlay("Learn");
-               }
-               else if(_loc11_)
-               {
-                  this["ShoutTextInstance" + _loc7_].gotoAndStop("Known");
-                  this["ShoutTextInstance" + _loc7_].gotoAndStop("Known");
-               }
-               else
-               {
-                  this["ShoutTextInstance" + _loc7_].gotoAndStop("Unlocked");
-                  this["ShoutTextInstance" + _loc7_].gotoAndStop("Unlocked");
-               }
-               _loc7_ += 1;
-            }
-            this.ShoutEffectsLabel.enableShrinkToFit = true;
-            this.ShoutEffectsLabel.overflowMode = "ellipsis";
-            this.ShoutEffectsLabel.SetText(aUpdateObj.effects, true);
-            this.ShoutCostValue.text = aUpdateObj.spellCost.toString();
-            break;
-         case skyui.defines.Inventory.ICT_ACTIVE_EFFECT:
-            this.gotoAndStop("ActiveEffects");
-            this.MagicEffectsLabel.enableShrinkToFit = true;
-            this.MagicEffectsLabel.overflowMode = "ellipsis";
-            this.MagicEffectsLabel.SetText(aUpdateObj.effects,true);
-            if(aUpdateObj.timeRemaining > 0)
-            {
-               _loc12_ = Math.floor(aUpdateObj.timeRemaining);
-               this.ActiveEffectTimeValue._alpha = 100;
-               this.SecsText._alpha = 100;
-               if(_loc12_ >= 3600)
-               {
-                  _loc12_ = Math.floor(_loc12_ / 3600);
-                  this.ActiveEffectTimeValue.text = _loc12_.toString();
-                  if(_loc12_ == 1)
-                  {
-                     this.SecsText.text = "$hour";
-                     break;
-                  }
-                  this.SecsText.text = "$hours";
-                  break;
-               }
-               if(_loc12_ >= 60)
-               {
-                  _loc12_ = Math.floor(_loc12_ / 60);
-                  this.ActiveEffectTimeValue.text = _loc12_.toString();
-                  if(_loc12_ == 1)
-                  {
-                     this.SecsText.text = "$min";
-                     break;
-                  }
-                  this.SecsText.text = "$mins";
-                  break;
-               }
-               this.ActiveEffectTimeValue.text = _loc12_.toString();
-               if(_loc12_ == 1)
-               {
-                  this.SecsText.text = "$sec";
-                  break;
-               }
-               this.SecsText.text = "$secs";
-               break;
-            }
-            this.ActiveEffectTimeValue._alpha = 0;
-            this.SecsText._alpha = 0;
-            break;
-         case skyui.defines.Inventory.ICT_SOUL_GEMS:
-            this.gotoAndStop("SoulGem");
-            this.SoulLevel.text = aUpdateObj.soulLVL;
-            break;
-         case skyui.defines.Inventory.ICT_LIST:
-            this.gotoAndStop("Item_list");
-            if(aUpdateObj.listItems != undefined)
-            {
-               this.ItemList.entryList = aUpdateObj.listItems;
-               this.ItemList.InvalidateData();
-               this.ItemCardMeters[skyui.defines.Inventory.ICT_LIST] = new Components.DeltaMeter(this.ListChargeMeter.MeterInstance);
-               this.ItemCardMeters[skyui.defines.Inventory.ICT_LIST].SetPercent(aUpdateObj.currentCharge);
-               this.ItemCardMeters[skyui.defines.Inventory.ICT_LIST].SetDeltaPercent(aUpdateObj.currentCharge + this.ItemList.selectedEntry.chargeAdded);
-               this.OpenListMenu();
-            }
-            break;
-         case skyui.defines.Inventory.ICT_CRAFT_ENCHANTING:
-         case skyui.defines.Inventory.ICT_HOUSE_PART:
-            if(aUpdateObj.type == skyui.defines.Inventory.ICT_HOUSE_PART)
-            {
-               this.gotoAndStop("Magic_short");
-               if(aUpdateObj.effects == undefined)
-               {
-                  this.MagicEffectsLabel.SetText("",true);
-               }
-               else
-               {
-                  this.MagicEffectsLabel.SetText(aUpdateObj.effects,true);
-               }
-            }
-            else if(aUpdateObj.sliderShown == true)
-            {
-               this.gotoAndStop("Craft_Enchanting");
-               this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON] = new Components.DeltaMeter(this.ChargeMeter_Default.MeterInstance);
-               if(aUpdateObj.totalCharges != undefined && aUpdateObj.totalCharges != 0)
-               {
-                  this.TotalChargesValue.text = aUpdateObj.totalCharges;
-               }
-            }
-            else if(aUpdateObj.damage == undefined)
-            {
-               if(aUpdateObj.armor == undefined)
-               {
-                  if(aUpdateObj.soulLVL == undefined)
-                  {
-                     if(this.QuantitySlider_mc._alpha == 0)
-                     {
-                        this.gotoAndStop("Craft_Enchanting_Enchantment");
-                        this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON] = new Components.DeltaMeter(this.ChargeMeter_Enchantment.MeterInstance);
-                     }
-                  }
-                  else
-                  {
-                     this.gotoAndStop("Craft_Enchanting_SoulGem");
-                     this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON] = new Components.DeltaMeter(this.ChargeMeter_SoulGem.MeterInstance);
-                     this.SoulLevel.text = aUpdateObj.soulLVL;
-                  }
-               }
-               else
-               {
-                  this.gotoAndStop("Craft_Enchanting_Armor");
-                  this.ApparelArmorValue.SetText(aUpdateObj.armor);
-                  this.SkillTextInstance.text = aUpdateObj.skillText;
-               }
-            }
-            else
-            {
-               this.gotoAndStop("Craft_Enchanting_Weapon");
-               this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON] = new Components.DeltaMeter(this.ChargeMeter_Weapon.MeterInstance);
-               this.WeaponDamageValue.textAutoSize = "shrink";
-               this.WeaponDamageValue.SetText(aUpdateObj.damage);
-            }
-            if(aUpdateObj.usedCharge == 0 && aUpdateObj.totalCharges == 0)
-            {
-               this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON].DeltaMeterMovieClip._parent._parent._alpha = 0;
-            }
-            else if(aUpdateObj.usedCharge != undefined)
-            {
-               this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON].SetPercent(aUpdateObj.usedCharge);
-            }
-            if(aUpdateObj.effects != undefined && aUpdateObj.effects.length > 0)
-            {
-               if(this.EnchantmentLabel != undefined)
-               {
-                  this.EnchantmentLabel.enableShrinkToFit = true;
-                  this.EnchantmentLabel.overflowMode = "ellipsis";
-                  this.EnchantmentLabel.SetText(aUpdateObj.effects,true);
-               }
-               this.WeaponChargeMeter._alpha = 100;
-               this.Enchanting_Background._alpha = 60;
-               this.Enchanting_Slim_Background._alpha = 0;
-               break;
-            }
-            if(this.EnchantmentLabel != undefined)
-            {
-               this.EnchantmentLabel.SetText("",true);
-            }
-            this.WeaponChargeMeter._alpha = 0;
-            this.Enchanting_Slim_Background._alpha = 60;
-            this.Enchanting_Background._alpha = 0;
-            break;
-         case skyui.defines.Inventory.ICT_KEY:
-         case skyui.defines.Inventory.ICT_NONE:
-         default:
-            this.gotoAndStop("Empty");
-      }
-      this.SetupItemName(_loc3_);
-      var _loc13_;
-      if(aUpdateObj.name != undefined)
-      {
-         _loc13_ = !(aUpdateObj.count != undefined && aUpdateObj.count > 1) ? aUpdateObj.name : aUpdateObj.name + " (" + aUpdateObj.count + ")";
-         this.ItemText.ItemTextField.SetText(!(this._bEditNameMode || aUpdateObj.upperCaseName == false) ? _loc13_.toUpperCase() : _loc13_,false);
-         this.ItemText.ItemTextField.textColor = aUpdateObj.negativeEffect != true ? 16777215 : 16711680;
-      }
-      this.ItemValueText.textAutoSize = "shrink";
-      this.ItemWeightText.textAutoSize = "shrink";
-      if(aUpdateObj.value != undefined && this.ItemValueText != undefined)
-      {
-         this.ItemValueText.SetText(aUpdateObj.value.toString());
-      }
-      if(aUpdateObj.weight != undefined && this.ItemWeightText != undefined)
-      {
-         this.ItemWeightText.SetText(this.RoundDecimal(aUpdateObj.weight,2).toString());
-      }
-      this.StolenTextInstance._visible = aUpdateObj.stolen == true;
-      this.LastUpdateObj = aUpdateObj;
-   }
-   function RoundDecimal(aNumber, aPrecision)
-   {
-      var _loc3_ = Math.pow(10,aPrecision);
-      return Math.round(_loc3_ * aNumber) / _loc3_;
-   }
-   function PrepareInputElements(aActiveClip)
-   {
-      var _loc3_ = 92;
-      var _loc4_ = 98;
-      var _loc5_ = 147.3;
-      var _loc6_ = 130;
-      var _loc7_ = 166;
-      switch(aActiveClip)
-      {
-         case this.EnchantingSlider_mc:
-            this.QuantitySlider_mc._y = -100;
-            this.ButtonRect._y = _loc7_;
-            this.EnchantingSlider_mc._y = _loc5_;
-            this.CardList_mc._y = -100;
-            this.QuantitySlider_mc._alpha = 0;
-            this.ButtonRect._alpha = 100;
-            this.EnchantingSlider_mc._alpha = 100;
-            this.CardList_mc._alpha = 0;
-            break;
-         case this.QuantitySlider_mc:
-            this.QuantitySlider_mc._y = _loc3_;
-            this.ButtonRect._y = _loc6_;
-            this.EnchantingSlider_mc._y = -100;
-            this.CardList_mc._y = -100;
-            this.QuantitySlider_mc._alpha = 100;
-            this.ButtonRect._alpha = 100;
-            this.EnchantingSlider_mc._alpha = 0;
-            this.CardList_mc._alpha = 0;
-            break;
-         case this.CardList_mc:
-            this.QuantitySlider_mc._y = -100;
-            this.ButtonRect._y = -100;
-            this.EnchantingSlider_mc._y = -100;
-            this.CardList_mc._y = _loc4_;
-            this.QuantitySlider_mc._alpha = 0;
-            this.ButtonRect._alpha = 0;
-            this.EnchantingSlider_mc._alpha = 0;
-            this.CardList_mc._alpha = 100;
-            break;
-         case this.ButtonRect:
-            this.QuantitySlider_mc._y = -100;
-            this.ButtonRect._y = _loc6_;
-            this.EnchantingSlider_mc._y = -100;
-            this.CardList_mc._y = -100;
-            this.QuantitySlider_mc._alpha = 0;
-            this.ButtonRect._alpha = 100;
-            this.EnchantingSlider_mc._alpha = 0;
-            this.CardList_mc._alpha = 0;
-         default:
+    var ActiveEffectTimeValue: TextField;
+    var ApparelArmorValue: TextField;
+    var ApparelEnchantedLabel: TextField;
+    var BookDescriptionLabel: TextField;
+    var EnchantmentLabel: TextField;
+    var ItemName: TextField;
+    var ItemText: TextField;
+    var ItemValueText: TextField;
+    var ItemWeightText: TextField;
+    var MagicCostLabel: TextField;
+    var MagicCostPerSec: TextField;
+    var MagicCostTimeLabel: TextField;
+    var MagicCostTimeValue: TextField;
+    var MagicCostValue: TextField;
+    var MagicEffectsLabel: TextField;
+    var MessageText: TextField;
+    var PotionsLabel: TextField;
+    var SecsText: TextField;
+    var ShoutCostValue: TextField;
+    var ShoutEffectsLabel: TextField;
+    var SkillLevelText: TextField;
+    var SkillTextInstance: TextField;
+    var SliderValueText: TextField;
+    var SoulLevel: TextField;
+    var StolenTextInstance: TextField;
+    var TotalChargesValue: TextField;
+    var WeaponDamageValue: TextField;
+    var WeaponEnchantedLabel: TextField;
+    
+    var ButtonRect: MovieClip;
+    var ButtonRect_mc: MovieClip;
+    var CardList_mc: MovieClip;
+    var ChargeMeter_Default: MovieClip;
+    var ChargeMeter_Enchantment: MovieClip;
+    var ChargeMeter_SoulGem: MovieClip;
+    var ChargeMeter_Weapon: MovieClip;
+    var EnchantingSlider_mc: MovieClip;
+    var Enchanting_Background: MovieClip;
+    var Enchanting_Slim_Background: MovieClip;
+    var ItemList: MovieClip;
+    var ListChargeMeter: MovieClip;
+    var PoisonInstance: MovieClip;
+    var PrevFocus: MovieClip;
+    var QuantitySlider_mc: MovieClip;
+    var WeaponChargeMeter: MovieClip;
+    
+    var InputHandler: Function;
+    var dispatchEvent: Function;
+    
+    var ItemCardMeters: Object;
+    var LastUpdateObj: Object;
+    
+    var _bEditNameMode: Boolean;
+    var bFadedIn: Boolean;
+    
+
+    function ItemCard()
+    {
+        super();
+        Shared.GlobalFunc.MaintainTextFormat();
+        Shared.GlobalFunc.AddReverseFunctions();
+        gfx.events.EventDispatcher.initialize(this);
+        this.QuantitySlider_mc = this.QuantitySlider_mc;
+        this.ButtonRect_mc = this.ButtonRect;
+        this.ItemList = this.CardList_mc.List_mc;
+        this.SetupItemName();
+        this.bFadedIn = false;
+        this.InputHandler = undefined;
+        this._bEditNameMode = false;
+    }
+
+    function get bEditNameMode()
+    {
+        return this._bEditNameMode;
+    }
+
+    function GetItemName()
+    {
+        return this.ItemName;
+    }
+
+    function SetupItemName(aPrevName: String)
+    {
+        this.ItemName = this.ItemText.ItemTextField;
+        if (this.ItemName != undefined) {
+            this.ItemName.textAutoSize = "shrink";
+            this.ItemName.htmlText = aPrevName;
+            this.ItemName.selectable = false;
+        }
+    }
+
+    function onLoad()
+    {
+        this.QuantitySlider_mc.addEventListener("change", this, "onSliderChange");
+        this.ButtonRect_mc.AcceptMouseButton.addEventListener("click", this, "onAcceptMouseClick");
+        this.ButtonRect_mc.CancelMouseButton.addEventListener("click", this, "onCancelMouseClick");
+        this.ButtonRect_mc.AcceptMouseButton.SetPlatform(0, false);
+        this.ButtonRect_mc.CancelMouseButton.SetPlatform(0, false);
+    }
+
+    function SetPlatform(aiPlatform: Number, abPS3Switch: Boolean)
+    {
+        this.ButtonRect_mc.AcceptGamepadButton._visible = aiPlatform != 0;
+        this.ButtonRect_mc.CancelGamepadButton._visible = aiPlatform != 0;
+        this.ButtonRect_mc.AcceptMouseButton._visible = aiPlatform == 0;
+        this.ButtonRect_mc.CancelMouseButton._visible = aiPlatform == 0;
+        if (aiPlatform != 0) {
+            this.ButtonRect_mc.AcceptGamepadButton.SetPlatform(aiPlatform, abPS3Switch);
+            this.ButtonRect_mc.CancelGamepadButton.SetPlatform(aiPlatform, abPS3Switch);
+        }
+        this.ItemList.SetPlatform(aiPlatform, abPS3Switch);
+    }
+
+    function onAcceptMouseClick()
+    {
+        if (this.ButtonRect_mc._alpha == 100 && this.ButtonRect_mc.AcceptMouseButton._visible == true && this.InputHandler != undefined) {
+            var inputEnterObj: Object = {value: "keyDown", navEquivalent: gfx.ui.NavigationCode.ENTER};
+            this.InputHandler(inputEnterObj);
+        }
+    }
+
+    function onCancelMouseClick()
+    {
+        if (this.ButtonRect_mc._alpha == 100 && this.ButtonRect_mc.CancelMouseButton._visible == true && this.InputHandler != undefined) {
+            var inputTabObj: Object = {value: "keyDown", navEquivalent: gfx.ui.NavigationCode.TAB};
+            this.InputHandler(inputTabObj);
+        }
+    }
+
+    function FadeInCard()
+    {
+        if (this.bFadedIn)
             return;
-      }
-   }
-   function ShowEnchantingSlider(aiMaxValue, aiMinValue, aiCurrentValue)
-   {
-      this.gotoAndStop("Craft_Enchanting");
-      this.QuantitySlider_mc = this.EnchantingSlider_mc;
-      this.QuantitySlider_mc.addEventListener("change",this,"onSliderChange");
-      this.PrepareInputElements(this.EnchantingSlider_mc);
-      this.QuantitySlider_mc.maximum = aiMaxValue;
-      this.QuantitySlider_mc.minimum = aiMinValue;
-      this.QuantitySlider_mc.value = aiCurrentValue;
-      this.PrevFocus = gfx.managers.FocusHandler.instance.getFocus(0);
-      gfx.managers.FocusHandler.instance.setFocus(this.QuantitySlider_mc,0);
-      this.InputHandler = this.HandleQuantityMenuInput;
-      this.dispatchEvent({type:"subMenuAction",opening:true,menu:"quantity"});
-   }
-   function ShowQuantityMenu(aiMaxAmount)
-   {
-      this.gotoAndStop("Quantity");
-      this.PrepareInputElements(this.QuantitySlider_mc);
-      this.QuantitySlider_mc.maximum = aiMaxAmount;
-      this.QuantitySlider_mc.value = aiMaxAmount;
-      this.SliderValueText.textAutoSize = "shrink";
-      this.SliderValueText.SetText(Math.floor(this.QuantitySlider_mc.value).toString());
-      this.PrevFocus = gfx.managers.FocusHandler.instance.getFocus(0);
-      gfx.managers.FocusHandler.instance.setFocus(this.QuantitySlider_mc,0);
-      this.InputHandler = this.HandleQuantityMenuInput;
-      this.dispatchEvent({type:"subMenuAction",opening:true,menu:"quantity"});
-   }
-   function HideQuantityMenu(abCanceled)
-   {
-      gfx.managers.FocusHandler.instance.setFocus(this.PrevFocus,0);
-      this.QuantitySlider_mc._alpha = 0;
-      this.ButtonRect_mc._alpha = 0;
-      this.InputHandler = undefined;
-      this.dispatchEvent({type:"subMenuAction",opening:false,canceled:abCanceled,menu:"quantity"});
-   }
-   function OpenListMenu()
-   {
-      this.PrevFocus = gfx.managers.FocusHandler.instance.getFocus(0);
-      gfx.managers.FocusHandler.instance.setFocus(this.ItemList,0);
-      this.ItemList._visible = true;
-      this.ItemList.addEventListener("itemPress",this,"onListItemPress");
-      this.ItemList.addEventListener("listMovedUp",this,"onListSelectionChange");
-      this.ItemList.addEventListener("listMovedDown",this,"onListSelectionChange");
-      this.ItemList.addEventListener("selectionChange",this,"onListMouseSelectionChange");
-      this.PrepareInputElements(this.CardList_mc);
-      this.ListChargeMeter._alpha = 100;
-      this.InputHandler = this.HandleListMenuInput;
-      this.dispatchEvent({type:"subMenuAction",opening:true,menu:"list"});
-   }
-   function HideListMenu()
-   {
-      gfx.managers.FocusHandler.instance.setFocus(this.PrevFocus,0);
-      this.ListChargeMeter._alpha = 0;
-      this.CardList_mc._alpha = 0;
-      this.ItemCardMeters[skyui.defines.Inventory.ICT_LIST] = undefined;
-      this.InputHandler = undefined;
-      this.ItemList._visible = true;
-      this.dispatchEvent({type:"subMenuAction",opening:false,menu:"list"});
-   }
-   function ShowConfirmMessage(astrMessage)
-   {
-      this.gotoAndStop("ConfirmMessage");
-      this.PrepareInputElements(this.ButtonRect_mc);
-      var _loc3_ = astrMessage.split("\r\n");
-      var _loc4_ = _loc3_.join("\n");
-      this.MessageText.SetText(_loc4_);
-      this.PrevFocus = gfx.managers.FocusHandler.instance.getFocus(0);
-      gfx.managers.FocusHandler.instance.setFocus(this,0);
-      this.InputHandler = this.HandleConfirmMessageInput;
-      this.dispatchEvent({type:"subMenuAction",opening:true,menu:"message"});
-   }
-   function HideConfirmMessage()
-   {
-      gfx.managers.FocusHandler.instance.setFocus(this.PrevFocus,0);
-      this.ButtonRect_mc._alpha = 0;
-      this.InputHandler = undefined;
-      this.dispatchEvent({type:"subMenuAction",opening:false,menu:"message"});
-   }
-   function StartEditName(aInitialText, aiMaxChars)
-   {
-      if(Selection.getFocus() != this.ItemName)
-      {
-         this.PrevFocus = gfx.managers.FocusHandler.instance.getFocus(0);
-         if(aInitialText != undefined)
-         {
-            this.ItemName.text = aInitialText;
-         }
-         this.ItemName.type = "input";
-         this.ItemName.noTranslate = true;
-         this.ItemName.selectable = true;
-         this.ItemName.maxChars = aiMaxChars != undefined ? aiMaxChars : null;
-         Selection.setFocus(this.ItemName,0);
-         Selection.setSelection(0,0);
-         this.InputHandler = this.HandleEditNameInput;
-         this.dispatchEvent({type:"subMenuAction",opening:true,menu:"editName"});
-         this._bEditNameMode = true;
-      }
-   }
-   function EndEditName()
-   {
-      this.ItemName.type = "dynamic";
-      this.ItemName.noTranslate = false;
-      this.ItemName.selectable = false;
-      this.ItemName.maxChars = null;
-      var _loc2_ = this.PrevFocus.focusEnabled;
-      this.PrevFocus.focusEnabled = true;
-      Selection.setFocus(this.PrevFocus,0);
-      this.PrevFocus.focusEnabled = _loc2_;
-      this.InputHandler = undefined;
-      this.dispatchEvent({type:"subMenuAction",opening:false,menu:"editName"});
-      this._bEditNameMode = false;
-   }
-   function handleInput(details, pathToFocus)
-   {
-      var _loc4_ = false;
-      if(pathToFocus.length > 0 && pathToFocus[0].handleInput != undefined)
-      {
-         pathToFocus[0].handleInput(details,pathToFocus.slice(1));
-      }
-      if(this.InputHandler != undefined)
-      {
-         _loc4_ = this.InputHandler(details);
-      }
-      return _loc4_;
-   }
-   function HandleQuantityMenuInput(details)
-   {
-      var _loc3_ = false;
-      if(Shared.GlobalFunc.IsKeyPressed(details))
-      {
-         if(details.navEquivalent == gfx.ui.NavigationCode.ENTER)
-         {
-            this.HideQuantityMenu(false);
-            if(this.QuantitySlider_mc.value > 0)
-            {
-               this.dispatchEvent({type:"quantitySelect",amount:Math.floor(this.QuantitySlider_mc.value)});
+        this._visible = true;
+        this._parent.gotoAndPlay("fadeIn");
+        this.bFadedIn = true;
+    }
+
+    function FadeOutCard()
+    {
+        if (this.bFadedIn) {
+            this._parent.gotoAndPlay("fadeOut");
+            this.bFadedIn = false;
+        }
+    }
+
+    function get quantitySlider()
+    {
+        return this.QuantitySlider_mc;
+    }
+
+    function get weaponChargeMeter()
+    {
+        return this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON];
+    }
+
+    function get itemInfo()
+    {
+        return this.LastUpdateObj;
+    }
+
+    function set itemInfo(aUpdateObj: Object)
+    {
+        this.ItemCardMeters = new Array();
+        var strItemNameHtml: String = this.ItemName == undefined ? "" : this.ItemName.htmlText;
+        var _iItemType: Number = aUpdateObj.type;
+        
+        
+        switch (_iItemType) {
+            case skyui.defines.Inventory.ICT_ARMOR:
+                if (aUpdateObj.effects.length == 0) {
+                    if (aUpdateObj.warmth != undefined)
+                        this.gotoAndStop("Apparel_Survival_reg");
+                    else
+                        this.gotoAndStop("Apparel_reg");
+                } else if(aUpdateObj.warmth != undefined) {
+                    this.gotoAndStop("Apparel_Survival_Enchanted");
+                } else {
+                    this.gotoAndStop("Apparel_Enchanted");
+                }
+                this.ApparelWarmthValue.textAutoSize = "shrink";
+                this.ApparelWarmthValue.SetText(aUpdateObj.warmth);
+                this.ApparelArmorValue.textAutoSize = "shrink";
+                this.ApparelArmorValue.SetText(aUpdateObj.armor);
+                this.ApparelEnchantedLabel.enableShrinkToFit = true;
+                this.ApparelEnchantedLabel.overflowMode = "ellipsis";
+                this.ApparelEnchantedLabel.SetText(aUpdateObj.effects, true);
+                this.SkillTextInstance.text = aUpdateObj.skillText;
+                break;
+                
+            case skyui.defines.Inventory.ICT_WEAPON:
+                if (aUpdateObj.effects.length == 0) {
+                    this.gotoAndStop("Weapons_reg");
+                } else {
+                    this.gotoAndStop("Weapons_Enchanted");
+                    if (this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON] == undefined)
+                        this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON] = new Components.DeltaMeter(this.WeaponChargeMeter.MeterInstance);
+                    if (aUpdateObj.usedCharge != undefined && aUpdateObj.charge != undefined) {
+                        this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON].SetPercent(aUpdateObj.usedCharge);
+                        this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON].SetDeltaPercent(aUpdateObj.charge);
+                        this.WeaponChargeMeter._visible = true;
+                    } else {
+                        this.WeaponChargeMeter._visible = false;
+                    }
+                }
+                var strIsPoisoned: String = aUpdateObj.poisoned == true ? "On" : "Off";
+                this.PoisonInstance.gotoAndStop(strIsPoisoned);
+                this.WeaponDamageValue.textAutoSize = "shrink";
+                this.WeaponDamageValue.SetText(aUpdateObj.damage);
+                this.WeaponEnchantedLabel.enableShrinkToFit = true;
+                this.WeaponEnchantedLabel.overflowMode = "ellipsis";
+                this.WeaponEnchantedLabel.SetText(aUpdateObj.effects, true);
+                break;
+                
+            case skyui.defines.Inventory.ICT_BOOK: 
+                if (aUpdateObj.description != undefined && aUpdateObj.description != "") {
+                    this.gotoAndStop("Books_Description");
+                    this.BookDescriptionLabel.enableShrinkToFit = true;
+                    this.BookDescriptionLabel.overflowMode = "ellipsis";
+                    this.BookDescriptionLabel.SetText(aUpdateObj.description, true);
+                } else {
+                    this.gotoAndStop("Books_reg");
+                }
+                break;
+                
+            case skyui.defines.Inventory.ICT_POTION:
+            case skyui.defines.Inventory.ICT_FOOD:
+                this.gotoAndStop("Potions_reg");
+                this.PotionsLabel.enableShrinkToFit = true;
+                this.PotionsLabel.overflowMode = "ellipsis";
+                this.PotionsLabel.SetText(aUpdateObj.effects, true);
+                this.SkillTextInstance.text = aUpdateObj.skillName == undefined ? "" : aUpdateObj.skillName;
+                break;
+                
+            case skyui.defines.Inventory.ICT_SPELL_DEFAULT:
+                this.gotoAndStop("Power_reg");
+                this.MagicEffectsLabel.enableShrinkToFit = true;
+                this.MagicEffectsLabel.overflowMode = "ellipsis";
+                this.MagicEffectsLabel.SetText(aUpdateObj.effects, true);
+                if (aUpdateObj.spellCost <= 0) {
+                    this.MagicCostValue._alpha = 0;
+                    this.MagicCostTimeValue._alpha = 0;
+                    this.MagicCostLabel._alpha = 0;
+                    this.MagicCostTimeLabel._alpha = 0;
+                    this.MagicCostPerSec._alpha = 0;
+                } else {
+                    this.MagicCostValue._alpha = 100;
+                    this.MagicCostLabel._alpha = 100;
+                    this.MagicCostValue.text = aUpdateObj.spellCost.toString();
+                }
+                break;
+                
+            case skyui.defines.Inventory.ICT_SPELL:
+                var bCastTime: Boolean = aUpdateObj.castTime == 0;
+                if (bCastTime)
+                    this.gotoAndStop("Magic_time_label");
+                else
+                    this.gotoAndStop("Magic_reg");
+                this.SkillLevelText.text = aUpdateObj.castLevel.toString();
+                this.MagicEffectsLabel.enableShrinkToFit = true;
+                this.MagicEffectsLabel.overflowMode = "ellipsis";
+                this.MagicEffectsLabel.SetText(aUpdateObj.effects, true);
+                this.MagicCostValue.textAutoSize = "shrink";
+                this.MagicCostTimeValue.textAutoSize = "shrink";
+                if (bCastTime)
+                    this.MagicCostTimeValue.text = aUpdateObj.spellCost.toString();
+                else
+                    this.MagicCostValue.text = aUpdateObj.spellCost.toString();
+                break;
+                
+            case skyui.defines.Inventory.ICT_INGREDIENT:
+                this.gotoAndStop("Ingredients_reg");
+                for (var i: Number = 0; i < 4; i++) {
+                    this["EffectLabel" + i].textAutoSize = "shrink";
+                    if (aUpdateObj["itemEffect" + i] != undefined && aUpdateObj["itemEffect" + i] != "") {
+                        this["EffectLabel" + i].textColor = 0xFFFFFF;
+                        this["EffectLabel" + i].SetText(aUpdateObj["itemEffect" + i]);
+                    } else if (i < aUpdateObj.numItemEffects) {
+                        this["EffectLabel" + i].textColor = 0x999999;
+                        this["EffectLabel" + i].SetText("$UNKNOWN");
+                    } else {
+                        this["EffectLabel" + i].SetText("");
+                    }
+                }
+                break;
+                
+            case skyui.defines.Inventory.ICT_MISC:
+                this.gotoAndStop("Misc_reg");
+                break;
+                
+            case skyui.defines.Inventory.ICT_SHOUT:
+                this.gotoAndStop("Shouts_reg");
+                var iLastWord: Number = 0;
+                for (var i: Number = 0; i < 3; i++) {
+                    if (aUpdateObj["word" + i] != undefined && aUpdateObj["word" + i] != "" && aUpdateObj["unlocked" + i] == true)
+                        iLastWord = i;
+                }
+                for (var i: Number = 0; i < 3; i++) {
+                    var strDragonWord: String = aUpdateObj["dragonWord" + i] == undefined ? "" : aUpdateObj["dragonWord" + i];
+                    var strWord: String = aUpdateObj["word" + i] == undefined ? "" : aUpdateObj["word" + i];
+                    var bWordKnown: Boolean = aUpdateObj["unlocked" + i] == true;
+                    this["ShoutTextInstance" + i].DragonShoutLabelInstance.ShoutWordsLabel.textAutoSize = "shrink";
+                    this["ShoutTextInstance" + i].ShoutLabelInstance.ShoutWordsLabelTranslation.textAutoSize = "shrink";
+                    this["ShoutTextInstance" + i].DragonShoutLabelInstance.ShoutWordsLabel.SetText(strDragonWord.toUpperCase());
+                    this["ShoutTextInstance" + i].ShoutLabelInstance.ShoutWordsLabelTranslation.SetText(strWord);
+                    if (bWordKnown && i == iLastWord && this.LastUpdateObj.soulSpent == true) {
+                        this["ShoutTextInstance" + i].gotoAndPlay("Learn");
+                    } else if (bWordKnown) {
+                        this["ShoutTextInstance" + i].gotoAndStop("Known");
+                        this["ShoutTextInstance" + i].gotoAndStop("Known");
+                    } else {
+                        this["ShoutTextInstance" + i].gotoAndStop("Unlocked");
+                        this["ShoutTextInstance" + i].gotoAndStop("Unlocked");
+                    }
+                }
+                this.ShoutEffectsLabel.enableShrinkToFit = true;
+                this.ShoutEffectsLabel.overflowMode = "ellipsis";
+                this.ShoutEffectsLabel.SetText(aUpdateObj.effects, true);
+                this.ShoutCostValue.text = aUpdateObj.spellCost.toString();
+                break;
+                
+            case skyui.defines.Inventory.ICT_ACTIVE_EFFECT:
+                this.gotoAndStop("ActiveEffects");
+                this.MagicEffectsLabel.enableShrinkToFit = true;
+                this.MagicEffectsLabel.overflowMode = "ellipsis";
+                this.MagicEffectsLabel.SetText(aUpdateObj.effects,true);
+                if (aUpdateObj.timeRemaining > 0) {
+                    var iEffectTimeRemaining: Number = Math.floor(aUpdateObj.timeRemaining);
+                    this.ActiveEffectTimeValue._alpha = 100;
+                    this.SecsText._alpha = 100;
+                    if (iEffectTimeRemaining >= 3600) {
+                        iEffectTimeRemaining = Math.floor(iEffectTimeRemaining / 3600);
+                        this.ActiveEffectTimeValue.text = iEffectTimeRemaining.toString();
+                        if (iEffectTimeRemaining == 1)
+                            this.SecsText.text = "$hour";
+                        else
+                            this.SecsText.text = "$hours";
+                    } else if (iEffectTimeRemaining >= 60) {
+                        iEffectTimeRemaining = Math.floor(iEffectTimeRemaining / 60);
+                        this.ActiveEffectTimeValue.text = iEffectTimeRemaining.toString();
+                        if (iEffectTimeRemaining == 1)
+                            this.SecsText.text = "$min";
+                        else
+                            this.SecsText.text = "$mins";
+                    } else {
+                        this.ActiveEffectTimeValue.text = iEffectTimeRemaining.toString();
+                        if (iEffectTimeRemaining == 1)
+                            this.SecsText.text = "$sec";
+                        else
+                            this.SecsText.text = "$secs";
+                    }
+                } else {
+                    this.ActiveEffectTimeValue._alpha = 0;
+                    this.SecsText._alpha = 0;
+                }
+                break;
+                
+            case skyui.defines.Inventory.ICT_SOUL_GEMS:
+                this.gotoAndStop("SoulGem");
+                this.SoulLevel.text = aUpdateObj.soulLVL;
+                break;
+                
+            case skyui.defines.Inventory.ICT_LIST:
+                this.gotoAndStop("Item_list");
+                if (aUpdateObj.listItems != undefined) {
+                    this.ItemList.entryList = aUpdateObj.listItems;
+                    this.ItemList.InvalidateData();
+                    this.ItemCardMeters[skyui.defines.Inventory.ICT_LIST] = new Components.DeltaMeter(this.ListChargeMeter.MeterInstance);
+                    this.ItemCardMeters[skyui.defines.Inventory.ICT_LIST].SetPercent(aUpdateObj.currentCharge);
+                    this.ItemCardMeters[skyui.defines.Inventory.ICT_LIST].SetDeltaPercent(aUpdateObj.currentCharge + this.ItemList.selectedEntry.chargeAdded);
+                    this.OpenListMenu();
+                }
+                break;
+                
+            case skyui.defines.Inventory.ICT_CRAFT_ENCHANTING:
+            case skyui.defines.Inventory.ICT_HOUSE_PART:
+                if (aUpdateObj.type == skyui.defines.Inventory.ICT_HOUSE_PART) {
+                    this.gotoAndStop("Magic_short");
+                    if (aUpdateObj.effects == undefined)
+                        this.MagicEffectsLabel.SetText("", true);
+                    else
+                        this.MagicEffectsLabel.SetText(aUpdateObj.effects, true);
+                } else if (aUpdateObj.sliderShown == true) {
+                    this.gotoAndStop("Craft_Enchanting");
+                    this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON] = new Components.DeltaMeter(this.ChargeMeter_Default.MeterInstance);
+                    if (aUpdateObj.totalCharges != undefined && aUpdateObj.totalCharges != 0)
+                        this.TotalChargesValue.text = aUpdateObj.totalCharges;
+                } else if (aUpdateObj.damage == undefined) {
+                    if (aUpdateObj.armor == undefined) {
+                        if (aUpdateObj.soulLVL == undefined) {
+                            if (this.QuantitySlider_mc._alpha == 0) {
+                                this.gotoAndStop("Craft_Enchanting_Enchantment");
+                                this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON] = new Components.DeltaMeter(this.ChargeMeter_Enchantment.MeterInstance);
+                            }
+                        } else {
+                            this.gotoAndStop("Craft_Enchanting_SoulGem");
+                            this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON] = new Components.DeltaMeter(this.ChargeMeter_SoulGem.MeterInstance);
+                            this.SoulLevel.text = aUpdateObj.soulLVL;
+                        }
+                    } else {
+                        this.gotoAndStop("Craft_Enchanting_Armor");
+                        this.ApparelArmorValue.SetText(aUpdateObj.armor);
+                        this.SkillTextInstance.text = aUpdateObj.skillText;
+                    }
+                } else {
+                    this.gotoAndStop("Craft_Enchanting_Weapon");
+                    this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON] = new Components.DeltaMeter(this.ChargeMeter_Weapon.MeterInstance);
+                    this.WeaponDamageValue.textAutoSize = "shrink";
+                    this.WeaponDamageValue.SetText(aUpdateObj.damage);
+                }
+                
+                if (aUpdateObj.usedCharge == 0 && aUpdateObj.totalCharges == 0)
+                    this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON].DeltaMeterMovieClip._parent._parent._alpha = 0;
+                else if (aUpdateObj.usedCharge != undefined)
+                    this.ItemCardMeters[skyui.defines.Inventory.ICT_WEAPON].SetPercent(aUpdateObj.usedCharge);
+                
+                if (aUpdateObj.effects != undefined && aUpdateObj.effects.length > 0) {
+                    if (this.EnchantmentLabel != undefined) {
+                        this.EnchantmentLabel.enableShrinkToFit = true;
+                        this.EnchantmentLabel.overflowMode = "ellipsis";
+                        this.EnchantmentLabel.SetText(aUpdateObj.effects,true);
+                    }
+                    this.WeaponChargeMeter._alpha = 100;
+                    this.Enchanting_Background._alpha = 60;
+                    this.Enchanting_Slim_Background._alpha = 0;
+                } else {
+                    if (this.EnchantmentLabel != undefined)
+                        this.EnchantmentLabel.SetText("", true);
+                    
+                    this.WeaponChargeMeter._alpha = 0;
+                    this.Enchanting_Slim_Background._alpha = 60;
+                    this.Enchanting_Background._alpha = 0;
+                }
+                break;
+            
+            case skyui.defines.Inventory.ICT_KEY:
+            case skyui.defines.Inventory.ICT_NONE:
+            default:
+                this.gotoAndStop("Empty");
+        }
+        
+        this.SetupItemName(strItemNameHtml);
+        if (aUpdateObj.name != undefined) {
+            var strItemName: String = aUpdateObj.count != undefined && aUpdateObj.count > 1 ? aUpdateObj.name + " (" + aUpdateObj.count + ")" : aUpdateObj.name;
+            this.ItemText.ItemTextField.SetText(this._bEditNameMode || aUpdateObj.upperCaseName == false ? strItemName : strItemName.toUpperCase(), false);
+            this.ItemText.ItemTextField.textColor = aUpdateObj.negativeEffect == true ? 0xFF0000 : 0xFFFFFF;
+        }
+        this.ItemValueText.textAutoSize = "shrink";
+        this.ItemWeightText.textAutoSize = "shrink";
+        if (aUpdateObj.value != undefined && this.ItemValueText != undefined)
+            this.ItemValueText.SetText(aUpdateObj.value.toString());
+        if (aUpdateObj.weight != undefined && this.ItemWeightText != undefined)
+            this.ItemWeightText.SetText(this.RoundDecimal(aUpdateObj.weight, 2).toString());
+        this.StolenTextInstance._visible = aUpdateObj.stolen == true;
+        this.LastUpdateObj = aUpdateObj;
+    }
+
+    function RoundDecimal(aNumber: Number, aPrecision: Number)
+    {
+        var significantFigures = Math.pow(10, aPrecision);
+        return Math.round(significantFigures * aNumber) / significantFigures;
+    }
+
+    function PrepareInputElements(aActiveClip: MovieClip)
+    {
+        var iQuantitySlider_yOffset = 92;
+        var iCardList_yOffset = 98;
+        var iEnchantingSlider_yOffset = 147.3;
+        var iButtonRect_iOffset = 130;
+        var iButtonRect_iOffsetEnchanting = 166;
+        
+        switch (aActiveClip) {
+            case this.EnchantingSlider_mc: 
+                this.QuantitySlider_mc._y = -100;
+                this.ButtonRect._y = iButtonRect_iOffsetEnchanting;
+                this.EnchantingSlider_mc._y = iEnchantingSlider_yOffset;
+                this.CardList_mc._y = -100;
+                this.QuantitySlider_mc._alpha = 0;
+                this.ButtonRect._alpha = 100;
+                this.EnchantingSlider_mc._alpha = 100;
+                this.CardList_mc._alpha = 0;
+                break;
+                
+            case this.QuantitySlider_mc: 
+                this.QuantitySlider_mc._y = iQuantitySlider_yOffset;
+                this.ButtonRect._y = iButtonRect_iOffset;
+                this.EnchantingSlider_mc._y = -100;
+                this.CardList_mc._y = -100;
+                this.QuantitySlider_mc._alpha = 100;
+                this.ButtonRect._alpha = 100;
+                this.EnchantingSlider_mc._alpha = 0;
+                this.CardList_mc._alpha = 0;
+                break;
+                
+            case this.CardList_mc: 
+                this.QuantitySlider_mc._y = -100;
+                this.ButtonRect._y = -100;
+                this.EnchantingSlider_mc._y = -100;
+                this.CardList_mc._y = iCardList_yOffset;
+                this.QuantitySlider_mc._alpha = 0;
+                this.ButtonRect._alpha = 0;
+                this.EnchantingSlider_mc._alpha = 0;
+                this.CardList_mc._alpha = 100;
+                break;
+                
+            case this.ButtonRect: 
+                this.QuantitySlider_mc._y = -100;
+                this.ButtonRect._y = iButtonRect_iOffset;
+                this.EnchantingSlider_mc._y = -100;
+                this.CardList_mc._y = -100;
+                this.QuantitySlider_mc._alpha = 0;
+                this.ButtonRect._alpha = 100;
+                this.EnchantingSlider_mc._alpha = 0;
+                this.CardList_mc._alpha = 0;
+                break;
+        }
+    }
+
+    function ShowEnchantingSlider(aiMaxValue: Number, aiMinValue: Number, aiCurrentValue: Number)
+    {
+        this.gotoAndStop("Craft_Enchanting");
+        this.QuantitySlider_mc = this.EnchantingSlider_mc;
+        this.QuantitySlider_mc.addEventListener("change", this, "onSliderChange");
+        this.PrepareInputElements(this.EnchantingSlider_mc);
+        this.QuantitySlider_mc.maximum = aiMaxValue;
+        this.QuantitySlider_mc.minimum = aiMinValue;
+        this.QuantitySlider_mc.value = aiCurrentValue;
+        this.PrevFocus = gfx.managers.FocusHandler.instance.getFocus(0);
+        gfx.managers.FocusHandler.instance.setFocus(this.QuantitySlider_mc, 0);
+        this.InputHandler = this.HandleQuantityMenuInput;
+        this.dispatchEvent({type: "subMenuAction", opening: true, menu: "quantity"});
+    }
+
+    function ShowQuantityMenu(aiMaxAmount: Number)
+    {
+        this.gotoAndStop("Quantity");
+        this.PrepareInputElements(this.QuantitySlider_mc);
+        this.QuantitySlider_mc.maximum = aiMaxAmount;
+        this.QuantitySlider_mc.value = aiMaxAmount;
+        this.SliderValueText.textAutoSize = "shrink";
+        this.SliderValueText.SetText(Math.floor(this.QuantitySlider_mc.value).toString());
+        this.PrevFocus = gfx.managers.FocusHandler.instance.getFocus(0);
+        gfx.managers.FocusHandler.instance.setFocus(this.QuantitySlider_mc, 0);
+        this.InputHandler = this.HandleQuantityMenuInput;
+        this.dispatchEvent({type: "subMenuAction", opening: true, menu: "quantity"});
+    }
+
+    function HideQuantityMenu(abCanceled: Boolean)
+    {
+        gfx.managers.FocusHandler.instance.setFocus(this.PrevFocus, 0);
+        this.QuantitySlider_mc._alpha = 0;
+        this.ButtonRect_mc._alpha = 0;
+        this.InputHandler = undefined;
+        this.dispatchEvent({type: "subMenuAction", opening: false, canceled: abCanceled, menu: "quantity"});
+    }
+
+    function OpenListMenu()
+    {
+        this.PrevFocus = gfx.managers.FocusHandler.instance.getFocus(0);
+        gfx.managers.FocusHandler.instance.setFocus(this.ItemList, 0);
+        this.ItemList._visible = true;
+        this.ItemList.addEventListener("itemPress", this, "onListItemPress");
+        this.ItemList.addEventListener("listMovedUp", this, "onListSelectionChange");
+        this.ItemList.addEventListener("listMovedDown", this, "onListSelectionChange");
+        this.ItemList.addEventListener("selectionChange", this, "onListMouseSelectionChange");
+        this.PrepareInputElements(this.CardList_mc);
+        this.ListChargeMeter._alpha = 100;
+        this.InputHandler = this.HandleListMenuInput;
+        this.dispatchEvent({type: "subMenuAction", opening: true, menu: "list"});
+    }
+
+    function HideListMenu()
+    {
+        gfx.managers.FocusHandler.instance.setFocus(this.PrevFocus, 0);
+        this.ListChargeMeter._alpha = 0;
+        this.CardList_mc._alpha = 0;
+        this.ItemCardMeters[skyui.defines.Inventory.ICT_LIST] = undefined;
+        this.InputHandler = undefined;
+        this.ItemList._visible = true;
+        this.dispatchEvent({type: "subMenuAction", opening: false, menu: "list"});
+    }
+
+    function ShowConfirmMessage(astrMessage: String)
+    {
+        this.gotoAndStop("ConfirmMessage");
+        this.PrepareInputElements(this.ButtonRect_mc);
+        var messageArray: Array = astrMessage.split("\r\n");
+        var strMessageText = messageArray.join("\n");
+        this.MessageText.SetText(strMessageText);
+        this.PrevFocus = gfx.managers.FocusHandler.instance.getFocus(0);
+        gfx.managers.FocusHandler.instance.setFocus(this, 0);
+        this.InputHandler = this.HandleConfirmMessageInput;
+        this.dispatchEvent({type: "subMenuAction", opening: true, menu: "message"});
+    }
+
+    function HideConfirmMessage()
+    {
+        gfx.managers.FocusHandler.instance.setFocus(this.PrevFocus, 0);
+        this.ButtonRect_mc._alpha = 0;
+        this.InputHandler = undefined;
+        this.dispatchEvent({type: "subMenuAction", opening: false, menu: "message"});
+    }
+
+    function StartEditName(aInitialText: String, aiMaxChars: Number)
+    {
+        if (Selection.getFocus() != this.ItemName) {
+            this.PrevFocus = gfx.managers.FocusHandler.instance.getFocus(0);
+            if (aInitialText != undefined)
+                this.ItemName.text = aInitialText;
+            this.ItemName.type = "input";
+            this.ItemName.noTranslate = true;
+            this.ItemName.selectable = true;
+            this.ItemName.maxChars = aiMaxChars == undefined ? null : aiMaxChars;
+            Selection.setFocus(this.ItemName, 0);
+            Selection.setSelection(0, 0);
+            this.InputHandler = this.HandleEditNameInput;
+            this.dispatchEvent({type: "subMenuAction", opening: true, menu: "editName"});
+            this._bEditNameMode = true;
+        }
+    }
+
+    function EndEditName()
+    {
+        this.ItemName.type = "dynamic";
+        this.ItemName.noTranslate = false;
+        this.ItemName.selectable = false;
+        this.ItemName.maxChars = null;
+        var bPreviousFocusEnabled: Boolean = this.PrevFocus.focusEnabled;
+        this.PrevFocus.focusEnabled = true;
+        Selection.setFocus(this.PrevFocus, 0);
+        this.PrevFocus.focusEnabled = bPreviousFocusEnabled;
+        this.InputHandler = undefined;
+        this.dispatchEvent({type: "subMenuAction", opening: false, menu: "editName"});
+        this._bEditNameMode = false;
+    }
+
+    function handleInput(details: InputDetails, pathToFocus: Array)
+    {
+        var bHandledInput: Boolean = false;
+        if (pathToFocus.length > 0 && pathToFocus[0].handleInput != undefined) 
+            pathToFocus[0].handleInput(details, pathToFocus.slice(1));
+        if (this.InputHandler != undefined)
+            bHandledInput = this.InputHandler(details);
+        return bHandledInput;
+    }
+
+    function HandleQuantityMenuInput(details: Object)
+    {
+        var bValidKeyPressed: Boolean = false;
+        if (Shared.GlobalFunc.IsKeyPressed(details))
+            if (details.navEquivalent == gfx.ui.NavigationCode.ENTER) {
+                this.HideQuantityMenu(false);
+                if (this.QuantitySlider_mc.value > 0)
+                    this.dispatchEvent({type: "quantitySelect", amount: Math.floor(this.QuantitySlider_mc.value)});
+                else
+                    this.itemInfo = this.LastUpdateObj;
+                bValidKeyPressed = true;
+            } else if (details.navEquivalent == gfx.ui.NavigationCode.TAB) {
+                this.HideQuantityMenu(true);
+                this.itemInfo = this.LastUpdateObj;
+                bValidKeyPressed = true;
             }
-            else
-            {
-               this.itemInfo = this.LastUpdateObj;
+        return bValidKeyPressed;
+    }
+
+    function HandleListMenuInput(details: Object)
+    {
+        var bValidKeyPressed: Boolean = false;
+        if (Shared.GlobalFunc.IsKeyPressed(details) && details.navEquivalent == gfx.ui.NavigationCode.TAB) {
+            this.HideListMenu();
+            bValidKeyPressed = true;
+        }
+        return bValidKeyPressed;
+    }
+
+    function HandleConfirmMessageInput(details: Object)
+    {
+        var bValidKeyPressed: Boolean = false;
+        if (Shared.GlobalFunc.IsKeyPressed(details)) {
+            if (details.navEquivalent == gfx.ui.NavigationCode.ENTER) {
+                this.HideConfirmMessage();
+                this.dispatchEvent({type: "messageConfirm"});
+                bValidKeyPressed = true;
+            } else if (details.navEquivalent == gfx.ui.NavigationCode.TAB) {
+                this.HideConfirmMessage();
+                this.dispatchEvent({type: "messageCancel"});
+                this.itemInfo = this.LastUpdateObj;
+                bValidKeyPressed = true;
             }
-            _loc3_ = true;
-         }
-         else if(details.navEquivalent == gfx.ui.NavigationCode.TAB)
-         {
-            this.HideQuantityMenu(true);
-            this.itemInfo = this.LastUpdateObj;
-            _loc3_ = true;
-         }
-      }
-      return _loc3_;
-   }
-   function HandleListMenuInput(details)
-   {
-      var _loc3_ = false;
-      if(Shared.GlobalFunc.IsKeyPressed(details) && details.navEquivalent == gfx.ui.NavigationCode.TAB)
-      {
-         this.HideListMenu();
-         _loc3_ = true;
-      }
-      return _loc3_;
-   }
-   function HandleConfirmMessageInput(details)
-   {
-      var _loc3_ = false;
-      if(Shared.GlobalFunc.IsKeyPressed(details))
-      {
-         if(details.navEquivalent == gfx.ui.NavigationCode.ENTER)
-         {
-            this.HideConfirmMessage();
-            this.dispatchEvent({type:"messageConfirm"});
-            _loc3_ = true;
-         }
-         else if(details.navEquivalent == gfx.ui.NavigationCode.TAB)
-         {
-            this.HideConfirmMessage();
-            this.dispatchEvent({type:"messageCancel"});
-            this.itemInfo = this.LastUpdateObj;
-            _loc3_ = true;
-         }
-      }
-      return _loc3_;
-   }
-   function HandleEditNameInput(details)
-   {
-      Selection.setFocus(this.ItemName,0);
-      if(Shared.GlobalFunc.IsKeyPressed(details))
-      {
-         if(details.navEquivalent == gfx.ui.NavigationCode.ENTER && details.code != 32)
-         {
-            this.dispatchEvent({type:"endEditItemName",useNewName:true,newName:this.ItemName.text});
-         }
-         else if(details.navEquivalent == gfx.ui.NavigationCode.TAB)
-         {
-            this.dispatchEvent({type:"endEditItemName",useNewName:false,newName:""});
-         }
-      }
-      return true;
-   }
-   function onSliderChange()
-   {
-      var _loc2_ = this.EnchantingSlider_mc._alpha > 0 ? this.TotalChargesValue : this.SliderValueText;
-      var _loc3_ = Number(_loc2_.text);
-      var _loc4_ = Math.floor(this.QuantitySlider_mc.value);
-      if(_loc3_ != _loc4_)
-      {
-         _loc2_.SetText(_loc4_.toString());
-         gfx.io.GameDelegate.call("PlaySound",["UIMenuPrevNext"]);
-         this.dispatchEvent({type:"sliderChange",value:_loc4_});
-      }
-   }
-   function onListItemPress(event)
-   {
-      this.dispatchEvent(event);
-      this.HideListMenu();
-   }
-   function onListMouseSelectionChange(event)
-   {
-      if(event.keyboardOrMouse == 0)
-      {
-         this.onListSelectionChange(event);
-      }
-   }
-   function onListSelectionChange(event)
-   {
-      this.ItemCardMeters[skyui.defines.Inventory.ICT_LIST].SetDeltaPercent(this.ItemList.selectedEntry.chargeAdded + this.LastUpdateObj.currentCharge);
-   }
+        }
+        return bValidKeyPressed;
+    }
+
+    function HandleEditNameInput(details: Object)
+    {
+        Selection.setFocus(this.ItemName, 0);
+        if (Shared.GlobalFunc.IsKeyPressed(details)) {
+            if (details.navEquivalent == gfx.ui.NavigationCode.ENTER && details.code != 32)
+                this.dispatchEvent({type: "endEditItemName", useNewName: true, newName: this.ItemName.text});
+            else if (details.navEquivalent == gfx.ui.NavigationCode.TAB)
+                this.dispatchEvent({type: "endEditItemName", useNewName: false, newName: ""});
+        }
+        return true;
+    }
+
+    function onSliderChange()
+    {
+        var currentValue_tf: TextField = this.EnchantingSlider_mc._alpha <= 0 ? this.SliderValueText : this.TotalChargesValue;
+        var iCurrentValue: Number = Number(currentValue_tf.text);
+        var iNewValue: Number = Math.floor(this.QuantitySlider_mc.value);
+        if (iCurrentValue != iNewValue) {
+            currentValue_tf.SetText(iNewValue.toString());
+            gfx.io.GameDelegate.call("PlaySound", ["UIMenuPrevNext"]);
+            this.dispatchEvent({type: "sliderChange", value: iNewValue});
+        }
+    }
+
+    function onListItemPress(event: Object)
+    {
+        this.dispatchEvent(event);
+        this.HideListMenu();
+    }
+
+    function onListMouseSelectionChange(event: Object)
+    {
+        if (event.keyboardOrMouse == 0) 
+            this.onListSelectionChange(event);
+    }
+
+    function onListSelectionChange(event: Object)
+    {
+        this.ItemCardMeters[skyui.defines.Inventory.ICT_LIST].SetDeltaPercent(this.ItemList.selectedEntry.chargeAdded + this.LastUpdateObj.currentCharge);
+    }
+
 }

--- a/source/actionscript/ItemMenus/ItemMenu.as
+++ b/source/actionscript/ItemMenus/ItemMenu.as
@@ -98,6 +98,7 @@ class ItemMenu extends MovieClip
         this.itemCard.addEventListener("subMenuAction", this, "onItemCardSubMenuAction");
         
         this.positionFixedElements();
+        this.updateDynamicListHeight();
         
         this.itemCard._visible = false;
         this.navPanel.hideButtons();
@@ -112,12 +113,6 @@ class ItemMenu extends MovieClip
     public function setConfig(a_config: Object)
     {
         this._config = a_config;
-
-         var customWidth = a_config["ListLayout"].defaults.entryWidth;
-      
-        if (customWidth != undefined && customWidth > 0) {
-            this.inventoryLists.applyDynamicWidth(customWidth);
-        }
 
         this.positionFloatingElements();
         
@@ -137,26 +132,27 @@ class ItemMenu extends MovieClip
         itemListState.negativeDisabledColor = appearance.colors.negative.disabled;
         itemListState.stolenDisabledColor = appearance.colors.stolen.disabled;
 
-        this._quantityMinCount = a_config["ItemList"].quantityMenu.minCount;
+        var itemList = a_config["ItemList"];
+        this._quantityMinCount = itemList.quantityMenu.minCount;
         
+        var input = a_config["Input"];
         if (this._platform == 0) {
-            this._switchTabKey = a_config["Input"].controls.pc.switchTab;
+            this._switchTabKey = input.controls.pc.switchTab;
         } else {
-            this._switchTabKey = a_config["Input"].controls.gamepad.switchTab;
-            
-            var previousColumnKey = a_config["Input"].controls.gamepad.prevColumn;
-            var nextColumnKey = a_config["Input"].controls.gamepad.nextColumn;
-            var sortOrderKey = a_config["Input"].controls.gamepad.sortOrder;
-            this._sortColumnControls = [{keyCode: previousColumnKey},
-                                {keyCode: nextColumnKey}];
-            this._sortOrderControls = {keyCode: sortOrderKey};
+            var gamepad = input.controls.gamepad;
+            this._switchTabKey = gamepad.switchTab;
+            this._sortColumnControls = [{keyCode: gamepad.prevColumn}, {keyCode: gamepad.nextColumn}];
+            this._sortOrderControls = {keyCode: gamepad.sortOrder};
         }
         
         this._switchControls = {keyCode: this._switchTabKey};
         
-        this._searchKey = a_config["Input"].controls.pc.search;
+        this._searchKey = input.controls.pc.search;
         this._searchControls = {keyCode: this._searchKey};
         
+        var listLayout = a_config["ListLayout"];
+        this.inventoryLists.applyDynamicWidth(listLayout.defaults.entryWidth);
+
         this.updateBottomBar(false);
     }
 
@@ -469,8 +465,6 @@ class ItemMenu extends MovieClip
         MovieClip(this.exitMenuRect).Lock("TL");
         this.exitMenuRect._x -= Stage.safeRect.x;
         this.exitMenuRect._y -= Stage.safeRect.y;
-
-        this.updateDynamicListHeight();
     }
     
     private function positionFloatingElements()

--- a/source/actionscript/ItemMenus/ItemMenu.as
+++ b/source/actionscript/ItemMenus/ItemMenu.as
@@ -1,458 +1,526 @@
 class ItemMenu extends MovieClip
 {
-   var _acceptControls;
-   var _bPlayBladeSound;
-   var _cancelControls;
-   var _config;
-   var _platform;
-   var _searchControls;
-   var _searchKey;
-   var _sortColumnControls;
-   var _sortOrderControls;
-   var _switchControls;
-   var _switchTabKey;
-   var bottomBar;
-   var exitMenuRect;
-   var inventoryLists;
-   var itemCard;
-   var itemCardFadeHolder;
-   var layout;
-   var listState;
-   var mouseRotationRect;
-   var navPanel;
-   var onInvalidate;
-   var onItemPress;
-   var onUnsuspend;
-   var scrollPosition;
-   var selectedIndex;
-   var _bItemCardFadedIn = false;
-   var _bItemCardPositioned = false;
-   var _quantityMinCount = 5;
-   var bEnableTabs = false;
-   var bPCControlsReady = true;
-   var bFadedIn = true;
-   function ItemMenu()
-   {
-      super();
-      this.itemCard = this.itemCardFadeHolder.ItemCard_mc;
-      this.navPanel = this.bottomBar.buttonPanel;
-      Mouse.addListener(this);
-      skyui.util.ConfigManager.registerLoadCallback(this,"onConfigLoad");
-      this.bFadedIn = true;
-      this._bItemCardFadedIn = false;
-   }
-   function InitExtensions(a_bPlayBladeSound)
-   {
-      Stage.scaleMode = "showAll";
-      Shared.GlobalFunc.SetLockFunction();
-      skse.ExtendData(true);
-      skse.ForceContainerCategorization(true);
-      this._bPlayBladeSound = a_bPlayBladeSound;
-      this.inventoryLists.InitExtensions();
-      if(this.bEnableTabs)
-      {
-         this.inventoryLists.enableTabBar();
-      }
-      gfx.io.GameDelegate.addCallBack("UpdatePlayerInfo",this,"UpdatePlayerInfo");
-      gfx.io.GameDelegate.addCallBack("UpdateItemCardInfo",this,"UpdateItemCardInfo");
-      gfx.io.GameDelegate.addCallBack("ToggleMenuFade",this,"ToggleMenuFade");
-      gfx.io.GameDelegate.addCallBack("RestoreIndices",this,"RestoreIndices");
-      this.inventoryLists.addEventListener("categoryChange",this,"onCategoryChange");
-      this.inventoryLists.addEventListener("itemHighlightChange",this,"onItemHighlightChange");
-      this.inventoryLists.addEventListener("showItemsList",this,"onShowItemsList");
-      this.inventoryLists.addEventListener("hideItemsList",this,"onHideItemsList");
-      this.inventoryLists.itemList.addEventListener("itemPress",this,"onItemSelect");
-      this.itemCard.addEventListener("quantitySelect",this,"onQuantityMenuSelect");
-      this.itemCard.addEventListener("subMenuAction",this,"onItemCardSubMenuAction");
-      this.positionFixedElements();
-      this.itemCard._visible = false;
-      this.navPanel.hideButtons();
-      this.exitMenuRect.onMouseDown = function()
-      {
-         if(this._parent.bFadedIn == true && Mouse.getTopMostEntity() == this)
-         {
-            this._parent.onExitMenuRectClick();
-         }
-      };
-   }
-   function setConfig(a_config)
-   {
-      this._config = a_config;
-   
-      var customWidth = a_config.ListLayout.defaults.entryWidth;
-      
-      if (customWidth != undefined && customWidth > 0) {
-         this.inventoryLists.applyDynamicWidth(customWidth);
-      }
+  /* PRIVATE VARIABLES */
 
-      this.positionFloatingElements();
-      var _loc3_ = this.inventoryLists.itemList.listState;
-      var _loc8_ = this.inventoryLists.categoryList.listState;
-      var _loc2_ = a_config.Appearance;
-      _loc8_.iconSource = _loc2_.icons.category.source;
-      _loc3_.iconSource = _loc2_.icons.item.source;
-      _loc3_.showStolenIcon = _loc2_.icons.item.showStolen;
-      _loc3_.defaultEnabledColor = _loc2_.colors.text.enabled;
-      _loc3_.negativeEnabledColor = _loc2_.colors.negative.enabled;
-      _loc3_.stolenEnabledColor = _loc2_.colors.stolen.enabled;
-      _loc3_.defaultDisabledColor = _loc2_.colors.text.disabled;
-      _loc3_.negativeDisabledColor = _loc2_.colors.negative.disabled;
-      _loc3_.stolenDisabledColor = _loc2_.colors.stolen.disabled;
-      this._quantityMinCount = a_config.ItemList.quantityMenu.minCount;
-      var _loc6_;
-      var _loc5_;
-      var _loc7_;
-      if(this._platform == 0)
-      {
-         this._switchTabKey = a_config.Input.controls.pc.switchTab;
-      }
-      else
-      {
-         this._switchTabKey = a_config.Input.controls.gamepad.switchTab;
-         _loc6_ = a_config.Input.controls.gamepad.prevColumn;
-         _loc5_ = a_config.Input.controls.gamepad.nextColumn;
-         _loc7_ = a_config.Input.controls.gamepad.sortOrder;
-         this._sortColumnControls = [{keyCode:_loc6_},{keyCode:_loc5_}];
-         this._sortOrderControls = {keyCode:_loc7_};
-      }
-      this._switchControls = {keyCode:this._switchTabKey};
-      this._searchKey = a_config.Input.controls.pc.search;
-      this._searchControls = {keyCode:this._searchKey};
-      this.updateBottomBar(false);
-   }
-   function SetPlatform(a_platform, a_bPS3Switch)
-   {
-      this._platform = a_platform;
-      if(a_platform == 0)
-      {
-         this._acceptControls = skyui.defines.Input.Enter;
-         this._cancelControls = skyui.defines.Input.Tab;
-         this._switchControls = skyui.defines.Input.Alt;
-      }
-      else
-      {
-         this._acceptControls = skyui.defines.Input.Accept;
-         this._cancelControls = skyui.defines.Input.Cancel;
-         this._switchControls = skyui.defines.Input.GamepadBack;
-         this._sortColumnControls = skyui.defines.Input.SortColumn;
-         this._sortOrderControls = skyui.defines.Input.SortOrder;
-      }
-      this._searchControls = skyui.defines.Input.Space;
-      this.inventoryLists.setPlatform(a_platform,a_bPS3Switch);
-      this.itemCard.SetPlatform(a_platform,a_bPS3Switch);
-      this.bottomBar.setPlatform(a_platform,a_bPS3Switch);
-   }
-   function GetInventoryItemList()
-   {
-      return this.inventoryLists.itemList;
-   }
-   function handleInput(details, pathToFocus)
-   {
-      if(!this.bFadedIn)
-      {
-         return true;
-      }
-      var _loc3_ = pathToFocus.shift();
-      if(_loc3_.handleInput(details,pathToFocus))
-      {
-         return true;
-      }
-      if(Shared.GlobalFunc.IsKeyPressed(details) && (details.navEquivalent == gfx.ui.NavigationCode.TAB || details.navEquivalent == gfx.ui.NavigationCode.SHIFT_TAB))
-      {
-         gfx.io.GameDelegate.call("CloseMenu",[]);
-      }
-      return true;
-   }
-   function UpdatePlayerInfo(aUpdateObj)
-   {
-      this.bottomBar.UpdatePlayerInfo(aUpdateObj,this.itemCard.itemInfo);
-   }
-   function UpdateItemCardInfo(aUpdateObj)
-   {
-      this.itemCard.itemInfo = aUpdateObj;
-      this.bottomBar.updatePerItemInfo(aUpdateObj);
-   }
-   function ToggleMenuFade()
-   {
-      if(this.bFadedIn)
-      {
-         this._parent.gotoAndPlay("fadeOut");
-         this.bFadedIn = false;
-         this.inventoryLists.itemList.disableSelection = true;
-         this.inventoryLists.itemList.disableInput = true;
-         this.inventoryLists.categoryList.disableSelection = true;
-         this.inventoryLists.categoryList.disableInput = true;
-      }
-      else
-      {
-         this._parent.gotoAndPlay("fadeIn");
-      }
-   }
-   function SetFadedIn()
-   {
-      this.bFadedIn = true;
-      this.inventoryLists.itemList.disableSelection = false;
-      this.inventoryLists.itemList.disableInput = false;
-      this.inventoryLists.categoryList.disableSelection = false;
-      this.inventoryLists.categoryList.disableInput = false;
-   }
-   function RestoreIndices()
-   {
-      var _loc4_ = this.inventoryLists.categoryList;
-      var _loc3_ = this.inventoryLists.itemList;
-      if(arguments[0] != undefined && arguments[0] != -1 && arguments.length == 5)
-      {
-         _loc4_.listState.restoredItem = arguments[0];
-         _loc4_.onUnsuspend = function()
-         {
-            this.onItemPress(this.listState.restoredItem,0);
-            delete this.onUnsuspend;
-         };
-         _loc3_.listState.restoredScrollPosition = arguments[2];
-         _loc3_.listState.restoredSelectedIndex = arguments[1];
-         _loc3_.listState.restoredActiveColumnIndex = arguments[3];
-         _loc3_.listState.restoredActiveColumnState = arguments[4];
-         _loc3_.onUnsuspend = function()
-         {
-            this.onInvalidate = function()
+    private var _platform: Number;
+    private var _bItemCardFadedIn: Boolean = false;
+    private var _bItemCardPositioned: Boolean = false;
+    
+    private var _quantityMinCount: Number = 5;
+    
+    private var _config: Object;
+    
+    private var _bPlayBladeSound: Boolean;
+    
+    private var _searchKey: Number;
+    private var _switchTabKey: Number;
+    
+    private var _acceptControls: Object;
+    private var _cancelControls: Object;
+    private var _searchControls: Object;
+    private var _switchControls: Object;
+    private var _sortColumnControls: Array;
+    private var _sortOrderControls: Object;
+    
+    
+  /* STAGE ELEMENTS */
+    
+    public var inventoryLists: InventoryLists;
+    
+    public var itemCardFadeHolder: MovieClip;
+
+    public var bottomBar: BottomBar;
+    
+    public var mouseRotationRect: MovieClip;
+    public var exitMenuRect: MovieClip;
+    
+    
+  /* PROPERTIES */
+    
+    public var itemCard: MovieClip;
+    
+    public var navPanel: ButtonPanel;
+    
+    public var bEnableTabs: Boolean = false;
+    
+    // @GFx
+    public var bPCControlsReady: Boolean = true;
+    
+    public var bFadedIn: Boolean = true;
+    
+    
+  /* INITIALIZATION */
+
+    public function ItemMenu()
+    {
+        super();
+        
+        this.itemCard = this.itemCardFadeHolder.ItemCard_mc;
+        this.navPanel = this.bottomBar.buttonPanel;
+        
+        Mouse.addListener(this);
+        skyui.util.ConfigManager.registerLoadCallback(this, "onConfigLoad");
+        
+        this.bFadedIn = true;
+        this._bItemCardFadedIn = false;
+    }
+
+  /* PUBLIC FUNCTIONS */
+
+    // @API
+    public function InitExtensions(a_bPlayBladeSound)
+    {
+        Stage.scaleMode = "showAll";
+        Shared.GlobalFunc.SetLockFunction();
+        skse.ExtendData(true);
+        skse.ForceContainerCategorization(true);
+        
+        this._bPlayBladeSound = a_bPlayBladeSound;
+        
+        this.inventoryLists.InitExtensions();
+        
+        if (this.bEnableTabs)
+            this.inventoryLists.enableTabBar();
+        
+        gfx.io.GameDelegate.addCallBack("UpdatePlayerInfo", this, "UpdatePlayerInfo");
+        gfx.io.GameDelegate.addCallBack("UpdateItemCardInfo", this, "UpdateItemCardInfo");
+        gfx.io.GameDelegate.addCallBack("ToggleMenuFade", this, "ToggleMenuFade");
+        gfx.io.GameDelegate.addCallBack("RestoreIndices", this, "RestoreIndices");
+        
+        this.inventoryLists.addEventListener("categoryChange", this, "onCategoryChange");
+        this.inventoryLists.addEventListener("itemHighlightChange", this, "onItemHighlightChange");
+        this.inventoryLists.addEventListener("showItemsList", this, "onShowItemsList");
+        this.inventoryLists.addEventListener("hideItemsList", this, "onHideItemsList");
+        
+        this.inventoryLists.itemList.addEventListener("itemPress", this ,"onItemSelect");
+        
+        this.itemCard.addEventListener("quantitySelect", this, "onQuantityMenuSelect");
+        this.itemCard.addEventListener("subMenuAction", this, "onItemCardSubMenuAction");
+        
+        this.positionFixedElements();
+        
+        this.itemCard._visible = false;
+        this.navPanel.hideButtons();
+        
+        this.exitMenuRect.onMouseDown = function()
+        {
+            if (this._parent.bFadedIn == true && Mouse.getTopMostEntity() == this)
+                this._parent.onExitMenuRectClick();
+        };
+    }
+    
+    public function setConfig(a_config: Object)
+    {
+        this._config = a_config;
+
+         var customWidth = a_config["ListLayout"].defaults.entryWidth;
+      
+        if (customWidth != undefined && customWidth > 0) {
+            this.inventoryLists.applyDynamicWidth(customWidth);
+        }
+
+        this.positionFloatingElements();
+        
+        var itemListState = this.inventoryLists.itemList.listState;
+        var categoryListState = this.inventoryLists.categoryList.listState;
+        var appearance = a_config["Appearance"];
+        
+        categoryListState.iconSource = appearance.icons.category.source;
+        
+        itemListState.iconSource = appearance.icons.item.source;
+        itemListState.showStolenIcon = appearance.icons.item.showStolen;
+        
+        itemListState.defaultEnabledColor = appearance.colors.text.enabled;
+        itemListState.negativeEnabledColor = appearance.colors.negative.enabled;
+        itemListState.stolenEnabledColor = appearance.colors.stolen.enabled;
+        itemListState.defaultDisabledColor = appearance.colors.text.disabled;
+        itemListState.negativeDisabledColor = appearance.colors.negative.disabled;
+        itemListState.stolenDisabledColor = appearance.colors.stolen.disabled;
+
+        this._quantityMinCount = a_config["ItemList"].quantityMenu.minCount;
+        
+        if (this._platform == 0) {
+            this._switchTabKey = a_config["Input"].controls.pc.switchTab;
+        } else {
+            this._switchTabKey = a_config["Input"].controls.gamepad.switchTab;
+            
+            var previousColumnKey = a_config["Input"].controls.gamepad.prevColumn;
+            var nextColumnKey = a_config["Input"].controls.gamepad.nextColumn;
+            var sortOrderKey = a_config["Input"].controls.gamepad.sortOrder;
+            this._sortColumnControls = [{keyCode: previousColumnKey},
+                                {keyCode: nextColumnKey}];
+            this._sortOrderControls = {keyCode: sortOrderKey};
+        }
+        
+        this._switchControls = {keyCode: this._switchTabKey};
+        
+        this._searchKey = a_config["Input"].controls.pc.search;
+        this._searchControls = {keyCode: this._searchKey};
+        
+        this.updateBottomBar(false);
+    }
+
+    // @API
+    public function SetPlatform(a_platform: Number, a_bPS3Switch: Boolean)
+    {
+        this._platform = a_platform;
+        
+        if (a_platform == 0) {
+            this._acceptControls = skyui.defines.Input.Enter;
+            this._cancelControls = skyui.defines.Input.Tab;
+            
+            // Defaults
+            this._switchControls = skyui.defines.Input.Alt;
+        } else {
+            this._acceptControls = skyui.defines.Input.Accept;
+            this._cancelControls = skyui.defines.Input.Cancel;
+            
+            // Defaults
+            this._switchControls = skyui.defines.Input.GamepadBack;
+            this._sortColumnControls = skyui.defines.Input.SortColumn;
+            this._sortOrderControls = skyui.defines.Input.SortOrder;
+        }
+        
+        // Defaults
+        this._searchControls = skyui.defines.Input.Space;
+        
+        this.inventoryLists.setPlatform(a_platform,a_bPS3Switch);
+        this.itemCard.SetPlatform(a_platform,a_bPS3Switch);
+        this.bottomBar.setPlatform(a_platform,a_bPS3Switch);
+    }
+
+    // @API
+    public function GetInventoryItemList()
+    {
+        return this.inventoryLists.itemList;
+    }
+
+    // @GFx
+    public function handleInput(details: gfx.ui.InputDetails, pathToFocus: Array)
+    {
+        if (!this.bFadedIn)
+            return true;
+            
+        var nextClip = pathToFocus.shift();
+            
+        if (nextClip.handleInput(details, pathToFocus))
+            return true;
+        
+        if (Shared.GlobalFunc.IsKeyPressed(details) && (details.navEquivalent == gfx.ui.NavigationCode.TAB || details.navEquivalent == gfx.ui.NavigationCode.SHIFT_TAB))
+            gfx.io.GameDelegate.call("CloseMenu", []);
+
+        return true;
+    }
+
+    // @API
+    public function UpdatePlayerInfo(aUpdateObj: Object)
+    {
+        this.bottomBar.UpdatePlayerInfo(aUpdateObj, this.itemCard.itemInfo);
+    }
+
+    // @API
+    public function UpdateItemCardInfo(aUpdateObj: Object)
+    {
+        this.itemCard.itemInfo = aUpdateObj;
+        this.bottomBar.updatePerItemInfo(aUpdateObj);
+    }
+
+    // @API
+    public function ToggleMenuFade()
+    {
+        if (this.bFadedIn) {
+            this._parent.gotoAndPlay("fadeOut");
+            this.bFadedIn = false;
+            this.inventoryLists.itemList.disableSelection = true;
+            this.inventoryLists.itemList.disableInput = true;
+            this.inventoryLists.categoryList.disableSelection = true;
+            this.inventoryLists.categoryList.disableInput = true;
+        } else {
+            this._parent.gotoAndPlay("fadeIn");
+        }
+    }
+
+    // @API
+    public function SetFadedIn()
+    {
+        this.bFadedIn = true;
+        this.inventoryLists.itemList.disableSelection = false;
+        this.inventoryLists.itemList.disableInput = false;
+        this.inventoryLists.categoryList.disableSelection = false;
+        this.inventoryLists.categoryList.disableInput = false;
+    }
+    
+    // @API
+    public function RestoreIndices()
+    {
+        var categoryList = this.inventoryLists.categoryList;
+        var itemList = this.inventoryLists.itemList;
+        
+        if (arguments[0] != undefined && arguments[0] != -1 && arguments.length == 5) {
+            categoryList.listState.restoredItem = arguments[0];
+            categoryList.onUnsuspend = function()
             {
-               this.scrollPosition = this.listState.restoredScrollPosition;
-               this.selectedIndex = this.listState.restoredSelectedIndex;
-               delete this.onInvalidate;
+                this.onItemPress(this.listState.restoredItem, 0);
+                delete this.onUnsuspend;
             };
-            this.layout.restoreColumnState(this.listState.restoredActiveColumnIndex,this.listState.restoredActiveColumnState);
-            delete this.onUnsuspend;
-         };
-      }
-      else
-      {
-         _loc4_.onUnsuspend = function()
-         {
-            this.onItemPress(1,0);
-            delete this.onUnsuspend;
-         };
-      }
-   }
-   function onItemCardSubMenuAction(event)
-   {
-      if(event.opening == true)
-      {
-         this.inventoryLists.itemList.disableSelection = true;
-         this.inventoryLists.itemList.disableInput = true;
-         this.inventoryLists.categoryList.disableSelection = true;
-         this.inventoryLists.categoryList.disableInput = true;
-      }
-      else if(event.opening == false)
-      {
-         this.inventoryLists.itemList.disableSelection = false;
-         this.inventoryLists.itemList.disableInput = false;
-         this.inventoryLists.categoryList.disableSelection = false;
-         this.inventoryLists.categoryList.disableInput = false;
-      }
-   }
-   function onConfigLoad(event)
-   {
-      this.setConfig(event.config);
-      this.inventoryLists.showPanel(this._bPlayBladeSound);
-   }
-   function onMouseWheel(delta)
-   {
-      if(this.mouseRotationRect != undefined && this.mouseRotationRect.hitTest(_root._xmouse, _root._ymouse, true))
-      {
-         if(this.shouldProcessItemsListInput(false) || (!this.bFadedIn && delta == -1))
-         {
-            gfx.io.GameDelegate.call("ZoomItemModel",[delta]);
-         }
-      }
-   }
-   function onExitMenuRectClick()
-   {
-      gfx.io.GameDelegate.call("CloseMenu",[]);
-   }
-   function onCategoryChange(event)
-   {
-   }
-   function onItemHighlightChange(event)
-   {
-      if(event.index != -1)
-      {
-         if(!this._bItemCardFadedIn)
-         {
-            this._bItemCardFadedIn = true;
-            if(this._bItemCardPositioned)
+            
+            itemList.listState.restoredScrollPosition = arguments[2];
+            itemList.listState.restoredSelectedIndex = arguments[1];
+            itemList.listState.restoredActiveColumnIndex = arguments[3];
+            itemList.listState.restoredActiveColumnState = arguments[4];
+
+            itemList.onUnsuspend = function()
             {
-               this.itemCard.FadeInCard();
+                this.onInvalidate = function()
+                {
+                    this.scrollPosition = this.listState.restoredScrollPosition;
+                    this.selectedIndex = this.listState.restoredSelectedIndex;
+                    delete this.onInvalidate;
+                };
+                
+                this.layout.restoreColumnState(this.listState.restoredActiveColumnIndex, this.listState.restoredActiveColumnState);
+                delete this.onUnsuspend;
+            };
+        } else {
+            
+            categoryList.onUnsuspend = function()
+            {
+                this.onItemPress(1, 0); // ALL
+                delete this.onUnsuspend;
+            };
+        }
+    }
+    
+    
+  /* PRIVATE FUNCTIONS */
+
+    public function onItemCardSubMenuAction(event: Object)
+    {
+        if (event.opening == true) {
+            this.inventoryLists.itemList.disableSelection = true;
+            this.inventoryLists.itemList.disableInput = true;
+            this.inventoryLists.categoryList.disableSelection = true;
+            this.inventoryLists.categoryList.disableInput = true;
+        } else if (event.opening == false) {
+            this.inventoryLists.itemList.disableSelection = false;
+            this.inventoryLists.itemList.disableInput = false;
+            this.inventoryLists.categoryList.disableSelection = false;
+            this.inventoryLists.categoryList.disableInput = false;
+        }
+    }
+    
+    private function onConfigLoad(event: Object)
+    {
+        this.setConfig(event.config);
+
+        this.inventoryLists.showPanel(this._bPlayBladeSound);
+    }
+
+    private function onMouseWheel(delta)
+    {
+        if(this.mouseRotationRect != undefined && this.mouseRotationRect.hitTest(_root._xmouse, _root._ymouse, true))
+        {
+            if(this.shouldProcessItemsListInput(false) || (!this.bFadedIn && delta == -1))
+            {
+                gfx.io.GameDelegate.call("ZoomItemModel", [delta]);
             }
-         }
-         if(this._bItemCardPositioned)
-         {
-            gfx.io.GameDelegate.call("UpdateItem3D",[true]);
-         }
-         gfx.io.GameDelegate.call("RequestItemCardInfo",[],this,"UpdateItemCardInfo");
-      }
-      else
-      {
-         if(!this.bFadedIn)
-         {
-            this.resetMenu();
-         }
-         if(this._bItemCardFadedIn)
-         {
-            this._bItemCardFadedIn = false;
-            this.onHideItemsList();
-         }
-      }
-   }
-   function onShowItemsList(event)
-   {
-      this.onItemHighlightChange(event);
-   }
-   function onHideItemsList(event)
-   {
-      gfx.io.GameDelegate.call("UpdateItem3D",[false]);
-      this.itemCard.FadeOutCard();
-   }
-   function onItemSelect(event)
-   {
-      if(event.entry.enabled)
-      {
-         if(this._quantityMinCount < 1 || event.entry.count < this._quantityMinCount)
-         {
-            this.onQuantityMenuSelect({amount:1});
-         }
-         else
-         {
-            this.itemCard.ShowQuantityMenu(event.entry.count);
-         }
-      }
-      else
-      {
-         gfx.io.GameDelegate.call("DisabledItemSelect",[]);
-      }
-   }
-   function onQuantityMenuSelect(event)
-   {
-      gfx.io.GameDelegate.call("ItemSelect",[event.amount]);
-   }
-   function onMouseRotationStart()
-   {
-      gfx.io.GameDelegate.call("StartMouseRotation",[]);
-      this.inventoryLists.categoryList.disableSelection = true;
-      this.inventoryLists.itemList.disableSelection = true;
-   }
-   function onMouseRotationStop()
-   {
-      gfx.io.GameDelegate.call("StopMouseRotation",[]);
-      this.inventoryLists.categoryList.disableSelection = false;
-      this.inventoryLists.itemList.disableSelection = false;
-   }
-   function onMouseRotationFastClick()
-   {
-      if(this.shouldProcessItemsListInput(false))
-      {
-         this.onItemSelect({entry:this.inventoryLists.itemList.selectedEntry,keyboardOrMouse:0});
-      }
-   }
-   function saveIndices()
-   {
-      var _loc2_ = new Array();
-      _loc2_.push(this.inventoryLists.categoryList.selectedIndex);
-      _loc2_.push(this.inventoryLists.itemList.selectedIndex);
-      _loc2_.push(this.inventoryLists.itemList.scrollPosition);
-      _loc2_.push(this.inventoryLists.itemList.layout.activeColumnIndex);
-      _loc2_.push(this.inventoryLists.itemList.layout.activeColumnState);
-      gfx.io.GameDelegate.call("SaveIndices",[_loc2_]);
-   }
-   function updateDynamicListHeight()
-   {
-      var listPoint = {
-         x: this.inventoryLists.itemList._x, 
-         y: this.inventoryLists.itemList._y
-      };
-      this._parent.globalToLocal(listPoint);
-      this.inventoryLists.panelContainer.localToGlobal(listPoint);
+        }
+    }
 
-      var tab = this.inventoryLists.panelContainer.tabBar;
-      var paddingItemList = 0;
-      var minHeightItemList = 100;
-      var heightItemList = this.bottomBar._y - listPoint.y - paddingItemList;
+    private function onExitMenuRectClick()
+    {
+        gfx.io.GameDelegate.call("CloseMenu", []);
+    }
 
-      if (heightItemList < minHeightItemList)
-      {
-         heightItemList = minHeightItemList;
-      }
-      if (tab)
-      {
-         heightItemList -= tab._height;
-      }
-      this.inventoryLists.itemList.listHeight = heightItemList;
-      this.inventoryLists.itemList.requestUpdate();
-   }
+    private function onCategoryChange(event: Object)
+    {
+    }
+    
+    private function onItemHighlightChange(event: Object)
+    {		
+        if (event.index != -1) {
+            if (!this._bItemCardFadedIn) {
+                this._bItemCardFadedIn = true;
+                
+                if (this._bItemCardPositioned)
+                    this.itemCard.FadeInCard();
+            }
+            
+            if (this._bItemCardPositioned)
+                gfx.io.GameDelegate.call("UpdateItem3D", [true]);
+                
+            gfx.io.GameDelegate.call("RequestItemCardInfo", [], this, "UpdateItemCardInfo");
+            
+        } else {
+            if (!this.bFadedIn)
+                this.resetMenu();
+            
+            if (this._bItemCardFadedIn) {
+                this._bItemCardFadedIn = false;
+                this.onHideItemsList();
+            }
+        }
+    }
 
-   function positionFixedElements()
-   {
-      this.inventoryLists.Lock("TL");
-      this.inventoryLists._x -= 20;
-      this.inventoryLists._y -= Stage.safeRect.y;
-      
-      var leftOffset = Stage.visibleRect.x + Stage.safeRect.x;
-      var rightOffset = Stage.visibleRect.x - Stage.safeRect.x + Stage.visibleRect.width;
-      var marginBottomBar = 17;
+    private function onShowItemsList(event: Object)
+    {
+        this.onItemHighlightChange(event);
+    }
 
-      this.bottomBar.Lock("B");
-      this.bottomBar._y += Stage.safeRect.y - this.bottomBar._height + marginBottomBar;
-      this.bottomBar.positionElements(leftOffset, rightOffset);
-      
-      MovieClip(this.exitMenuRect).Lock("TL");
-      this.exitMenuRect._x -= Stage.safeRect.x;
-      this.exitMenuRect._y -= Stage.safeRect.y;
+    private function onHideItemsList(event: Object)
+    {
+        gfx.io.GameDelegate.call("UpdateItem3D", [false]);
+        this.itemCard.FadeOutCard();
+    }
 
-      this.updateDynamicListHeight();
-   }
-   function positionFloatingElements()
-   {
-      var _loc8_ = Stage.visibleRect.x + Stage.safeRect.x;
-      var _loc6_ = Stage.visibleRect.x + Stage.visibleRect.width - Stage.safeRect.x;
-      var _loc7_ = this.inventoryLists.getContentBounds();
-      var _loc5_ = this.inventoryLists._x + _loc7_[0] + _loc7_[2] + 25;
-      var _loc2_ = this.itemCard._parent;
-      var _loc3_ = this._config.ItemInfo.itemcard;
-      var _loc9_ = this._config.ItemInfo.itemicon;
-      var _loc4_ = (_loc6_ - _loc5_) / _loc2_._width;
-      if(_loc4_ < 1)
-      {
-         _loc2_._width *= _loc4_;
-         _loc2_._height *= _loc4_;
-         _loc9_.scale *= _loc4_;
-      }
-      if(_loc3_.align == "left")
-      {
-         _loc2_._x = _loc5_ + _loc8_ + _loc3_.xOffset;
-      }
-      else if(_loc3_.align == "right")
-      {
-         _loc2_._x = _loc6_ - _loc2_._width + _loc3_.xOffset;
-      }
-      else
-      {
-         _loc2_._x = _loc5_ + _loc3_.xOffset + (Stage.visibleRect.x + Stage.visibleRect.width - _loc5_ - _loc2_._width) / 2;
-      }
-      _loc2_._y += _loc3_.yOffset;
-      if(this.mouseRotationRect != undefined)
-      {
-         MovieClip(this.mouseRotationRect).Lock("T");
-         this.mouseRotationRect._x = this.itemCard._parent._x;
-         this.mouseRotationRect._width = _loc2_._width;
-         this.mouseRotationRect._height = 0.55 * Stage.visibleRect.height;
-      }
-      this._bItemCardPositioned = true;
-      if(this._bItemCardFadedIn)
-      {
-         gfx.io.GameDelegate.call("UpdateItem3D",[true]);
-         this.itemCard.FadeInCard();
-      }
-   }
-   function shouldProcessItemsListInput(abCheckIfOverRect)
+    private function onItemSelect(event: Object)
+    {
+        if (event.entry.enabled) {
+            if (this._quantityMinCount < 1 || (event.entry.count < this._quantityMinCount))
+                this.onQuantityMenuSelect({amount:1});
+            else
+                this.itemCard.ShowQuantityMenu(event.entry.count);
+        } else {
+            gfx.io.GameDelegate.call("DisabledItemSelect", []);
+        }
+
+
+    }
+
+    private function onQuantityMenuSelect(event: Object)
+    {
+        gfx.io.GameDelegate.call("ItemSelect", [event.amount]);
+    }
+
+    private function onMouseRotationStart()
+    {
+        gfx.io.GameDelegate.call("StartMouseRotation", []);
+        this.inventoryLists.categoryList.disableSelection = true;
+        this.inventoryLists.itemList.disableSelection = true;
+    }
+
+    private function onMouseRotationStop()
+    {
+        gfx.io.GameDelegate.call("StopMouseRotation", []);
+        this.inventoryLists.categoryList.disableSelection = false;
+        this.inventoryLists.itemList.disableSelection = false;
+    }
+
+    private function onMouseRotationFastClick()
+    {
+        if (this.shouldProcessItemsListInput(false))
+            this.onItemSelect({entry: this.inventoryLists.itemList.selectedEntry, keyboardOrMouse: 0});
+    }
+
+    private function saveIndices()
+    {
+        var a = new Array();
+        
+        // Save selected category, selected item and relative scroll position
+        a.push(this.inventoryLists.categoryList.selectedIndex);
+        a.push(this.inventoryLists.itemList.selectedIndex);
+        a.push(this.inventoryLists.itemList.scrollPosition);
+        a.push(this.inventoryLists.itemList.layout.activeColumnIndex);
+        a.push(this.inventoryLists.itemList.layout.activeColumnState);
+        
+        gfx.io.GameDelegate.call("SaveIndices", [a]);
+    }
+
+    function updateDynamicListHeight()
+    {
+        var listPoint = {
+            x: this.inventoryLists.itemList._x, 
+            y: this.inventoryLists.itemList._y
+        };
+        this._parent.globalToLocal(listPoint);
+        this.inventoryLists.panelContainer.localToGlobal(listPoint);
+
+        var tab = this.inventoryLists.panelContainer.tabBar;
+        var paddingItemList = 0;
+        var minHeightItemList = 100;
+        var heightItemList = this.bottomBar._y - listPoint.y - paddingItemList;
+
+        if (heightItemList < minHeightItemList)
+        {
+            heightItemList = minHeightItemList;
+        }
+        if (tab)
+        {
+            heightItemList -= tab._height;
+        }
+        this.inventoryLists.itemList.listHeight = heightItemList;
+        this.inventoryLists.itemList.requestUpdate();
+    }
+    
+    private function positionFixedElements()
+    {
+        this.inventoryLists.Lock("TL");
+        this.inventoryLists._x -= 20;
+        this.inventoryLists._y -= Stage.safeRect.y;
+        
+        var leftEdge = Stage.visibleRect.x + Stage.safeRect.x;
+        var rightEdge = Stage.visibleRect.x - Stage.safeRect.x + Stage.visibleRect.width;
+        var marginBottomBar = 17;
+        
+        this.bottomBar.Lock("B");
+        this.bottomBar._y += Stage.safeRect.y - this.bottomBar._height + marginBottomBar;
+        this.bottomBar.positionElements(leftEdge, rightEdge);
+        
+        MovieClip(this.exitMenuRect).Lock("TL");
+        this.exitMenuRect._x -= Stage.safeRect.x;
+        this.exitMenuRect._y -= Stage.safeRect.y;
+
+        this.updateDynamicListHeight();
+    }
+    
+    private function positionFloatingElements()
+    {
+        var leftEdge = Stage.visibleRect.x + Stage.safeRect.x;
+        var rightEdge = Stage.visibleRect.x + Stage.visibleRect.width - Stage.safeRect.x;
+        
+        var a = this.inventoryLists.getContentBounds();
+        // 25 is hardcoded cause thats the final offset after the animation of the panel container is done
+        var panelEdge = this.inventoryLists._x + a[0] + a[2] + 25;
+
+        var itemCardContainer = this.itemCard._parent;
+        var itemcardPosition = this._config.ItemInfo.itemcard;
+        var itemiconPosition = this._config.ItemInfo.itemicon;
+        
+        var scaleMult = (rightEdge - panelEdge) / itemCardContainer._width;
+        
+        // Scale down if necessary
+        if (scaleMult < 1.0) {
+            itemCardContainer._width *= scaleMult;
+            itemCardContainer._height *= scaleMult;
+            itemiconPosition.scale *= scaleMult;
+        }
+        
+        if (itemcardPosition.align == "left")
+            itemCardContainer._x = panelEdge + leftEdge + itemcardPosition.xOffset;
+        else if (itemcardPosition.align == "right")
+            itemCardContainer._x = rightEdge - itemCardContainer._width + itemcardPosition.xOffset;
+        else
+            itemCardContainer._x = panelEdge + itemcardPosition.xOffset + (Stage.visibleRect.x + Stage.visibleRect.width - panelEdge - itemCardContainer._width) / 2;
+
+        itemCardContainer._y = itemCardContainer._y + itemcardPosition.yOffset;
+
+        if (this.mouseRotationRect != undefined) {
+            MovieClip(this.mouseRotationRect).Lock("T");
+            this.mouseRotationRect._x = this.itemCard._parent._x;
+            this.mouseRotationRect._width = itemCardContainer._width;
+            this.mouseRotationRect._height = 0.55 * Stage.visibleRect.height;
+        }
+            
+        this._bItemCardPositioned = true;
+        
+        // Delayed fade in if positioned wasn't set
+        if (this._bItemCardFadedIn) {
+            gfx.io.GameDelegate.call("UpdateItem3D", [true]);
+            this.itemCard.FadeInCard();
+        }
+    }
+    
+    private function shouldProcessItemsListInput(abCheckIfOverRect)
    {
       var bCanProcess = this.bFadedIn == true && 
                         this.inventoryLists.currentState == InventoryLists.SHOW_PANEL && 
@@ -465,67 +533,90 @@ class ItemMenu extends MovieClip
       
       return bCanProcess;
    }
-   function confirmSelectedEntry()
-   {
-      if(this._platform != 0) return true;
-      
-      var list = this.inventoryLists.itemList;
-      if(list.selectedIndex != -1 && list.selectedEntry != undefined && list.selectedEntry.clipIndex != undefined) 
-      {
-         var clip = list.getClipByIndex(list.selectedEntry.clipIndex);
-         if (clip != undefined && clip._visible && clip.hitTest(_root._xmouse, _root._ymouse, true))
-            return true;
-      }
-      return false;
-   }
-   function resetMenu()
-   {
-      this.saveIndices();
-      gfx.io.GameDelegate.call("CloseMenu",[]);
-      skse.OpenMenu("Inventory Menu");
-   }
-   function checkBook(a_entryObject)
-   {
-      if(a_entryObject.type != skyui.defines.Inventory.ICT_BOOK || _global.skse == null)
-      {
-         return false;
-      }
-      a_entryObject.flags |= skyui.defines.Item.BOOKFLAG_READ;
-      a_entryObject.skyui_itemDataProcessed = false;
-      this.inventoryLists.itemList.requestInvalidate();
-      return true;
-   }
-   function getEquipButtonData(a_itemType, a_bAlwaysEquip)
-   {
-      var _loc1_ = {};
-      var _loc3_ = skyui.defines.Input.Activate;
-      var _loc2_ = skyui.defines.Input.Equip;
-      switch(a_itemType)
-      {
-         case skyui.defines.Inventory.ICT_ARMOR:
-            _loc1_.text = "$Equip";
-            _loc1_.controls = !a_bAlwaysEquip ? _loc3_ : _loc2_;
-            break;
-         case skyui.defines.Inventory.ICT_BOOK:
-            _loc1_.text = "$Read";
-            _loc1_.controls = !a_bAlwaysEquip ? _loc3_ : _loc2_;
-            break;
-         case skyui.defines.Inventory.ICT_FOOD:
-         case skyui.defines.Inventory.ICT_INGREDIENT:
-            _loc1_.text = "$Eat";
-            _loc1_.controls = !a_bAlwaysEquip ? _loc3_ : _loc2_;
-            break;
-         case skyui.defines.Inventory.ICT_WEAPON:
-            _loc1_.text = "$Equip";
-            _loc1_.controls = _loc2_;
-            break;
-         default:
-            _loc1_.text = "$Use";
-            _loc1_.controls = !a_bAlwaysEquip ? _loc3_ : _loc2_;
-      }
-      return _loc1_;
-   }
-   function updateBottomBar(a_bSelected)
-   {
-   }
+
+    // Added to prevent clicks on the scrollbar from equipping/using stuff
+    function confirmSelectedEntry()
+    {
+        // only confirm when using mouse
+        if(this._platform != 0) return true;
+        
+        var list = this.inventoryLists.itemList;
+        if(list.selectedIndex != -1 && list.selectedEntry != undefined && list.selectedEntry.clipIndex != undefined) 
+        {
+            var clip = list.getClipByIndex(list.selectedEntry.clipIndex);
+            if (clip != undefined && clip._visible && clip.hitTest(_root._xmouse, _root._ymouse, true))
+                return true;
+        }
+        return false;
+    }
+
+    /*
+        This method is only used for the InventoryMenu Favorites Category.
+        It prevents a lockup when unfavoriting the last item from favorites list by
+        resetting the menu.
+    */
+    private function resetMenu()
+    {
+        this.saveIndices();
+        gfx.io.GameDelegate.call("CloseMenu", []);
+        skse.OpenMenu("Inventory Menu");
+    }
+
+    /*
+        This method is only used in InventoryMenu and ContainerMenu.
+        It it allows determination of read books.
+        Item list isn't re-sent when you activate a book, unlike other items,
+        so the flags don't get updated.
+        If the item is a book, we apply the book read flag and invalidate locally
+    */
+    private function checkBook(a_entryObject: Object)
+    {
+
+        if (a_entryObject.type != skyui.defines.Inventory.ICT_BOOK || _global.skse == null)
+            return false;
+
+        a_entryObject.flags |= skyui.defines.Item.BOOKFLAG_READ;
+        a_entryObject.skyui_itemDataProcessed = false;
+        
+        this.inventoryLists.itemList.requestInvalidate();
+
+        return true;
+    }
+    
+    private function getEquipButtonData(a_itemType: Number, a_bAlwaysEquip: Boolean)
+    {
+        var btnData = {};
+        
+        var useControls = skyui.defines.Input.Activate;
+        var equipControls = skyui.defines.Input.Equip;
+        
+        switch (a_itemType) {
+            case skyui.defines.Inventory.ICT_ARMOR :
+                btnData.text = "$Equip";
+                btnData.controls = a_bAlwaysEquip ? equipControls : useControls;
+                break;
+            case skyui.defines.Inventory.ICT_BOOK :
+                btnData.text = "$Read";
+                btnData.controls = a_bAlwaysEquip ? equipControls : useControls;
+                break;
+            case skyui.defines.Inventory.ICT_FOOD :
+            case skyui.defines.Inventory.ICT_INGREDIENT :
+                btnData.text = "$Eat";
+                btnData.controls = a_bAlwaysEquip ? equipControls : useControls;
+                break;
+            case skyui.defines.Inventory.ICT_WEAPON :
+                btnData.text = "$Equip";
+                btnData.controls = equipControls;
+                break;
+
+            default :
+                btnData.text = "$Use";
+                btnData.controls = a_bAlwaysEquip ? equipControls : useControls;
+        }
+        
+        return btnData;
+    }
+    
+    // @abstract
+    private function updateBottomBar(a_bSelected: Boolean) {}
 }

--- a/source/actionscript/ItemMenus/ItemcardDataExtender.as
+++ b/source/actionscript/ItemMenus/ItemcardDataExtender.as
@@ -1,84 +1,113 @@
+// @abstract
 class ItemcardDataExtender implements skyui.components.list.IListProcessor
 {
-   var _itemInfo;
-   var _requestItemInfo;
-   var _selectedIndex;
-   function ItemcardDataExtender()
-   {
-      this._requestItemInfo = function(a_target, a_index)
-      {
-         var _loc2_ = this._selectedIndex;
-         this._selectedIndex = a_index;
-         gfx.io.GameDelegate.call("RequestItemCardInfo",[],a_target,"updateItemInfo");
-         this._selectedIndex = _loc2_;
-      };
-   }
-   function updateItemInfo(a_updateObj)
-   {
-      this._itemInfo = a_updateObj;
-   }
-   function processList(a_list)
-   {
-      var _loc4_ = a_list.entryList;
-      var _loc3_ = 0;
-      var _loc2_;
-      while(_loc3_ < _loc4_.length)
-      {
-         _loc2_ = _loc4_[_loc3_];
-         if(!(_loc2_.skyui_itemDataProcessed || _loc2_.filterFlag == 0))
-         {
-            _loc2_.skyui_itemDataProcessed = true;
-            this.fixSKSEExtendedObject(_loc2_);
-            this._requestItemInfo.apply(a_list,[this,_loc3_]);
-            this.processEntry(_loc2_,this._itemInfo);
-         }
-         _loc3_ = _loc3_ + 1;
-      }
-   }
-   function processEntry(a_entryObject, a_itemInfo)
-   {
-   }
-   function fixSKSEExtendedObject(a_extendedObject)
-   {
-      if(a_extendedObject.formType == undefined)
-      {
-         return undefined;
-      }
-      var _loc2_;
-      switch(a_extendedObject.formType)
-      {
-         case skyui.defines.Form.TYPE_SPELL:
-         case skyui.defines.Form.TYPE_SCROLLITEM:
-         case skyui.defines.Form.TYPE_INGREDIENT:
-         case skyui.defines.Form.TYPE_POTION:
-         case skyui.defines.Form.TYPE_EFFECTSETTING:
-            if(a_extendedObject.school == undefined && a_extendedObject.subType != undefined)
-            {
-               a_extendedObject.school = a_extendedObject.subType;
-               delete a_extendedObject.subType;
-            }
-            if(a_extendedObject.resistance == undefined && a_extendedObject.magicType != undefined)
-            {
-               a_extendedObject.resistance = a_extendedObject.magicType;
-               delete a_extendedObject.magicType;
-            }
-            break;
-         case skyui.defines.Form.TYPE_WEAPON:
-            if(a_extendedObject.weaponType == undefined && a_extendedObject.subType != undefined)
-            {
-               a_extendedObject.weaponType = a_extendedObject.subType;
-               delete a_extendedObject.subType;
-            }
-            break;
-         case skyui.defines.Form.TYPE_BOOK:
-            if(a_extendedObject.flags == undefined && a_extendedObject.bookType != undefined)
-            {
-               _loc2_ = a_extendedObject.bookType;
-               a_extendedObject.bookType = (_loc2_ & 0xFF00) >>> 8;
-               a_extendedObject.flags = _loc2_ & 0xFF;
-            }
-         default:
+  /* PRIVATE VARIABLES */
+
+    private var _itemInfo: Object;
+    private var _requestItemInfo: Function;
+    
+    
+  /* INITIALIZATION */
+    
+    public function ItemcardDataExtender()
+    {
+        this._requestItemInfo = function(a_target: Object, a_index: Number)
+        {
+            var oldIndex = this._selectedIndex;
+            this._selectedIndex = a_index;
+            gfx.io.GameDelegate.call("RequestItemCardInfo", [], a_target, "updateItemInfo");
+            this._selectedIndex = oldIndex;
+        };
+    }
+    
+    
+  /* PUBLIC FUNCTIONS */
+    
+    public function updateItemInfo(a_updateObj: Object)
+    {
+        this._itemInfo = a_updateObj;
+    }
+    
+    // @override IListProcessor
+    public function processList(a_list: BasicList)
+    {
+        var entryList = a_list.entryList;
+        
+        for (var i = 0; i < entryList.length; i++) {
+            var e = entryList[i];
+            if (e.skyui_itemDataProcessed || e.filterFlag == 0)
+                continue;
+                
+            e.skyui_itemDataProcessed = true;
+            
+            // Fix wrong property names
+            this.fixSKSEExtendedObject(e);
+
+            // Hack to retrieve itemcard info
+            this._requestItemInfo.apply(a_list, [this, i]);
+            this.processEntry(e, this._itemInfo);
+        }
+    }
+
+
+  /* PRIVATE FUNCTIONS */
+    
+    // @abstract
+    private function processEntry(a_entryObject: Object, a_itemInfo: Object) {}
+
+    private function fixSKSEExtendedObject(a_extendedObject: Object)
+    {
+        if (a_extendedObject.formType == undefined)
             return;
-      }
-   }
+
+        switch(a_extendedObject.formType) {
+            case skyui.defines.Form.TYPE_SPELL:
+            case skyui.defines.Form.TYPE_SCROLLITEM:
+            case skyui.defines.Form.TYPE_INGREDIENT:
+            case skyui.defines.Form.TYPE_POTION:
+            case skyui.defines.Form.TYPE_EFFECTSETTING:
+
+                // school is sent as subType
+                if (a_extendedObject.school == undefined && a_extendedObject.subType != undefined) {
+                    a_extendedObject.school = a_extendedObject.subType;
+                    delete(a_extendedObject.subType);
+                }
+
+                // resistance is sent as magicType
+                if (a_extendedObject.resistance == undefined && a_extendedObject.magicType != undefined) {
+                    a_extendedObject.resistance = a_extendedObject.magicType;
+                    delete(a_extendedObject.magicType);
+                }
+
+                // primaryValue is sent as actorValue
+                /* // Ignore
+                if (a_extendedObject.primaryValue == undefined && a_extendedObject.actorValue != undefined) {
+                    a_extendedObject.primaryValue = a_extendedObject.actorValue;
+                    delete(a_extendedObject.actorValue);
+                }
+                */
+                break;
+
+            case skyui.defines.Form.TYPE_WEAPON:
+                // weaponType is sent as subType
+                if (a_extendedObject.weaponType == undefined && a_extendedObject.subType != undefined) {
+                    a_extendedObject.weaponType = a_extendedObject.subType;
+                    delete(a_extendedObject.subType);
+                }
+                break;
+
+            case skyui.defines.Form.TYPE_BOOK:
+                // (SKSE < 1.6.6) flags and bookType (and some padding) are sent as one UInt32 bookType
+                if (a_extendedObject.flags == undefined && a_extendedObject.bookType != undefined) {
+                    var oldBookType: Number = a_extendedObject.bookType;
+                    a_extendedObject.bookType	= (oldBookType & 0xFF00) >>> 8;
+                    a_extendedObject.flags		= (oldBookType & 0x00FF);
+                }
+                break;
+
+            default:
+                break;
+        }
+
+    }
 }

--- a/source/actionscript/ItemMenus/MagicDataSetter.as
+++ b/source/actionscript/ItemMenus/MagicDataSetter.as
@@ -1,114 +1,124 @@
 class MagicDataSetter extends ItemcardDataExtender
 {
-   var _defaultDisabledColor;
-   var _defaultEnabledColor;
-   function MagicDataSetter(a_configAppearance)
-   {
-      super();
-      this._defaultEnabledColor = a_configAppearance.colors.text.enabled;
-      this._defaultDisabledColor = a_configAppearance.colors.text.disabled;
-   }
-   function processEntry(a_entryObject, a_itemInfo)
-   {
-      a_entryObject.baseId = a_entryObject.formId & 0xFFFFFF;
-      a_entryObject.type = a_itemInfo.type;
-      var recharge;
-      var s;
-      var m;
-      var h;
-      var d;
-      var spellCost;
-      switch (a_entryObject.type)
-      {
-         case skyui.defines.Inventory.ICT_SHOUT:
-            recharge = a_itemInfo.spellCost.split(" , ");
-            if (a_itemInfo.word0)
-            {
-               a_entryObject.word0 = a_itemInfo.word0 + " (" + recharge[0] + ")";
-               a_entryObject.word0Recharge = recharge[0];
-               a_entryObject.word0Color = !a_itemInfo.unlocked0 ? this._defaultDisabledColor : this._defaultEnabledColor;
-            }
-            if (a_itemInfo.word1)
-            {
-               a_entryObject.word1 = a_itemInfo.word1 + " (" + recharge[1] + ")";
-               a_entryObject.word1Recharge = recharge[1];
-               a_entryObject.word1Color = !a_itemInfo.unlocked1 ? this._defaultDisabledColor : this._defaultEnabledColor;
-            }
-            if (a_itemInfo.word2)
-            {
-               a_entryObject.word2 = a_itemInfo.word2 + " (" + recharge[2] + ")";
-               a_entryObject.word2Recharge = recharge[2];
-               a_entryObject.word2Color = !a_itemInfo.unlocked2 ? this._defaultDisabledColor : this._defaultEnabledColor;
-               return;
-            }
-            return;
-            break;
-         case skyui.defines.Inventory.ICT_ACTIVE_EFFECT:
-            if (a_itemInfo.timeRemaining != undefined && a_itemInfo.timeRemaining > 0)
-            {
-               s = Math.floor(a_itemInfo.timeRemaining);
-               m = 0;
-               h = 0;
-               d = 0;
-               if (s >= 60)
-               {
-                  m = Math.floor(s / 60);
-                  s %= 60;
-               }
-               if (m >= 60)
-               {
-                  h = Math.floor(m / 60);
-                  m %= 60;
-               }
-               if (h >= 24)
-               {
-                  d = Math.floor(h / 24);
-                  h %= 24;
-               }
+  /* PRIVATE VARIABLES */
 
-               var dayStr = skyui.util.Translator.translate("$d");
-               var hourStr = skyui.util.Translator.translate("$h");
-               var minStr = skyui.util.Translator.translate("$m");
-               var secStr = skyui.util.Translator.translate("$s");
+    private var _defaultEnabledColor: Number;
+    private var _defaultDisabledColor: Number;
 
-               var result = "";
 
-               if (d > 0)
-                  result += d + dayStr + " ";
+  /* INITIALIZATION */
 
-               if (h > 0 || d > 0)
-                  result += h + hourStr + " ";
+    public function MagicDataSetter(a_configAppearance: Object)
+    {
+        super();
+        this._defaultEnabledColor = a_configAppearance.colors.text.enabled;
+        this._defaultDisabledColor = a_configAppearance.colors.text.disabled;
+    }
+    
+    
+  /* PUBLIC FUNCTIONS */
+    
+    // @override ItemcardDataExtender
+    public function processEntry(a_entryObject: Object, a_itemInfo: Object): Void
+    {
+        a_entryObject.baseId = a_entryObject.formId & 0x00FFFFFF;
+        a_entryObject.type = a_itemInfo.type;
 
-               if (m > 0 || h > 0 || d > 0)
-                  result += m + minStr + " ";
+        switch (a_entryObject.type) {
+            
+            // Shout
+            case skyui.defines.Inventory.ICT_SHOUT:
+                var recharge: Array = a_itemInfo.spellCost.split(" , ");
+                
+                if (a_itemInfo.word0) {
+                    a_entryObject.word0 = a_itemInfo.word0 + " (" + recharge[0] + ")";
+                    a_entryObject.word0Recharge = recharge[0];
+                    a_entryObject.word0Color = a_itemInfo.unlocked0 ? this._defaultEnabledColor : this._defaultDisabledColor;
+                }
+                
+                if (a_itemInfo.word1) {
+                    a_entryObject.word1 = a_itemInfo.word1 + " (" + recharge[1] + ")";
+                    a_entryObject.word1Recharge = recharge[1];
+                    a_entryObject.word1Color = a_itemInfo.unlocked1 ? this._defaultEnabledColor : this._defaultDisabledColor;
+                }
+                
+                if (a_itemInfo.word2) {
+                    a_entryObject.word2 = a_itemInfo.word2 + " (" + recharge[2] + ")";
+                    a_entryObject.word2Recharge = recharge[2];
+                    a_entryObject.word2Color = a_itemInfo.unlocked2 ? this._defaultEnabledColor : this._defaultDisabledColor;
+                }
+                break;
+            
+            // Active effect
+            case skyui.defines.Inventory.ICT_ACTIVE_EFFECT:
+                if (a_itemInfo.timeRemaining != undefined && a_itemInfo.timeRemaining > 0) {
+        
+                    var s: Number = Math.floor(a_itemInfo.timeRemaining);
+                    var m: Number = 0;
+                    var h: Number = 0;
+                    var d: Number = 0;
+                    
+                    if (s >= 60) {
+                        m = Math.floor(s / 60);
+                        s %= 60;
+                    }
+                    if  (m >= 60) {
+                        h = Math.floor(m / 60);
+                        m %= 60;
+                    }
+                    if  (h >= 24) {
+                        d = Math.floor(h / 24);
+                        h %= 24;
+                    }
+                    
+                    var dayStr = skyui.util.Translator.translate("$d");
+                    var hourStr = skyui.util.Translator.translate("$h");
+                    var minStr = skyui.util.Translator.translate("$m");
+                    var secStr = skyui.util.Translator.translate("$s");
 
-               result += s + secStr;
+                    var result = "";
 
-               a_entryObject.timeRemainingDisplay = result;
-               return;
-            }
-            return;
-            break;
-         case skyui.defines.Inventory.ICT_SPELL:
-            a_entryObject.infoCastLevel = a_itemInfo.castLevel;
-            a_entryObject.infoSchoolName = a_itemInfo.magicSchoolName;
-            a_entryObject.duration = a_entryObject.duration <= 0 ? null : Math.round(a_entryObject.duration * 100) / 100;
-            a_entryObject.magnitude = a_entryObject.magnitude <= 0 ? null : Math.round(a_entryObject.magnitude * 100) / 100;
-            spellCost = a_itemInfo.spellCost;
-            a_entryObject.infoSpellCost = spellCost;
-            if (spellCost != 0 && a_itemInfo.castTime == 0)
-            {
-               a_entryObject.spellCostDisplay = spellCost + "/s";
-               return;
-            }
-            a_entryObject.spellCostDisplay = spellCost;
-            return;
-            break;
-         case skyui.defines.Inventory.ICT_SPELL_DEFAULT:
-         default:
-            a_entryObject.skillLevel = null;
-            a_entryObject.infoSpellCost = a_itemInfo.spellCost;
-            return;
-      }
-   }
+                    if (d > 0)
+                        result += d + dayStr + " ";
+
+                    if (h > 0 || d > 0)
+                        result += h + hourStr + " ";
+
+                    if (m > 0 || h > 0 || d > 0)
+                        result += m + minStr + " ";
+
+                    result += s + secStr;
+
+                    a_entryObject.timeRemainingDisplay = result;
+                }
+                break;
+
+            // Spell
+            case skyui.defines.Inventory.ICT_SPELL:
+                a_entryObject.infoCastLevel = a_itemInfo.castLevel;
+                a_entryObject.infoSchoolName = a_itemInfo.magicSchoolName;
+                
+                // 0 -> "-"
+                a_entryObject.duration = (a_entryObject.duration > 0) ? (Math.round(a_entryObject.duration * 100) / 100) : null;
+                a_entryObject.magnitude = (a_entryObject.magnitude > 0) ? (Math.round(a_entryObject.magnitude * 100) / 100) : null;
+                
+                var spellCost = a_itemInfo.spellCost;
+                a_entryObject.infoSpellCost = spellCost;
+            
+                if (spellCost != 0 && a_itemInfo.castTime == 0)
+                    a_entryObject.spellCostDisplay = spellCost + "/s";
+                else
+                    a_entryObject.spellCostDisplay = spellCost;
+                    
+                break;
+
+            //Power
+            case skyui.defines.Inventory.ICT_SPELL_DEFAULT:
+            default:
+                a_entryObject.skillLevel = null;	// Sent by SKSE, we don't want it for powers
+                a_entryObject.infoSpellCost = a_itemInfo.spellCost;	// For lesser powers
+                
+                break;
+        }
+    }
 }

--- a/source/actionscript/ItemMenus/MagicDataSetter.as
+++ b/source/actionscript/ItemMenus/MagicDataSetter.as
@@ -19,7 +19,7 @@ class MagicDataSetter extends ItemcardDataExtender
   /* PUBLIC FUNCTIONS */
     
     // @override ItemcardDataExtender
-    public function processEntry(a_entryObject: Object, a_itemInfo: Object): Void
+    public function processEntry(a_entryObject: Object, a_itemInfo: Object)
     {
         a_entryObject.baseId = a_entryObject.formId & 0x00FFFFFF;
         a_entryObject.type = a_itemInfo.type;

--- a/source/actionscript/ItemMenus/MagicIconSetter.as
+++ b/source/actionscript/ItemMenus/MagicIconSetter.as
@@ -1,113 +1,136 @@
 class MagicIconSetter implements skyui.components.list.IListProcessor
 {
-   var _noIconColors;
-   function MagicIconSetter(a_configAppearance)
-   {
-      this._noIconColors = a_configAppearance.icons.item.noColor;
-   }
-   function processList(a_list)
-   {
-      var _loc3_ = a_list.entryList;
-      var _loc2_ = 0;
-      while(_loc2_ < _loc3_.length)
-      {
-         this.processEntry(_loc3_[_loc2_]);
-         _loc2_ = _loc2_ + 1;
-      }
-   }
-   function processEntry(a_entryObject)
-   {
-      switch(a_entryObject.type)
-      {
-         case skyui.defines.Inventory.ICT_SPELL:
-            this.processSpellIcon(a_entryObject);
-            break;
-         case skyui.defines.Inventory.ICT_SHOUT:
-            a_entryObject.iconLabel = "default_shout";
-            break;
-         case skyui.defines.Inventory.ICT_ACTIVE_EFFECT:
-            a_entryObject.iconLabel = "default_effect";
-            break;
-         case skyui.defines.Inventory.ICT_SPELL_DEFAULT:
-            a_entryObject.iconLabel = "default_power";
-      }
-      this.processSpellBaseId(a_entryObject);
-      if(this._noIconColors && a_entryObject.iconColor != undefined)
-      {
-         delete a_entryObject.iconColor;
-      }
-   }
-   function processSpellIcon(a_entryObject)
-   {
-      a_entryObject.iconLabel = "default_power";
-      switch(a_entryObject.school)
-      {
-         case skyui.defines.Actor.AV_ALTERATION:
-            a_entryObject.iconLabel = "default_alteration";
-            break;
-         case skyui.defines.Actor.AV_CONJURATION:
-            a_entryObject.iconLabel = "default_conjuration";
-            break;
-         case skyui.defines.Actor.AV_DESTRUCTION:
-            a_entryObject.iconLabel = "default_destruction";
-            this.processResist(a_entryObject);
-            break;
-         case skyui.defines.Actor.AV_ILLUSION:
-            a_entryObject.iconLabel = "default_illusion";
-            break;
-         case skyui.defines.Actor.AV_RESTORATION:
-            a_entryObject.iconLabel = "default_restoration";
-         default:
+  /* PRIVATE VARIABLES */
+
+    private var _noIconColors: Boolean;
+
+  /* INITIALIZATION */
+
+    public function MagicIconSetter(a_configAppearance: Object)
+    {
+        this._noIconColors = a_configAppearance.icons.item.noColor;
+    }
+
+
+  /* PUBLIC FUNCTIONS */
+
+    // @override IListProcessor
+    public function processList(a_list: BasicList)
+    {
+        var entryList: Array = a_list.entryList;
+        
+        for (var i: Number = 0; i < entryList.length; i++)
+            this.processEntry(entryList[i]);
+    }
+
+
+  /* PRIVATE FUNCTIONS */
+
+    private function processEntry(a_entryObject: Object)
+    {
+        switch (a_entryObject.type) {
+            case skyui.defines.Inventory.ICT_SPELL:
+                this.processSpellIcon(a_entryObject);
+                break;
+
+            case skyui.defines.Inventory.ICT_SHOUT:
+                a_entryObject.iconLabel = "default_shout";
+                break;
+
+            case skyui.defines.Inventory.ICT_ACTIVE_EFFECT:
+                a_entryObject.iconLabel = "default_effect";
+                break;
+
+            case skyui.defines.Inventory.ICT_SPELL_DEFAULT:
+                a_entryObject.iconLabel = "default_power";
+                break;
+                
+            default:
+                break;
+        }
+        this.processSpellBaseId(a_entryObject);
+
+        if (this._noIconColors && a_entryObject.iconColor != undefined)
+            delete(a_entryObject.iconColor);
+    }
+
+    private function processSpellIcon(a_entryObject: Object)
+    {
+        a_entryObject.iconLabel = "default_power";
+        // fire rune, actorValue = Health, school = Destruction, resistance = Fire, effectFlags = hostile+detrimental
+        switch(a_entryObject.school)
+        {
+            case skyui.defines.Actor.AV_ALTERATION:
+                a_entryObject.iconLabel = "default_alteration";
+                break;
+
+            case skyui.defines.Actor.AV_CONJURATION:
+                a_entryObject.iconLabel = "default_conjuration";
+                break;
+
+            case skyui.defines.Actor.AV_DESTRUCTION:
+                a_entryObject.iconLabel = "default_destruction";
+                this.processResist(a_entryObject);
+                break;
+
+            case skyui.defines.Actor.AV_ILLUSION:
+                a_entryObject.iconLabel = "default_illusion";
+                break;
+
+            case skyui.defines.Actor.AV_RESTORATION:
+                a_entryObject.iconLabel = "default_restoration";
+                break;
+
+        }
+    }
+
+    private function processResist(a_entryObject: Object)
+    {
+        if (a_entryObject.resistance == undefined || a_entryObject.resistance == skyui.defines.Actor.AV_NONE)
             return;
-      }
-   }
-   function processResist(a_entryObject)
-   {
-      if(a_entryObject.resistance == undefined || a_entryObject.resistance == skyui.defines.Actor.AV_NONE)
-      {
-         return undefined;
-      }
-      switch(a_entryObject.resistance)
-      {
-         case skyui.defines.Actor.AV_FIRERESIST:
-            a_entryObject.iconLabel = "magic_fire";
-            a_entryObject.iconColor = 13055542;
-            break;
-         case skyui.defines.Actor.AV_ELECTRICRESIST:
-            a_entryObject.iconLabel = "magic_shock";
-            a_entryObject.iconColor = 15379200;
-            break;
-         case skyui.defines.Actor.AV_FROSTRESIST:
-            a_entryObject.iconLabel = "magic_frost";
-            a_entryObject.iconColor = 2096127;
-         default:
-            return;
-      }
-   }
-   function processSpellBaseId(a_entryObject)
-   {
-      switch(a_entryObject.baseId)
-      {
-         case 0x38B5:
-         case 0x3F52:
-         case 0x38B6:
-            a_entryObject.iconLabel = "magic_sun";
-            a_entryObject.iconColor = 16746240;
-            break;
-         case 0x1D74B:
-            a_entryObject.iconLabel = "misc_remains";
-            a_entryObject.iconColor = 6465078;
-            break;
-         case 0x1772D:
-            a_entryObject.iconLabel = "magic_wind";
-            a_entryObject.iconColor = 13487044;
-            break;
-         case 0x72320:
-         case 0x72311:
-         case 0x7233B:
-            a_entryObject.iconLabel = "magic_fire";
-            a_entryObject.iconColor = 2096127;
-            break;
-      }
-   }
+
+        switch(a_entryObject.resistance) {
+            case skyui.defines.Actor.AV_FIRERESIST:
+                a_entryObject.iconLabel = "magic_fire";
+                a_entryObject.iconColor = 0xC73636;
+                break;
+
+            case skyui.defines.Actor.AV_ELECTRICRESIST:
+                a_entryObject.iconLabel = "magic_shock";
+                a_entryObject.iconColor = 0xEAAB00;
+                break;
+
+            case skyui.defines.Actor.AV_FROSTRESIST:
+                a_entryObject.iconLabel = "magic_frost";
+                a_entryObject.iconColor = 0x1FFBFF;
+                break;
+        }
+    }
+
+    function processSpellBaseId(a_entryObject)
+    {
+        switch(a_entryObject.baseId)
+        {
+            case 0x38B5:
+            case 0x3F52:
+            case 0x38B6:
+                a_entryObject.iconLabel = "magic_sun";
+                a_entryObject.iconColor = 0xFF8700;
+                break;
+            case 0x1D74B:
+                a_entryObject.iconLabel = "misc_remains";
+                a_entryObject.iconColor = 0x62A636;
+                break;
+            case 0x1772D:
+                a_entryObject.iconLabel = "magic_wind";
+                a_entryObject.iconColor = 0xCDCBC4;
+                break;
+            case 0x72320:
+            case 0x72311:
+            case 0x7233B:
+                a_entryObject.iconLabel = "magic_fire";
+                a_entryObject.iconColor = 0x1FFBFF;
+                break;
+        }
+    }
 }

--- a/source/actionscript/ItemMenus/MagicMenu.as
+++ b/source/actionscript/ItemMenus/MagicMenu.as
@@ -1,199 +1,212 @@
 class MagicMenu extends ItemMenu
 {
-   var ToggleMenuFade;
-   var _cancelControls;
-   var _categoryListIconArt;
-   var _platform;
-   var _searchControls;
-   var _sortColumnControls;
-   var _sortOrderControls;
-   var _switchControls;
-   var _switchTabKey;
-   var bFadedIn;
-   var bottomBar;
-   var confirmSelectedEntry;
-   var inventoryLists;
-   var itemCard;
-   var navPanel;
-   var saveIndices;
-   var shouldProcessItemsListInput;
-   var _hideButtonFlag = 0;
-   var _bMenuClosing = false;
-   var _bSwitchMenus = false;
-   function MagicMenu()
-   {
-      super();
-      this._categoryListIconArt = ["cat_favorites","mag_all","mag_alteration","mag_illusion","mag_destruction","mag_conjuration","mag_restoration","mag_shouts","mag_powers","mag_activeeffects"];
-   }
-   function InitExtensions()
-   {
-      super.InitExtensions();
-      gfx.io.GameDelegate.addCallBack("DragonSoulSpent",this,"DragonSoulSpent");
-      gfx.io.GameDelegate.addCallBack("AttemptEquip",this,"AttemptEquip");
-      this.bottomBar.updatePerItemInfo({type:skyui.defines.Inventory.ICT_SPELL_DEFAULT});
-      var _loc3_ = this.inventoryLists.categoryList;
-      _loc3_.iconArt = this._categoryListIconArt;
-   }
-   function setConfig(a_config)
-   {
-      super.setConfig(a_config);
-      var _loc3_ = this.inventoryLists.itemList;
-      _loc3_.addDataProcessor(new MagicDataSetter(a_config.Appearance));
-      _loc3_.addDataProcessor(new MagicIconSetter(a_config.Appearance));
-      _loc3_.addDataProcessor(new skyui.props.PropertyDataExtender(a_config.Appearance,a_config.Properties,"magicProperties","magicIcons","magicCompoundProperties"));
-      var _loc5_ = skyui.components.list.ListLayoutManager.createLayout(a_config.ListLayout,"MagicListLayout");
-      _loc3_.layout = _loc5_;
-      if(this.inventoryLists.categoryList.selectedEntry)
-      {
-         _loc5_.changeFilterFlag(this.inventoryLists.categoryList.selectedEntry.flag);
-      }
-   }
-   function handleInput(details, pathToFocus)
-   {
-      if(!this.bFadedIn)
-      {
-         return true;
-      }
-      var _loc3_ = pathToFocus.shift();
-      if(_loc3_.handleInput(details,pathToFocus))
-      {
-         return true;
-      }
-      if(Shared.GlobalFunc.IsKeyPressed(details))
-      {
-         if(details.navEquivalent == gfx.ui.NavigationCode.TAB || details.navEquivalent == gfx.ui.NavigationCode.SHIFT_TAB)
-         {
-            this.startMenuFade();
-            gfx.io.GameDelegate.call("CloseTweenMenu",[]);
-         }
-         else if(!this.inventoryLists.itemList.disableInput)
-         {
-            if(details.skseKeycode == this._switchTabKey || details.control == "Quick Inventory")
-            {
-               this.openInventoryMenu(true);
+  /* PRIVATE VARIABLES */
+
+    private var _hideButtonFlag: Number = 0;
+    private var _bMenuClosing: Boolean = false;
+    private var _bSwitchMenus: Boolean = false;
+
+    private var _categoryListIconArt: Array;
+    
+    
+  /* PROPERTIES */
+
+    public var hideButtonFlag: Number;
+    
+
+  /* INITIALIZATION */
+
+    public function MagicMenu()
+    {
+        super();
+        
+        this._categoryListIconArt = ["cat_favorites", "mag_all", "mag_alteration", "mag_illusion",
+                            "mag_destruction", "mag_conjuration", "mag_restoration", "mag_shouts",
+                            "mag_powers", "mag_activeeffects"];
+    }
+    
+    
+  /* PUBLIC FUNCTIONS */
+
+    public function InitExtensions()
+    {
+        super.InitExtensions();
+        
+        gfx.io.GameDelegate.addCallBack("DragonSoulSpent", this, "DragonSoulSpent");
+        gfx.io.GameDelegate.addCallBack("AttemptEquip", this , "AttemptEquip");
+        
+        this.bottomBar.updatePerItemInfo({type: skyui.defines.Inventory.ICT_SPELL_DEFAULT});
+        
+        // Initialize menu-specific list components
+        var categoryList: CategoryList = this.inventoryLists.categoryList;
+        categoryList.iconArt = this._categoryListIconArt;
+    }
+
+    // @override ItemMenu
+    public function setConfig(a_config: Object)
+    {
+        super.setConfig(a_config);
+        
+        var itemList: TabularList = this.inventoryLists.itemList;
+        itemList.addDataProcessor(new MagicDataSetter(a_config["Appearance"]));
+        itemList.addDataProcessor(new MagicIconSetter(a_config["Appearance"]));
+        itemList.addDataProcessor(new skyui.props.PropertyDataExtender(a_config["Appearance"], a_config["Properties"], "magicProperties", "magicIcons", "magicCompoundProperties"));
+        
+        var layout: ListLayout = skyui.components.list.ListLayoutManager.createLayout(a_config["ListLayout"], "MagicListLayout");
+        itemList.layout = layout;
+
+        // Not 100% happy with doing this here, but has to do for now.
+        if (this.inventoryLists.categoryList.selectedEntry)
+            layout.changeFilterFlag(this.inventoryLists.categoryList.selectedEntry.flag);
+    }
+
+    // @GFx
+    public function handleInput(details: InputDetails, pathToFocus: Array)
+    {
+        if (!this.bFadedIn)
+            return true;
+        
+        var nextClip = pathToFocus.shift();
+            
+        if (nextClip.handleInput(details, pathToFocus))
+            return true;
+            
+        if (Shared.GlobalFunc.IsKeyPressed(details)) {
+            if (details.navEquivalent == gfx.ui.NavigationCode.TAB || details.navEquivalent == gfx.ui.NavigationCode.SHIFT_TAB ) {
+                this.startMenuFade();
+                gfx.io.GameDelegate.call("CloseTweenMenu",[]);
+            } else if (!this.inventoryLists.itemList.disableInput) {
+                // Gamepad back || ALT (default) || 'I'
+                if (details.skseKeycode == this._switchTabKey || details.control == "Quick Inventory")
+                    this.openInventoryMenu(true);
             }
-         }
-      }
-      return true;
-   }
-   function DragonSoulSpent()
-   {
-      this.itemCard.itemInfo.soulSpent = true;
-      this.updateBottomBar();
-   }
-   function AttemptEquip(a_slot)
-   {
-      if(this.shouldProcessItemsListInput(true) && this.confirmSelectedEntry())
-      {
-         gfx.io.GameDelegate.call("ItemSelect",[a_slot]);
-      }
-   }
-   function onItemSelect(event)
-   {
-      if(event.keyboardOrMouse != 0)
-      {
-         if(event.entry.enabled)
-         {
-            gfx.io.GameDelegate.call("ItemSelect",[]);
-         }
-         else
-         {
-            gfx.io.GameDelegate.call("ShowShoutFail",[]);
-         }
-      }
-   }
-   function onExitMenuRectClick()
-   {
-      this.startMenuFade();
-      gfx.io.GameDelegate.call("ShowTweenMenu",[]);
-   }
-   function onFadeCompletion()
-   {
-      if(!this._bMenuClosing)
-      {
-         return undefined;
-      }
-      gfx.io.GameDelegate.call("CloseMenu",[]);
-      if(this._bSwitchMenus)
-      {
-         gfx.io.GameDelegate.call("CloseTweenMenu",[]);
-         skse.OpenMenu("InventoryMenu");
-      }
-   }
-   function onShowItemsList(event)
-   {
-      super.onShowItemsList(event);
-      if(event.index != -1)
-      {
-         this.updateBottomBar(true);
-      }
-   }
-   function onItemHighlightChange(event)
-   {
-      super.onItemHighlightChange(event);
-      if(event.index != -1)
-      {
-         this.updateBottomBar(true);
-      }
-   }
-   function onHideItemsList(event)
-   {
-      super.onHideItemsList(event);
-      this.bottomBar.updatePerItemInfo({type:skyui.defines.Inventory.ICT_SPELL_DEFAULT});
-      this.updateBottomBar(false);
-   }
-   function openInventoryMenu(a_bFade)
-   {
-      if(a_bFade)
-      {
-         this._bSwitchMenus = true;
-         this.startMenuFade();
-      }
-      else
-      {
-         this.saveIndices();
-         gfx.io.GameDelegate.call("CloseMenu",[]);
-         gfx.io.GameDelegate.call("CloseTweenMenu",[]);
-         skse.OpenMenu("InventoryMenu");
-      }
-   }
-   function updateBottomBar(a_bSelected)
-   {
-      this.navPanel.clearButtons();
-      if(a_bSelected && (this.inventoryLists.itemList.selectedEntry.filterFlag & skyui.defines.Inventory.FILTERFLAG_MAGIC_ACTIVEEFFECTS) == 0)
-      {
-         this.navPanel.addButton({text:"$Equip",controls:skyui.defines.Input.Equip});
-         if(this.inventoryLists.itemList.selectedEntry.filterFlag & this.inventoryLists.categoryList.entryList[0].flag != 0)
-         {
-            this.navPanel.addButton({text:"$Unfavorite",controls:skyui.defines.Input.YButton});
-         }
-         else
-         {
-            this.navPanel.addButton({text:"$Favorite",controls:skyui.defines.Input.YButton});
-         }
-         if(this.itemCard.itemInfo.showUnlocked)
-         {
-            this.navPanel.addButton({text:"$Unlock",controls:skyui.defines.Input.XButton});
-         }
-      }
-      else
-      {
-         this.navPanel.addButton({text:"$Exit",controls:this._cancelControls});
-         this.navPanel.addButton({text:"$Search",controls:this._searchControls});
-         if(this._platform != 0)
-         {
-            this.navPanel.addButton({text:"$Column",controls:this._sortColumnControls});
-            this.navPanel.addButton({text:"$Order",controls:this._sortOrderControls});
-         }
-         this.navPanel.addButton({text:"$Inventory",controls:this._switchControls});
-      }
-      this.navPanel.updateButtons(true);
-   }
-   function startMenuFade()
-   {
-      this.inventoryLists.hidePanel();
-      this.ToggleMenuFade();
-      this.saveIndices();
-      this._bMenuClosing = true;
-   }
+        }
+        return true;
+    }
+
+    // @API
+    public function DragonSoulSpent()
+    {
+        this.itemCard.itemInfo.soulSpent = true;
+        this.updateBottomBar();
+    }
+    
+    // @API
+    public function AttemptEquip(a_slot: Number)
+    {
+        if (this.shouldProcessItemsListInput(true) && this.confirmSelectedEntry())
+            gfx.io.GameDelegate.call("ItemSelect",[a_slot]);
+    }
+    
+    
+  /* PRIVATE FUNCTIONS */
+
+    // @override ItemMenu
+    private function onItemSelect(event: Object)
+    {
+        //Vanilla bugfix
+        if (event.keyboardOrMouse != 0) {
+            if (event.entry.enabled)
+                gfx.io.GameDelegate.call("ItemSelect",[]);
+            else
+                gfx.io.GameDelegate.call("ShowShoutFail",[]);
+        }
+    }
+
+    // @override ItemMenu
+    private function onExitMenuRectClick()
+    {
+        this.startMenuFade();
+        gfx.io.GameDelegate.call("ShowTweenMenu",[]);
+    }
+
+    private function onFadeCompletion()
+    {
+        if (!this._bMenuClosing)
+            return;
+
+        gfx.io.GameDelegate.call("CloseMenu", []);
+        if (this._bSwitchMenus) {
+            gfx.io.GameDelegate.call("CloseTweenMenu",[]);
+            skse.OpenMenu("InventoryMenu");
+        }
+    }
+
+    // @override ItemMenu
+    private function onShowItemsList(event: Object)
+    {
+        super.onShowItemsList(event);
+        
+        if (event.index != -1)
+            this.updateBottomBar(true);
+    }
+
+    // @override ItemMenu
+    private function onItemHighlightChange(event: Object)
+    {
+        super.onItemHighlightChange(event);
+        
+        if (event.index != -1)
+            this.updateBottomBar(true);
+    }
+
+    // @override ItemMenu
+    private function onHideItemsList(event: Object)
+    {
+        super.onHideItemsList(event);
+        
+        this.bottomBar.updatePerItemInfo({type: skyui.defines.Inventory.ICT_SPELL_DEFAULT});
+        
+        this.updateBottomBar(false);
+    }
+    
+    private function openInventoryMenu(a_bFade: Boolean)
+    {
+        if (a_bFade) {
+            this._bSwitchMenus = true;
+            this.startMenuFade();
+        } else {
+            this.saveIndices();
+            gfx.io.GameDelegate.call("CloseMenu",[]);
+            gfx.io.GameDelegate.call("CloseTweenMenu",[]);
+            skse.OpenMenu("InventoryMenu");
+        }
+    }
+    
+    // @override ItemMenu
+    private function updateBottomBar(a_bSelected: Boolean)
+    {
+        this.navPanel.clearButtons();
+        
+        if (a_bSelected && (this.inventoryLists.itemList.selectedEntry.filterFlag & skyui.defines.Inventory.FILTERFLAG_MAGIC_ACTIVEEFFECTS) == 0) {
+            this.navPanel.addButton({text: "$Equip", controls: skyui.defines.Input.Equip});
+            
+            if (this.inventoryLists.itemList.selectedEntry.filterFlag & this.inventoryLists.categoryList.entryList[0].flag != 0)
+                this.navPanel.addButton({text: "$Unfavorite", controls: skyui.defines.Input.YButton});
+            else
+                this.navPanel.addButton({text: "$Favorite", controls: skyui.defines.Input.YButton});
+    
+            if (this.itemCard.itemInfo.showUnlocked)
+                this.navPanel.addButton({text: "$Unlock", controls: skyui.defines.Input.XButton});
+                
+        } else {
+            this.navPanel.addButton({text: "$Exit", controls: this._cancelControls});
+            this.navPanel.addButton({text: "$Search", controls: this._searchControls});
+            if (this._platform != 0) {
+                this.navPanel.addButton({text: "$Column", controls: this._sortColumnControls});
+                this.navPanel.addButton({text: "$Order", controls: this._sortOrderControls});
+            }
+            this.navPanel.addButton({text: "$Inventory", controls: this._switchControls});
+        }
+        
+        this.navPanel.updateButtons(true);
+    }
+    
+    private function startMenuFade()
+    {
+        this.inventoryLists.hidePanel();
+        this.ToggleMenuFade();
+        this.saveIndices();
+        this._bMenuClosing = true;
+    }
 }

--- a/source/actionscript/ItemMenus/MagicMenu.as
+++ b/source/actionscript/ItemMenus/MagicMenu.as
@@ -88,7 +88,7 @@ class MagicMenu extends ItemMenu
     public function DragonSoulSpent()
     {
         this.itemCard.itemInfo.soulSpent = true;
-        this.updateBottomBar();
+        this.updateBottomBar(true);
     }
     
     // @API


### PR DESCRIPTION
Restoring the original appearance of scripts from `ItemMenus` adapted for import into JPEXS.
The number of `this.` scripts before and after the change should be the same, and if the scripts import without errors, then everything is fine.

If the number of `this.` scripts is the same or there are errors, then to check:
1) Create `Test_1.as` and `Test_2.as`
2) In VS Code, `Ctrl + Shift + P` --> Compare Active File With...
3) In `Test_1.as`, place the selected script code from the main branch
4) `cmake --build --preset debug`
5) In `Test_2.as`, place the decompiled script code from JPEXS after importing the script
6) If the files don't differ significantly except for the numbering of the `_locN_` variable, then everything is fine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized many inventory/menu UI modules with explicit typing and clearer visibility while preserving behavior.

* **Bug Fixes / Polish**
  * More consistent barter/item price display (buy/sell clamping, rounding) and clearer bottom-bar/navigation labeling. Icon selection and per-item display logic adjusted for more reliable visuals.

* **Stability**
  * Internal structure and iteration fixes to improve robustness without altering user-facing features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/doodlum/SkyUI-Community/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->